### PR TITLE
Implement GHA workflow to build the Godot SDK

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -62,6 +62,17 @@ jobs:
         run: |
           scons platform=${{matrix.platform}} target=${{matrix.target}} arch=${{matrix.arch}}
 
+      - name: Separate debug symbols on Linux
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          pushd project/addons/sentrysdk/bin/
+          libname=libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}.so
+          objcopy --only-keep-debug ${libname} ${libname}.debug
+          objcopy --add-gnu-debuglink ${libname}.debug ${libname}
+          strip --strip-debug ${libname}
+          popd
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -1,7 +1,19 @@
 name: 🔌 Build GDExtension libs
 
 on:
-  push:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: 'The branch, tag or SHA to checkout (leave empty for event SHA)'
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: 'The branch, tag or SHA to checkout (leave empty for event SHA)'
 
 env:
   # Default SCons flags applied to each build.
@@ -44,6 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{inputs.ref}}
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -1,0 +1,69 @@
+name: 🔌 Build GDExtension libs
+
+on:
+  push:
+
+env:
+  # Default SCons flags applied to each build.
+  SCONSFLAGS: verbose=yes debug_symbols=yes symbols_visibility=visible
+
+jobs:
+  build:
+    name: ${{matrix.name}}
+    runs-on: ${{matrix.runner}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 🐧 Linux (x86_64, release)
+            runner: ubuntu-22.04
+            platform: linux
+            target: template_release
+            arch: x86_64
+
+          - name: 🐧 Linux (x86_64, debug)
+            runner: ubuntu-22.04
+            platform: linux
+            target: editor
+            arch: x86_64
+
+          - name: 🪟 Windows (x86_64, release)
+            runner: windows-latest
+            platform: windows
+            target: template_release
+            arch: x86_64
+
+          - name: 🪟 Windows (x86_64, debug)
+            runner: windows-latest
+            platform: windows
+            target: editor
+            arch: x86_64
+
+    steps:
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev
+
+      - name: Install SCons
+        run: |
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Compile GDExtension library
+        shell: bash
+        run: |
+          scons platform=${{matrix.platform}} target=${{matrix.target}} arch=${{matrix.arch}}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
+          path: project/addons/sentrysdk/

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -78,3 +78,15 @@ jobs:
         with:
           name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
           path: project/addons/sentrysdk/
+
+  package:
+    name: 📦 Package GDExtension
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: sentry-godot-gdextension
+          pattern: libsentrysdk.*
+          delete-merged: true

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
-          path: project/addons/sentrysdk/
+          path: project/
 
   package:
     name: 📦 Package GDExtension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - "*.md"
 
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "*.md"
 
 # Cancel in-progress runs on PR update and on push.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ⚙️ CI
+
+on:
+  push:
+    branches:
+      - "main"
+
+  pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "*.md"
+
+# Cancel in-progress runs on PR update and on push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-extension:
+    name: 🔌 Build GDExtension
+    uses: ./.github/workflows/build_gdextension.yml

--- a/scripts/build-sentry-native.sh
+++ b/scripts/build-sentry-native.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-pushd sentry-native
+cd sentry-native
 cmake -B build -DSENTRY_BUILD_SHARED_LIBS=OFF -DSENTRY_BACKEND=crashpad -DSENTRY_SDK_NAME="sentry.native.godot" -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build --target sentry --parallel --config RelWithDebInfo
 cmake --build build --target crashpad_handler --parallel --config RelWithDebInfo
 cmake --install build --prefix install --config RelWithDebInfo
-popd
+cd ..


### PR DESCRIPTION
This PR adds CI and a workflow to build and package GDExtension libraries in a ready-to-test form. CI is executed on push and PR.

GHA files:
- **ci.yml**: CI workflow.
- **build_gdextension.yml**: Build workflow.

Notes:
- I will add testing in a separate PR after both this and #19 are merged.
- Waiting for #25 and #26 before proceeding with this one.

Resolves #16