### PR TITLE
Fix sentry level in `capture_message`

### DIFF
--- a/project/main.gd
+++ b/project/main.gd
@@ -24,13 +24,13 @@ func _ready() -> void:
 
 func _init_level_choice_popup() -> void:
 	var popup: PopupMenu = level_choice.get_popup()
-	popup.add_item("DEBUG", SentrySDK.LEVEL_DEBUG + 1)
-	popup.add_item("INFO", SentrySDK.LEVEL_INFO + 1)
-	popup.add_item("WARNING", SentrySDK.LEVEL_WARNING + 1)
-	popup.add_item("ERROR", SentrySDK.LEVEL_ERROR + 1)
-	popup.add_item("FATAL", SentrySDK.LEVEL_FATAL + 1)
+	popup.add_item("DEBUG", SentrySDK.LEVEL_DEBUG)
+	popup.add_item("INFO", SentrySDK.LEVEL_INFO)
+	popup.add_item("WARNING", SentrySDK.LEVEL_WARNING)
+	popup.add_item("ERROR", SentrySDK.LEVEL_ERROR)
+	popup.add_item("FATAL", SentrySDK.LEVEL_FATAL)
 
-	_on_level_choice_id_pressed(SentrySDK.LEVEL_INFO + 1)
+	_on_level_choice_id_pressed(SentrySDK.LEVEL_INFO)
 
 
 func _update_user_info() -> void:
@@ -43,7 +43,7 @@ func _update_user_info() -> void:
 
 
 func _on_level_choice_id_pressed(id: int) -> void:
-	_event_level = (id - 1) as SentrySDK.Level
+	_event_level = id as SentrySDK.Level
 	match _event_level:
 		SentrySDK.LEVEL_DEBUG:
 			level_choice.text = "DEBUG"

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -4,6 +4,7 @@
 #include "sentry.h"
 #include "sentry/contexts.h"
 #include "sentry/environment.h"
+#include "sentry/level.h"
 #include "sentry/native/native_util.h"
 #include "sentry_options.h"
 
@@ -65,6 +66,23 @@ inline String _uuid_as_string(sentry_uuid_t p_uuid) {
 	char str[37];
 	sentry_uuid_as_string(&p_uuid, str);
 	return str;
+}
+
+sentry_level_t _level_as_native(sentry::Level p_level) {
+	switch (p_level) {
+		case sentry::Level::LEVEL_DEBUG:
+			return SENTRY_LEVEL_DEBUG;
+		case sentry::Level::LEVEL_INFO:
+			return SENTRY_LEVEL_INFO;
+		case sentry::Level::LEVEL_WARNING:
+			return SENTRY_LEVEL_WARNING;
+		case sentry::Level::LEVEL_ERROR:
+			return SENTRY_LEVEL_ERROR;
+		case sentry::Level::LEVEL_FATAL:
+			return SENTRY_LEVEL_FATAL;
+		default:
+			ERR_FAIL_V_MSG(SENTRY_LEVEL_ERROR, "SentrySDK: Internal error - unexpected level value. Please open an issue.");
+	}
 }
 
 } // unnamed namespace
@@ -130,7 +148,7 @@ void NativeSDK::add_breadcrumb(const String &p_message, const String &p_category
 
 String NativeSDK::capture_message(const String &p_message, Level p_level, const String &p_logger) {
 	sentry_value_t event = sentry_value_new_message_event(
-			(sentry_level_t)p_level,
+			_level_as_native(p_level),
 			p_logger.utf8().get_data(),
 			p_message.utf8().get_data());
 	last_uuid = sentry_capture_event(event);


### PR DESCRIPTION
This PR fixes sentry level not properly set in `SentrySDK.capture_message()`