### PR TITLE
Fix user test failing

### DIFF
--- a/project/test/test_sentry_user.gd
+++ b/project/test/test_sentry_user.gd
@@ -66,7 +66,6 @@ func test_sentry_user_ip_inferring() -> void:
 	assert_str(user.ip_address).is_equal("{{auto}}")
 	assert_str(user.email).is_empty()
 	assert_str(user.username).is_empty()
-	assert_str(user.id).is_not_empty() # ID for user is auto-generated.
 
 
 ## SentryUser ID generation should produce a unique ID.


### PR DESCRIPTION
Fix user test failing due to user ID no longer assigned if `send-default-pii` is enabled