### PR TITLE
Document steps to compile on Mac

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -62,6 +62,17 @@ jobs:
         run: |
           scons platform=${{matrix.platform}} target=${{matrix.target}} arch=${{matrix.arch}}
 
+      - name: Separate debug symbols on Linux
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          pushd project/addons/sentrysdk/bin/
+          libname=libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}.so
+          objcopy --only-keep-debug ${libname} ${libname}.debug
+          objcopy --add-gnu-debuglink ${libname}.debug ${libname}
+          strip --strip-debug ${libname}
+          popd
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -1,7 +1,19 @@
 name: 🔌 Build GDExtension libs
 
 on:
-  push:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: 'The branch, tag or SHA to checkout (leave empty for event SHA)'
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        default: ''
+        description: 'The branch, tag or SHA to checkout (leave empty for event SHA)'
 
 env:
   # Default SCons flags applied to each build.
@@ -44,6 +56,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          ref: ${{inputs.ref}}
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -1,0 +1,69 @@
+name: 🔌 Build GDExtension libs
+
+on:
+  push:
+
+env:
+  # Default SCons flags applied to each build.
+  SCONSFLAGS: verbose=yes debug_symbols=yes symbols_visibility=visible
+
+jobs:
+  build:
+    name: ${{matrix.name}}
+    runs-on: ${{matrix.runner}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 🐧 Linux (x86_64, release)
+            runner: ubuntu-22.04
+            platform: linux
+            target: template_release
+            arch: x86_64
+
+          - name: 🐧 Linux (x86_64, debug)
+            runner: ubuntu-22.04
+            platform: linux
+            target: editor
+            arch: x86_64
+
+          - name: 🪟 Windows (x86_64, release)
+            runner: windows-latest
+            platform: windows
+            target: template_release
+            arch: x86_64
+
+          - name: 🪟 Windows (x86_64, debug)
+            runner: windows-latest
+            platform: windows
+            target: editor
+            arch: x86_64
+
+    steps:
+      - name: Checkout repo and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev
+
+      - name: Install SCons
+        run: |
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Compile GDExtension library
+        shell: bash
+        run: |
+          scons platform=${{matrix.platform}} target=${{matrix.target}} arch=${{matrix.arch}}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
+          path: project/addons/sentrysdk/

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -78,3 +78,15 @@ jobs:
         with:
           name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
           path: project/addons/sentrysdk/
+
+  package:
+    name: 📦 Package GDExtension
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: sentry-godot-gdextension
+          pattern: libsentrysdk.*
+          delete-merged: true

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
-          path: project/addons/sentrysdk/
+          path: project/
 
   package:
     name: 📦 Package GDExtension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - "*.md"
 
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "*.md"
 
 # Cancel in-progress runs on PR update and on push.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ⚙️ CI
+
+on:
+  push:
+    branches:
+      - "main"
+
+  pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "*.md"
+
+# Cancel in-progress runs on PR update and on push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-extension:
+    name: 🔌 Build GDExtension
+    uses: ./.github/workflows/build_gdextension.yml

--- a/README.md
+++ b/README.md
@@ -23,11 +23,17 @@ python -m pip install scons
 # upgrade scons
 python -m pip install --upgrade scons
 ```
+Or, on a Mac:
+
+```
+brew install scons
+```
 
 ### Compiling
 
-1. Clone repository and its submodules.
-2. Build GDExtension libraries:
+1. Clone this repository
+2. Restore submodules: `git submodule update --init --recursive`
+3. Build GDExtension libraries:
     ```bash
     # build *editor* library for the current platform
     # run from the repository root dir
@@ -40,7 +46,7 @@ python -m pip install --upgrade scons
     # build *export* library for the current platform
     scons target=template_release debug_symbols=yes
     ```
-3. Open demo project in Godot Engine:
+4. Open demo project in Godot Engine:
     ```bash
     # open demo project in Godot 4.3
     godot project/project.godot

--- a/scripts/build-sentry-native.sh
+++ b/scripts/build-sentry-native.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-pushd sentry-native
+cd sentry-native
 cmake -B build -DSENTRY_BUILD_SHARED_LIBS=OFF -DSENTRY_BACKEND=crashpad -DSENTRY_SDK_NAME="sentry.native.godot" -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build --target sentry --parallel --config RelWithDebInfo
 cmake --build build --target crashpad_handler --parallel --config RelWithDebInfo
 cmake --install build --prefix install --config RelWithDebInfo
-popd
+cd ..


### PR DESCRIPTION
For the most part it seems to compile fine on a mac:

```
...
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_tools.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_handler_lib.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/bin/crashpad_handler
Copy("project/addons/sentrysdk/bin/crashpad_handler", "sentry-native/install/bin/crashpad_handler")
Linking Shared Library project/addons/sentrysdk/bin/libsentrysdk.macos.editor.framework/libsentrysdk.macos.editor ...
ld: library 'crashpad_compat' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [project/addons/sentrysdk/bin/libsentrysdk.macos.editor.framework/libsentrysdk.macos.editor] Error 1
scons: building terminated because of errors.
```

Except it failed on some crashpad related issue

```
> ls project/addons/sentrysdk/bi
crashpad_handler                        
libsentrysdk.macos.editor.framework     
sentrysdk.gdextension
```

Then with `scons target=template_release debug_symbols=yes` it also got mostly done:

```
[ 65%] Built target crashpad_client
[ 80%] Built target crashpad_snapshot
[ 93%] Built target crashpad_minidump
[ 98%] Built target crashpad_handler_lib
[100%] Built target crashpad_handler
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry_crashpad-targets.cmake
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry_crashpad-targets-relwithdebinfo.cmake
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libsentry.a
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/include/sentry.h
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry-targets.cmake
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry-targets-relwithdebinfo.cmake
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry-config.cmake
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/lib/cmake/sentry/sentry-config-version.cmake
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_minidump.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_snapshot.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_util.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libmini_chromium.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_client.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_tools.a
-- Installing: /Users/bruno/git/sentry-godot/sentry-native/install/lib/libcrashpad_handler_lib.a
-- Up-to-date: /Users/bruno/git/sentry-godot/sentry-native/install/bin/crashpad_handler
Copy("project/addons/sentrysdk/bin/crashpad_handler", "sentry-native/install/bin/crashpad_handler")
Linking Shared Library project/addons/sentrysdk/bin/libsentrysdk.macos.template_release.framework/libsentrysdk.macos.template_release ...
ld: library 'crashpad_compat' not found
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [project/addons/sentrysdk/bin/libsentrysdk.macos.template_release.framework/libsentrysdk.macos.template_release] Error 1
scons: building terminated because of errors.
```