### PR TITLE
Update dynamic values in the Device context

### DIFF
--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -73,6 +73,7 @@ Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config) {
 		device_context["model"] = model;
 	}
 
+	// Note: Godot Engine doesn't support changing screen resolution.
 	Vector2i resolution = DisplayServer::get_singleton()->screen_get_size(primary_screen);
 	device_context["screen_width_pixels"] = resolution.x;
 	device_context["screen_height_pixels"] = resolution.y;
@@ -102,6 +103,24 @@ Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config) {
 		p_runtime_config->set_installation_id(installation_id);
 	}
 	device_context["device_unique_identifier"] = installation_id;
+
+	return device_context;
+}
+
+Dictionary make_device_context_update() {
+	Dictionary device_context = Dictionary();
+	int primary_screen = DisplayServer::get_singleton()->get_primary_screen();
+	device_context["orientation"] = _screen_orientation_as_string(primary_screen);
+
+	const Dictionary &meminfo = OS::get_singleton()->get_memory_info();
+	// Note: Using double since int32 can't handle size in bytes.
+	device_context["free_memory"] = double(meminfo["free"]);
+	device_context["usable_memory"] = double(meminfo["available"]);
+
+	auto dir = DirAccess::open("user://");
+	if (dir.is_valid()) {
+		device_context["free_storage"] = double(dir->get_space_left());
+	}
 
 	return device_context;
 }
@@ -322,7 +341,8 @@ Dictionary make_performance_context() {
 
 HashMap<String, Dictionary> make_event_contexts() {
 	HashMap<String, Dictionary> event_contexts;
-	event_contexts["Godot Performance"] = make_performance_context();
+	event_contexts["godot_performance"] = make_performance_context();
+	event_contexts["device"] = make_device_context_update();
 	return event_contexts;
 }
 

--- a/src/sentry/contexts.h
+++ b/src/sentry/contexts.h
@@ -11,6 +11,11 @@ using namespace godot;
 namespace sentry::contexts {
 
 Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config);
+
+// Returns smaller device context dictionary that only includes values that are
+// dynamic and need to be updated right before the event is sent.
+Dictionary make_device_context_update();
+
 Dictionary make_app_context();
 Dictionary make_gpu_context();
 Dictionary make_culture_context();

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -13,17 +13,33 @@
 
 namespace {
 
-void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name, sentry_value_t p_context) {
+void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name, const Dictionary &p_context) {
 	ERR_FAIL_COND(sentry_value_get_type(p_event) != SENTRY_VALUE_TYPE_OBJECT);
-	ERR_FAIL_COND(sentry_value_get_type(p_context) != SENTRY_VALUE_TYPE_OBJECT);
 	ERR_FAIL_COND(strlen(p_context_name) == 0);
+
+	if (p_context.is_empty()) {
+		return;
+	}
 
 	sentry_value_t contexts = sentry_value_get_by_key(p_event, "contexts");
 	if (sentry_value_is_null(contexts)) {
 		contexts = sentry_value_new_object();
 		sentry_value_set_by_key(p_event, "contexts", contexts);
 	}
-	sentry_value_set_by_key(contexts, p_context_name, p_context);
+
+	// Check if context exists and update or add it.
+	sentry_value_t ctx = sentry_value_get_by_key(contexts, p_context_name);
+	if (!sentry_value_is_null(ctx)) {
+		// If context exists, update it with new values.
+		const Array &updated_keys = p_context.keys();
+		for (int i = 0; i < updated_keys.size(); i++) {
+			const String &key = updated_keys[i];
+			sentry_value_set_by_key(ctx, key.utf8(), sentry::native::variant_to_sentry_value(p_context[key]));
+		}
+	} else {
+		// If context doesn't exist, add it.
+		sentry_value_set_by_key(contexts, p_context_name, sentry::native::variant_to_sentry_value(p_context));
+	}
 }
 
 inline void inject_contexts(sentry_value_t p_event) {
@@ -31,7 +47,7 @@ inline void inject_contexts(sentry_value_t p_event) {
 
 	HashMap<String, Dictionary> contexts = sentry::contexts::make_event_contexts();
 	for (const auto &kv : contexts) {
-		sentry_event_set_context(p_event, kv.key.utf8(), sentry::native::variant_to_sentry_value(kv.value));
+		sentry_event_set_context(p_event, kv.key.utf8(), kv.value);
 	}
 }
 


### PR DESCRIPTION
The current default is to set context values during initialization, which works for most cases. The only context that is currently updated is "godot_performance".

This PR introduces a code path that updates values in the standard `Device` context just before the event is sent.
Values that are dynamically updated in the Device context with this PR: `orientation`, `free_memory`, `usable_memory`, `free_storage`. 