### PR TITLE
Fix: Project crashes on launch

### DIFF
--- a/src/sentry/godot_error_types.h
+++ b/src/sentry/godot_error_types.h
@@ -29,7 +29,7 @@ enum class GodotErrorMask {
 };
 
 // Used for exporting as PropertyInfo.
-const String GODOT_ERROR_MASK_EXPORT_STRING{ "Error,Warning,Script,Shader" };
+_FORCE_INLINE_ godot::String GODOT_ERROR_MASK_EXPORT_STRING() { return "Error,Warning,Script,Shader"; }
 
 _FORCE_INLINE_ Level get_sentry_level_for_godot_error_type(GodotErrorType p_error_type) { return p_error_type == GodotErrorType::ERROR_TYPE_WARNING ? LEVEL_WARNING : LEVEL_ERROR; }
 _FORCE_INLINE_ int godot_error_type_as_mask(GodotErrorType p_error_type) { return 1 << int(p_error_type); }

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -68,8 +68,8 @@ void SentryOptions::_define_project_settings() {
 	_define_setting("sentry/config/error_logger/enabled", error_logger_enabled);
 	_define_setting("sentry/config/error_logger/max_lines", error_logger_max_lines);
 	_define_setting("sentry/config/error_logger/include_source", error_logger_include_source);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING), error_logger_event_mask);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING), error_logger_breadcrumb_mask);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
 }
 
 SentryOptions::SentryOptions() {


### PR DESCRIPTION
Can't define Godot types before the GDExtension has been initialized. 
See: https://github.com/godotengine/godot-cpp/issues/1449
