### PR TITLE
Feature: Logger limits and throttling

### DIFF
--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -59,17 +59,14 @@ void SentryLogger::_process_log_file() {
 	log_file.clear(); // Remove eof flag, so that we can read the next line.
 
 	SentryOptions::LoggerLimits limits = SentryOptions::get_singleton()->get_error_logger_limits();
-	int max_lines = limits.max_lines_parsed;
-	int max_events = limits.events_per_frame;
-	int max_breadcrumbs = limits.breadcrumbs_per_frame;
 	auto throttle_interval = std::chrono::milliseconds{ limits.repeated_error_throttling_ms };
 
 	int num_lines_read = 0;
 	char first_line[MAX_LINE_LENGTH];
 	char second_line[MAX_LINE_LENGTH];
 
-	while (num_lines_read < max_lines && log_file.getline(first_line, MAX_LINE_LENGTH) &&
-			(num_breadcrumbs_captured < max_breadcrumbs || num_events_captured < max_events)) {
+	while (num_lines_read < limits.max_lines_parsed && log_file.getline(first_line, MAX_LINE_LENGTH) &&
+			(num_breadcrumbs_captured < limits.breadcrumbs_per_frame || num_events_captured < limits.events_per_frame)) {
 		num_lines_read++;
 
 		for (int i = 0; i < num_error_types; i++) {

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -1,6 +1,7 @@
 #include "sentry_logger.h"
 
 #include "sentry/util.h"
+#include "sentry_options.h"
 #include "sentry_sdk.h"
 
 #include <cstring>
@@ -57,12 +58,15 @@ void SentryLogger::_process_log_file() {
 
 	log_file.clear(); // Remove eof flag, so that we can read the next line.
 
+	SentryOptions::LoggerLimits limits = SentryOptions::get_singleton()->get_error_logger_limits();
+	int max_lines = limits.max_lines_parsed;
+	int max_events = limits.events_per_frame;
+	int max_breadcrumbs = limits.breadcrumbs_per_frame;
+	auto throttle_interval = std::chrono::milliseconds{ limits.repeated_error_throttling_ms };
+
 	int num_lines_read = 0;
 	char first_line[MAX_LINE_LENGTH];
 	char second_line[MAX_LINE_LENGTH];
-	int max_lines = SentryOptions::get_singleton()->get_error_logger_max_lines();
-	int max_events = SentryOptions::get_singleton()->get_error_logger_limit_events_per_frame();
-	int max_breadcrumbs = SentryOptions::get_singleton()->get_error_logger_limit_breadcrumbs_per_frame();
 
 	while (num_lines_read < max_lines && log_file.getline(first_line, MAX_LINE_LENGTH) &&
 			(num_breadcrumbs_captured < max_breadcrumbs || num_events_captured < max_events)) {
@@ -88,7 +92,20 @@ void SentryLogger::_process_log_file() {
 					if (last_colon != NULL) {
 						*last_colon = '\0';
 						int line = atoi(last_colon + 1);
-						_log_error(func, file_part, line, rationale, err_type);
+
+						// Log errors based on throttle interval to prevent repetitive logging
+						// caused by loops or recurring errors in each frame.
+						// Last log time is tracked for each source line that produced an error.
+						SourceLine src_line{ file_part, line };
+						TimePoint now = std::chrono::high_resolution_clock::now();
+						auto it = last_logged.find(src_line);
+						if (it == last_logged.end() || now - it->second >= throttle_interval) {
+							_log_error(func, file_part, line, rationale, err_type);
+							last_logged[src_line] = now;
+						} else {
+							sentry::util::print_debug("error capture was canceled due to throttling for ",
+									file_part, " at line ", line, ".");
+						}
 					}
 				}
 
@@ -102,10 +119,11 @@ void SentryLogger::_process_log_file() {
 }
 
 void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType p_error_type) {
+	SentryOptions::LoggerLimits limits = SentryOptions::get_singleton()->get_error_logger_limits();
 	bool as_breadcrumb = SentryOptions::get_singleton()->is_error_logger_breadcrumb_enabled(p_error_type) &&
-			num_breadcrumbs_captured < SentryOptions::get_singleton()->get_error_logger_limit_breadcrumbs_per_frame();
+			num_breadcrumbs_captured < limits.breadcrumbs_per_frame;
 	bool as_event = SentryOptions::get_singleton()->is_error_logger_event_enabled(p_error_type) &&
-			num_events_captured < SentryOptions::get_singleton()->get_error_logger_limit_events_per_frame();
+			num_events_captured < limits.events_per_frame;
 
 	if (!as_breadcrumb && !as_event) {
 		// Bail out if capture is disabled for this error type.

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -300,7 +300,7 @@ SentryLogger::SentryLogger() {
 
 	trim_timer = memnew(Timer);
 	trim_timer->set_one_shot(false);
-	trim_timer->set_wait_time(300); // 5 minutes
+	trim_timer->set_wait_time(60); // 1 minute
 	trim_timer->set_autostart(true);
 	add_child(trim_timer);
 }

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -5,6 +5,7 @@
 #include "sentry/level.h"
 
 #include <chrono>
+#include <deque>
 #include <fstream>
 #include <godot_cpp/classes/node.hpp>
 #include <unordered_map>
@@ -25,14 +26,22 @@ private:
 		}
 	};
 
-	// Stores the last time an error was logged for each source line.
-	std::unordered_map<SourceLine, TimePoint, SourceLineHash> last_logged;
+	// Stores the last time an error was logged for each source line that generated an error.
+	std::unordered_map<SourceLine, TimePoint, SourceLineHash> source_line_times;
+	// TODO: Needs to be trimmed periodically or it might get huge (unlikely but still possible).
+
+	// Time points for events captured within throttling window.
+	std::deque<TimePoint> event_times;
+	// Time points for breadcrumbs captured within throttling window.
+	std::deque<TimePoint> crumb_times;
+
+	// Number of breadcrumbs captured during this frame.
+	int frame_crumbs = 0;
+	// Number of events captured during this frame.
+	int frame_events = 0;
 
 	Callable process_log;
 	std::ifstream log_file;
-
-	int num_breadcrumbs_captured = 0;
-	int num_events_captured = 0;
 
 	void _setup();
 	void _process_log_file();

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -8,6 +8,7 @@
 #include <deque>
 #include <fstream>
 #include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/timer.hpp>
 #include <unordered_map>
 
 using namespace godot;
@@ -28,7 +29,6 @@ private:
 
 	// Stores the last time an error was logged for each source line that generated an error.
 	std::unordered_map<SourceLine, TimePoint, SourceLineHash> source_line_times;
-	// TODO: Needs to be trimmed periodically or it might get huge (unlikely but still possible).
 
 	// Time points for events captured within throttling window.
 	std::deque<TimePoint> event_times;
@@ -42,10 +42,12 @@ private:
 
 	Callable process_log;
 	std::ifstream log_file;
+	Timer *trim_timer = nullptr;
 
 	void _setup();
 	void _process_log_file();
 	void _log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType error_type);
+	void _trim_error_timepoints();
 
 	// Returns true if an error occurred. Populates the last three arguments passed by reference.
 	bool _get_script_context(const String &p_file, int p_line, String &r_context_line, PackedStringArray &r_pre_context, PackedStringArray &r_post_context) const;

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -32,11 +32,7 @@ private:
 
 	// Time points for events captured within throttling window.
 	std::deque<TimePoint> event_times;
-	// Time points for breadcrumbs captured within throttling window.
-	std::deque<TimePoint> crumb_times;
 
-	// Number of breadcrumbs captured during this frame.
-	int frame_crumbs = 0;
 	// Number of events captured during this frame.
 	int frame_events = 0;
 

--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -17,6 +17,9 @@ private:
 	Callable process_log;
 	std::ifstream log_file;
 
+	int num_breadcrumbs_captured = 0;
+	int num_events_captured = 0;
+
 	void _setup();
 	void _process_log_file();
 	void _log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType error_type);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -30,10 +30,10 @@ void SentryOptions::_load_project_settings() {
 	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
 
-	error_logger_limits.max_lines_parsed = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/max_lines_parsed", error_logger_limits.max_lines_parsed);
+	error_logger_limits.parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
 	error_logger_limits.breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limits.breadcrumbs_per_frame);
 	error_logger_limits.events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits.events_per_frame);
-	error_logger_limits.repeated_error_throttling_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_throttling_ms", error_logger_limits.repeated_error_throttling_ms);
+	error_logger_limits.repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", error_logger_limits.repeated_error_window_ms);
 }
 
 void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
@@ -78,10 +78,10 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
 
-	_define_setting("sentry/config/error_logger/limits/max_lines_parsed", error_logger_limits.max_lines_parsed);
+	_define_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.breadcrumbs_per_frame);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.events_per_frame);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_throttling_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_throttling_ms);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_window_ms);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -26,12 +26,14 @@ void SentryOptions::_load_project_settings() {
 	send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/config/send_default_pii", send_default_pii);
 
 	error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/enabled", error_logger_enabled);
-	error_logger_max_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/max_lines", error_logger_max_lines);
 	error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
-	error_logger_limit_breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limit_breadcrumbs_per_frame);
-	error_logger_limit_events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limit_events_per_frame);
+
+	error_logger_limits.max_lines_parsed = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/max_lines", error_logger_limits.max_lines_parsed);
+	error_logger_limits.breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limits.breadcrumbs_per_frame);
+	error_logger_limits.events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits.events_per_frame);
+	error_logger_limits.repeated_error_throttling_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_throttling_ms", error_logger_limits.repeated_error_throttling_ms);
 }
 
 void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
