### PR TITLE
Option to disable SDK in the editor

### DIFF
--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -17,6 +17,7 @@ void SentryOptions::_load_project_settings() {
 	release = release_str.format(format_params).utf8();
 
 	enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/enabled", enabled);
+	disabled_in_editor = ProjectSettings::get_singleton()->get_setting("sentry/config/disabled_in_editor", disabled_in_editor);
 	dsn = String(ProjectSettings::get_singleton()->get_setting("sentry/config/dsn", String(dsn))).utf8();
 	debug = ProjectSettings::get_singleton()->get_setting("sentry/config/debug", debug);
 	sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/config/sample_rate", sample_rate);
@@ -59,6 +60,7 @@ void SentryOptions::_define_setting(const godot::PropertyInfo &p_info, const god
 
 void SentryOptions::_define_project_settings() {
 	_define_setting("sentry/config/enabled", enabled);
+	_define_setting("sentry/config/disabled_in_editor", disabled_in_editor);
 	_define_setting("sentry/config/dsn", String(dsn));
 	_define_setting("sentry/config/release", String(release));
 	_define_setting("sentry/config/debug", debug);

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -18,6 +18,7 @@ private:
 	static SentryOptions *singleton;
 
 	bool enabled = true;
+	bool disabled_in_editor = true;
 	CharString dsn = "";
 	CharString release = "{app_name}@{app_version}";
 	bool debug = false;
@@ -42,6 +43,7 @@ public:
 	_FORCE_INLINE_ static SentryOptions *get_singleton() { return singleton; }
 
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }
+	_FORCE_INLINE_ bool is_disabled_in_editor() const { return disabled_in_editor; }
 	CharString get_dsn() const { return dsn; }
 	CharString get_release() const { return release; }
 	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -6,6 +6,7 @@
 #include "sentry/uuid.h"
 #include "sentry_options.h"
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
@@ -121,6 +122,10 @@ SentrySDK::SentrySDK() {
 #endif
 
 	enabled = enabled && SentryOptions::get_singleton()->is_enabled();
+	if (enabled && Engine::get_singleton()->is_editor_hint() && SentryOptions::get_singleton()->is_disabled_in_editor()) {
+		sentry::util::print_debug("Sentry SDK is disabled in the editor. Tip: This can be changed in the project settings.");
+		enabled = false;
+	}
 	if (!enabled) {
 		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
 		internal_sdk = std::make_shared<DisabledSDK>();


### PR DESCRIPTION
This PR introduces a new option `disabled_in_editor` which defaults to `true`. Disabled SDK does not process events or errors, and doesn't connect to Sentry servers. The extension library is still loaded for the purpose of editing options and such.
This option does NOT disable SDK while running projects from the editor. Unit tests also run fine, since they are executed in a separate process (not inside editor).