### PR TITLE
Allow capturing errors as an event and a breadcrumb at the same time

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -30,4 +30,4 @@ window/stretch/aspect="keep_height"
 
 config/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 config/debug=true
-config/error_logger/capture_type=1
+config/error_logger/capture_as_event=true

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -22,10 +22,12 @@ void SentryOptions::_load_project_settings() {
 	sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/config/sample_rate", sample_rate);
 	attach_log = ProjectSettings::get_singleton()->get_setting("sentry/config/attach_log", attach_log);
 	max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/config/max_breadcrumbs", max_breadcrumbs);
+
 	error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/enabled", error_logger_enabled);
+	error_logger_capture_as_breadcrumb = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/capture_as_breadcrumb", error_logger_capture_as_breadcrumb);
+	error_logger_capture_as_event = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/capture_as_event", error_logger_capture_as_event);
 	error_logger_max_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/max_lines", error_logger_max_lines);
 	error_logger_log_warnings = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/log_warnings", error_logger_log_warnings);
-	error_logger_capture_type = (CaptureType)(int)ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/capture_type", error_logger_capture_type);
 	error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 }
 
@@ -65,9 +67,10 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), max_breadcrumbs);
 
 	_define_setting("sentry/config/error_logger/enabled", error_logger_enabled);
+	_define_setting("sentry/config/error_logger/capture_as_breadcrumb", error_logger_capture_as_breadcrumb);
+	_define_setting("sentry/config/error_logger/capture_as_event", error_logger_capture_as_event);
 	_define_setting("sentry/config/error_logger/max_lines", error_logger_max_lines);
 	_define_setting("sentry/config/error_logger/log_warnings", error_logger_log_warnings);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/capture_type", godot::PROPERTY_HINT_ENUM, "As Breadcrumb,As Event"), error_logger_capture_type);
 	_define_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 }
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -9,12 +9,6 @@
 using namespace godot;
 
 class SentryOptions {
-public:
-	enum CaptureType {
-		CAPTURE_AS_BREADCRUMB,
-		CAPTURE_AS_EVENT,
-	};
-
 private:
 	static SentryOptions *singleton;
 
@@ -28,9 +22,10 @@ private:
 	int max_breadcrumbs = 100;
 
 	bool error_logger_enabled = true;
+	bool error_logger_capture_as_breadcrumb = true;
+	bool error_logger_capture_as_event = false;
 	int error_logger_max_lines = 30;
 	bool error_logger_log_warnings = true; // Note: Godot warnings are captured as breadcrumbs if this option is enabled.
-	CaptureType error_logger_capture_type = CaptureType::CAPTURE_AS_BREADCRUMB;
 	bool error_logger_include_source = true;
 
 	void _define_setting(const String &p_setting, const Variant &p_default, bool p_basic = true);
@@ -48,10 +43,12 @@ public:
 	double get_sample_rate() const { return sample_rate; }
 	bool is_attach_log_enabled() const { return attach_log; }
 	int get_max_breadcrumbs() const { return max_breadcrumbs; }
+
 	bool is_error_logger_enabled() const { return error_logger_enabled; }
+	bool is_error_logger_capture_as_breadcrumb_enabled() const { return error_logger_capture_as_breadcrumb; }
+	bool is_error_logger_capture_as_event_enabled() const { return error_logger_capture_as_event; }
 	int get_error_logger_max_lines() const { return error_logger_max_lines; }
 	bool is_error_logger_log_warnings_enabled() const { return error_logger_log_warnings; }
-	CaptureType get_error_logger_capture_type() const { return error_logger_capture_type; }
 	bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
 
 	SentryOptions();


### PR DESCRIPTION
Implements #10

![sentry-errors](https://github.com/user-attachments/assets/34a0c589-2908-41c7-b4f1-011c4d7b663e)
