### PR TITLE
ci: Delete intermediary artifact to encourage correct package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,16 @@ jobs:
     name: 📦 Package
     needs: build-extension
     uses: ./.github/workflows/package.yml
+
+  # Deleting "sentry-godot-gdextension" artifact due to broken file permissions.
+  # This encourages using the artifact from the "package" job instead which has correct permissions.
+  # See issue: https://github.com/getsentry/sentry-godot/issues/41
+  cleanup:
+    name: 🗑️ Cleanup
+    needs: [package, unit-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete sentry-godot-gdextension artifact
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
+        with:
+          name: sentry-godot-gdextension


### PR DESCRIPTION
Remove `sentry-godot-gdextension` artifact as the last step in CI, because it lacks executable permissions on `crashpad_handler`. These permissions are corrected in the "package" job which produces a separate artifact, so this encourages downloading the correct zip archive.

For more details, see #41
Resolves #41