@@ -72,12 +74,14 @@ void SentryOptions::_define_project_settings() {
 	_define_setting("sentry/config/send_default_pii", send_default_pii);
 
 	_define_setting("sentry/config/error_logger/enabled", error_logger_enabled);
-	_define_setting("sentry/config/error_logger/max_lines", error_logger_max_lines);
 	_define_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limit_breadcrumbs_per_frame);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limit_events_per_frame);
+
+	_define_setting("sentry/config/error_logger/max_lines", error_logger_limits.max_lines_parsed);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.breadcrumbs_per_frame);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.events_per_frame);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_throttling_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_throttling_ms);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -31,9 +31,10 @@ void SentryOptions::_load_project_settings() {
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
 
 	error_logger_limits.parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
-	error_logger_limits.breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limits.breadcrumbs_per_frame);
 	error_logger_limits.events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits.events_per_frame);
 	error_logger_limits.repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", error_logger_limits.repeated_error_window_ms);
+	error_logger_limits.throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_events", error_logger_limits.throttle_events);
+	error_logger_limits.throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_window_ms", error_logger_limits.throttle_window_ms);
 }
 
 void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
@@ -79,9 +80,10 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
 
 	_define_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.breadcrumbs_per_frame);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.events_per_frame);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_window_ms);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.throttle_events);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.throttle_window_ms);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -30,7 +30,7 @@ void SentryOptions::_load_project_settings() {
 	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
 
-	error_logger_limits.max_lines_parsed = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/max_lines", error_logger_limits.max_lines_parsed);
+	error_logger_limits.max_lines_parsed = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/max_lines_parsed", error_logger_limits.max_lines_parsed);
 	error_logger_limits.breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limits.breadcrumbs_per_frame);
 	error_logger_limits.events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits.events_per_frame);
 	error_logger_limits.repeated_error_throttling_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_throttling_ms", error_logger_limits.repeated_error_throttling_ms);
