### PR TITLE
GHA: Run unit tests in CI

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -93,7 +93,7 @@ jobs:
           path: |
             project/
             !project/addons/gdUnit4
-            !test
+            !project/test/
 
   package:
     name: 📦 Package GDExtension

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -90,7 +90,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: libsentrysdk.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}
-          path: project/
+          path: |
+            project/
+            !project/addons/gdUnit4
+            !test
 
   package:
     name: 📦 Package GDExtension

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,8 @@ jobs:
   build-extension:
     name: 🔌 Build GDExtension
     uses: ./.github/workflows/build_gdextension.yml
+
+  unit-tests:
+    name: 🧪 Unit tests
+    needs: build-extension
+    uses: ./.github/workflows/unit_tests.yml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,18 +2,6 @@ name: 🧪 Unit tests
 
 on:
   workflow_call:
-    inputs:
-      godot-version:
-        description: Godot Engine version to use for testing.
-        type: string
-        default: "4.3-stable"
-
-  workflow_dispatch:
-    inputs:
-      godot-version:
-        description: Godot Engine version to use for testing.
-        type: string
-        default: "4.3-stable"
 
 jobs:
   unit-tests:
@@ -24,20 +12,37 @@ jobs:
       matrix:
         include:
           - runner: windows-latest
-            bin-suffix: win64.exe
+            godot-suffix: win64.exe
           - runner: ubuntu-latest
-            bin-suffix: linux.x86_64
+            godot-suffix: linux.x86_64
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: false # don't initialize submodules automatically
+
+      - name: Checkout required submodules
+        run: |
+          git submodule update --init --depth 1 modules/gdUnit4
+          git submodule update --init --depth 1 modules/godot-cpp
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: sentry-godot-gdextension
+          path: project/
+
+      - name: Install SCons
+        run: |
+          python -m pip install scons
+          python --version
+          scons --version
 
       - name: Set up Godot
         shell: bash
         run: |
-          version=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1-stable/p' addons/sentrysdk/bin/sentrysdk.gdextension)
-          bin=Godot_v${version}_${{matrix.bin-suffix}}
+          version=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1-stable/p' project/addons/sentrysdk/bin/sentrysdk.gdextension)
+          bin=Godot_v${version}_${{matrix.godot-suffix}}
           url=https://github.com/godotengine/godot/releases/download/${version}/${bin}.zip
           mkdir godot/
           cd godot/
@@ -52,20 +57,27 @@ jobs:
       - name: Diagnostic info
         shell: bash
         run: |
-          ls -lR
+          ls -lR project/
 
-      - name: Prepare artifact
+      - name: Prepare project
         shell: bash
         timeout-minutes: 5
         run: |
-          chmod +x ./addons/sentrysdk/bin/crashpad_handler
-          ${GODOT_BIN} --headless --path . --import
+          scons project/addons/gdUnit4
+          chmod +x project/addons/sentrysdk/bin/crashpad_handler
+          echo "--- Rebuilding import cache.."
+          ${GODOT_BIN} --headless --editor --path project/ --quit-after 2000 || true
+          echo "--- Finished rebuilding import cache."
 
-      - name: Run gdUnit tests
+      - name: Run tests
         shell: bash
         timeout-minutes: 5
         run: |
-          ${GODOT_BIN} --headless --path . -s -d "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" --ignoreHeadlessMode -a test
-          exit_code=$?
-          echo "Run tests finished with code ${exit_code}"
-          exit ${exit_code}
+          ${GODOT_BIN} --headless --path project/ -s -d "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" --ignoreHeadlessMode -c -a test
+
+      - name: Upload results
+        if: always() # do this step even if the tests fail
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{matrix.runner}}
+          path: project/reports

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -73,6 +73,7 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
+          # Exit status codes: 0 - success, 100 - ends with test failures, 101 - ends with test warnings.
           ${GODOT_BIN} --headless --path project/ -s -d "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" --ignoreHeadlessMode -c -a test
 
       - name: Upload results

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,71 @@
+name: 🧪 Unit tests
+
+on:
+  workflow_call:
+    inputs:
+      godot-version:
+        description: Godot Engine version to use for testing.
+        type: string
+        default: "4.3-stable"
+
+  workflow_dispatch:
+    inputs:
+      godot-version:
+        description: Godot Engine version to use for testing.
+        type: string
+        default: "4.3-stable"
+
+jobs:
+  unit-tests:
+    name: Test on ${{matrix.runner}}
+    runs-on: ${{matrix.runner}}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            bin-suffix: win64.exe
+          - runner: ubuntu-latest
+            bin-suffix: linux.x86_64
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sentry-godot-gdextension
+
+      - name: Set up Godot
+        shell: bash
+        run: |
+          version=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1-stable/p' addons/sentrysdk/bin/sentrysdk.gdextension)
+          bin=Godot_v${version}_${{matrix.bin-suffix}}
+          url=https://github.com/godotengine/godot/releases/download/${version}/${bin}.zip
+          mkdir godot/
+          cd godot/
+          curl -L -o godot.zip "${url}"
+          unzip godot.zip
+          rm godot.zip
+          chmod u+x ${bin}
+          ls -l
+          ./${bin} --version
+          echo "GODOT_BIN=${GITHUB_WORKSPACE}/godot/${bin}" >> $GITHUB_ENV
+
+      - name: Diagnostic info
+        shell: bash
+        run: |
+          ls -lR
+
+      - name: Prepare artifact
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          chmod +x ./addons/sentrysdk/bin/crashpad_handler
+          ${GODOT_BIN} --headless --path . --import
+
+      - name: Run gdUnit tests
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          ${GODOT_BIN} --headless --path . -s -d "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" --ignoreHeadlessMode -a test
+          exit_code=$?
+          echo "Run tests finished with code ${exit_code}"
+          exit ${exit_code}


### PR DESCRIPTION
Run unit tests in CI using Windows and Linux runners. This will help us detect compilation and runtime issues early on.