### PR TITLE
Fix crash on shutdown on Windows

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -18,10 +18,9 @@ void _init_logger() {
 		return;
 	}
 	// Add experimental logger to scene tree.
-	SentryLogger *logger = memnew(SentryLogger);
 	SceneTree *sml = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
-	if (sml) {
-		sml->get_root()->add_child(logger);
+	if (sml && sml->get_root()) {
+		sml->get_root()->add_child(memnew(SentryLogger));
 	} else {
 		ERR_FAIL_MSG("Sentry: Internal error: SceneTree is null.");
 	}
@@ -56,8 +55,12 @@ void initialize_module(ModuleInitializationLevel p_level) {
 
 void uninitialize_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		memdelete(SentrySDK::get_singleton());
-		delete SentryOptions::get_singleton();
+		if (SentrySDK::get_singleton()) {
+			memdelete(SentrySDK::get_singleton());
+		}
+		if (SentryOptions::get_singleton()) {
+			delete SentryOptions::get_singleton();
+		}
 	}
 }
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -55,7 +55,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		memdelete(SentrySDK::get_singleton());
 		delete SentryOptions::get_singleton();
 	}

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -70,6 +70,7 @@ void SentrySDK::set_context(const godot::String &p_key, const godot::Dictionary 
 }
 
 void SentrySDK::_init_contexts() {
+	sentry::util::print_debug("initializing contexts");
 	internal_sdk->set_context("device", sentry::contexts::make_device_context(runtime_config));
 	internal_sdk->set_context("app", sentry::contexts::make_app_context());
 	internal_sdk->set_context("gpu", sentry::contexts::make_gpu_context());
@@ -121,6 +122,7 @@ SentrySDK::SentrySDK() {
 
 	enabled = enabled && SentryOptions::get_singleton()->is_enabled();
 	if (!enabled) {
+		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
 		internal_sdk = std::make_shared<DisabledSDK>();
 		return;
 	}


### PR DESCRIPTION
This PR fixes a crash on Windows related to memory release, adds sanity checks and debug prints.