@@ -78,7 +78,7 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
 
-	_define_setting("sentry/config/error_logger/max_lines", error_logger_limits.max_lines_parsed);
+	_define_setting("sentry/config/error_logger/limits/max_lines_parsed", error_logger_limits.max_lines_parsed);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.breadcrumbs_per_frame);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.events_per_frame);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_throttling_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_throttling_ms);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -30,6 +30,8 @@ void SentryOptions::_load_project_settings() {
 	error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
+	error_logger_limit_breadcrumbs_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/breadcrumbs_per_frame", error_logger_limit_breadcrumbs_per_frame);
+	error_logger_limit_events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limit_events_per_frame);
 }
 
 void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
@@ -74,6 +76,8 @@ void SentryOptions::_define_project_settings() {
 	_define_setting("sentry/config/error_logger/include_source", error_logger_include_source);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/breadcrumbs_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limit_breadcrumbs_per_frame);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limit_events_per_frame);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -22,13 +22,13 @@ public:
 		int parse_lines = 100;
 
 		// Protect frametime budget.
-		int events_per_frame = 1;
+		int events_per_frame = 5;
 
 		// Limit to 1 error captured per source line within T milliseconds window.
 		int repeated_error_window_ms = 1000;
 
 		// Limit to N events within T milliseconds window.
-		int throttle_events = 4;
+		int throttle_events = 20;
 		int throttle_window_ms = 10000;
 	};
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -22,15 +22,13 @@ public:
 		int parse_lines = 100;
 
 		// Protect frametime budget.
-		int breadcrumbs_per_frame = 5;
 		int events_per_frame = 1;
 
 		// Limit to 1 error captured per source line within T milliseconds window.
 		int repeated_error_window_ms = 1000;
 
-		// Limit to N events and M breadcrumbs within T milliseconds window.
+		// Limit to N events within T milliseconds window.
 		int throttle_events = 4;
-		int throttle_breadcrumbs = 20;
 		int throttle_window_ms = 10000;
 	};
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -16,10 +16,22 @@ class SentryOptions {
 
 public:
 	struct LoggerLimits {
-		int max_lines_parsed = 30;
-		int breadcrumbs_per_frame = 10;
-		int events_per_frame = 2;
-		int repeated_error_throttling_ms = 1000;
+		// TODO: Establish proper default limits with the Sentry team.
+
+		// Limit the number of lines that can be parsed per frame.
+		int parse_lines = 30;
+
+		// Protect frametime budget.
+		int breadcrumbs_per_frame = 5;
+		int events_per_frame = 1;
+
+		// Limit to 1 error captured per source line within T milliseconds window.
+		int repeated_error_window_ms = 1000;
+
+		// Limit to N events and M breadcrumbs within T milliseconds window.
+		int throttle_events = 4;
+		int throttle_breadcrumbs = 20;
+		int throttle_window_ms = 10000;
 	};
 
 private:

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -33,6 +33,8 @@ private:
 	bool error_logger_include_source = true;
 	int error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
 	int error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
+	int error_logger_limit_breadcrumbs_per_frame = 10;
+	int error_logger_limit_events_per_frame = 2;
 
 	void _define_setting(const String &p_setting, const Variant &p_default, bool p_basic = true);
 	void _define_setting(const PropertyInfo &p_info, const Variant &p_default, bool p_basic = true);
@@ -57,6 +59,8 @@ public:
 	bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
 	bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask & sentry::godot_error_type_as_mask(p_error_type); }
 	bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask & sentry::godot_error_type_as_mask(p_error_type); }
+	int get_error_logger_limit_breadcrumbs_per_frame() const { return error_logger_limit_breadcrumbs_per_frame; }
+	int get_error_logger_limit_events_per_frame() const { return error_logger_limit_events_per_frame; }
 
 	SentryOptions();
 	~SentryOptions();

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -19,7 +19,7 @@ public:
 		// TODO: Establish proper default limits with the Sentry team.
 
 		// Limit the number of lines that can be parsed per frame.
-		int parse_lines = 30;
+		int parse_lines = 100;
 
 		// Protect frametime budget.
 		int breadcrumbs_per_frame = 5;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -14,6 +14,14 @@ class SentryOptions {
 	using GodotErrorType = sentry::GodotErrorType;
 	using GodotErrorMask = sentry::GodotErrorMask;
 
+public:
+	struct LoggerLimits {
+		int max_lines_parsed = 30;
+		int breadcrumbs_per_frame = 10;
+		int events_per_frame = 2;
+		int repeated_error_throttling_ms = 1000;
+	};
+
 private:
 	static SentryOptions *singleton;
 
@@ -29,12 +37,10 @@ private:
 	bool send_default_pii = false;
 
 	bool error_logger_enabled = true;
-	int error_logger_max_lines = 30;
 	bool error_logger_include_source = true;
 	int error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
 	int error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
-	int error_logger_limit_breadcrumbs_per_frame = 10;
-	int error_logger_limit_events_per_frame = 2;
+	LoggerLimits error_logger_limits;
 
 	void _define_setting(const String &p_setting, const Variant &p_default, bool p_basic = true);
 	void _define_setting(const PropertyInfo &p_info, const Variant &p_default, bool p_basic = true);
@@ -55,12 +61,10 @@ public:
 	bool is_send_default_pii_enabled() const { return send_default_pii; }
 
 	bool is_error_logger_enabled() const { return error_logger_enabled; }
-	int get_error_logger_max_lines() const { return error_logger_max_lines; }
 	bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
 	bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask & sentry::godot_error_type_as_mask(p_error_type); }
 	bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask & sentry::godot_error_type_as_mask(p_error_type); }
-	int get_error_logger_limit_breadcrumbs_per_frame() const { return error_logger_limit_breadcrumbs_per_frame; }
-	int get_error_logger_limit_events_per_frame() const { return error_logger_limit_events_per_frame; }
+	LoggerLimits get_error_logger_limits() const { return error_logger_limits; }
 
 	SentryOptions();
 	~SentryOptions();


### PR DESCRIPTION
- **Problems**
  - Repeatedly logging the same error in a loop
  - Errors recurring every frame
  - Multiple various errors overwhelming quotas
  - Specific error type spamming & overwhelming quotas (?)
- **Goals**
  - Protect the frame budget
  - Reduce impact on quotas
  - Increase coverage: avoid duplicates, and some errors not reported at all
- **Complex solution**
  - **Limit errors to N events reported per frame**
    - Rationale: Protect the frame budget.
    - Options: `limits/events_per_frame`, ~~`limits/breadcrumbs_per_frame`~~
  - **Limit errors to 1 error captured per (file, lineno) within a T interval.**
    - Rationale: Increase error coverage and reduce redundancy.
    - Options: `limits/repeated_error_window_ms`
  - **Limit to N events ~~& M breadcrumbs~~ reported within a T milliseconds interval**
    - Rationale: Reduce overall impact on quotas.
    - Options: `limits/throttle_events`, `limits/throttle_window_ms`, ~~`limits/throttle_breadcrumbs`~~
- **Previously implemented**
  - **Limiting the number of log lines read per frame, defaults to 100.**
    - Limitation: If a user prints something heavy at the start of a frame, some errors may be omitted later that same frame (unlikely scenario).
    - This will go away with the logger API landing in Godot.
  - **Enabling/disabling capture for specific error types (event/breadcrumb).**
    - Drawback: It is manual and reactive, requiring developers to create a new build with updated configuration.

Aiming to resolve #22