### PR TITLE
feat: Improve & expose `SentryOptions` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve & expose `SentryOptions` class ([#56](https://github.com/getsentry/sentry-godot/pull/56))
+
 ## 0.0.3
 
 ### Various fixes & improvements

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -32,7 +32,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
 	} else if (p_level == godot::MODULE_INITIALIZATION_LEVEL_SERVERS) {
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		// Note: Godot singletons are only available at higher initialization levels.
+		GDREGISTER_CLASS(SentryLoggerLimits);
 		GDREGISTER_CLASS(SentryOptions);
 		SentryOptions *options = memnew(SentryOptions);
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -33,7 +33,8 @@ void initialize_module(ModuleInitializationLevel p_level) {
 	} else if (p_level == godot::MODULE_INITIALIZATION_LEVEL_SERVERS) {
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		// Note: Godot singletons are only available at higher initialization levels.
-		SentryOptions *options = new SentryOptions();
+		GDREGISTER_CLASS(SentryOptions);
+		SentryOptions *options = memnew(SentryOptions);
 
 		GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
 		GDREGISTER_CLASS(SentryUser);
@@ -59,7 +60,7 @@ void uninitialize_module(ModuleInitializationLevel p_level) {
 			memdelete(SentrySDK::get_singleton());
 		}
 		if (SentryOptions::get_singleton()) {
-			delete SentryOptions::get_singleton();
+			memdelete(SentryOptions::get_singleton());
 		}
 	}
 }

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -34,7 +34,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(SentryLoggerLimits);
 		GDREGISTER_CLASS(SentryOptions);
-		SentryOptions *options = memnew(SentryOptions);
+		SentryOptions::create_singleton();
 
 		GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
 		GDREGISTER_CLASS(SentryUser);
@@ -59,9 +59,7 @@ void uninitialize_module(ModuleInitializationLevel p_level) {
 		if (SentrySDK::get_singleton()) {
 			memdelete(SentrySDK::get_singleton());
 		}
-		if (SentryOptions::get_singleton()) {
-			memdelete(SentryOptions::get_singleton());
-		}
+		SentryOptions::destroy_singleton();
 	}
 }
 

--- a/src/sentry/godot_error_types.h
+++ b/src/sentry/godot_error_types.h
@@ -17,7 +17,7 @@ enum class GodotErrorType {
 };
 
 // Enum used with bitwise operations to represent the set of Godot error types that the Sentry logger should capture.
-enum class GodotErrorMask {
+enum GodotErrorMask {
 	MASK_NONE = 0,
 	MASK_ERROR = (1 << int(GodotErrorType::ERROR_TYPE_ERROR)),
 	MASK_WARNING = (1 << int(GodotErrorType::ERROR_TYPE_WARNING)),
@@ -31,7 +31,7 @@ enum class GodotErrorMask {
 _FORCE_INLINE_ godot::String GODOT_ERROR_MASK_EXPORT_STRING() { return "Error,Warning,Script,Shader"; }
 
 _FORCE_INLINE_ Level get_sentry_level_for_godot_error_type(GodotErrorType p_error_type) { return p_error_type == GodotErrorType::ERROR_TYPE_WARNING ? LEVEL_WARNING : LEVEL_ERROR; }
-_FORCE_INLINE_ int godot_error_type_as_mask(GodotErrorType p_error_type) { return 1 << int(p_error_type); }
+_FORCE_INLINE_ GodotErrorMask godot_error_type_as_mask(GodotErrorType p_error_type) { return (GodotErrorMask)(1 << int(p_error_type)); }
 
 } //namespace sentry
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -193,7 +193,7 @@ void NativeSDK::initialize() {
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
 	sentry_options_t *options = sentry_options_new();
-	sentry_options_set_dsn(options, SentryOptions::get_singleton()->get_dsn());
+	sentry_options_set_dsn(options, SentryOptions::get_singleton()->get_dsn().utf8());
 
 	// Establish handler path.
 	String handler_fn;
@@ -223,7 +223,7 @@ void NativeSDK::initialize() {
 
 	sentry_options_set_database_path(options, (OS::get_singleton()->get_user_data_dir() + "/sentry").utf8());
 	sentry_options_set_sample_rate(options, SentryOptions::get_singleton()->get_sample_rate());
-	sentry_options_set_release(options, SentryOptions::get_singleton()->get_release());
+	sentry_options_set_release(options, SentryOptions::get_singleton()->get_release().utf8());
 	sentry_options_set_debug(options, SentryOptions::get_singleton()->is_debug_enabled());
 	sentry_options_set_environment(options, sentry::environment::get_environment());
 	sentry_options_set_sdk_name(options, "sentry.native.godot");

--- a/src/sentry/simple_bind.h
+++ b/src/sentry/simple_bind.h
@@ -13,10 +13,17 @@ namespace sentry::bind {
 // Registers the specified property and its accessors in the ClassDB.
 // Note: This function is used in the macros defined below.
 template <auto Setter, auto Getter>
-_FORCE_INLINE_ void bind_property(const godot::StringName &p_class, godot::PropertyInfo p_info, const godot::StringName &p_setter_name, const godot::StringName &p_getter_name) {
+_FORCE_INLINE_ void bind_property(const godot::StringName &p_class, const godot::PropertyInfo &p_info, const godot::StringName &p_setter_name, const godot::StringName &p_getter_name) {
 	godot::ClassDB::bind_method(D_METHOD(p_setter_name, p_info.name), Setter);
 	godot::ClassDB::bind_method(D_METHOD(p_getter_name), Getter);
 	godot::ClassDB::add_property(p_class, p_info, p_setter_name, p_getter_name);
+}
+
+// Registers read-only property and its getter in the ClassDB.
+template <auto Getter>
+_FORCE_INLINE_ void bind_property_readonly(const godot::StringName &p_class, const godot::PropertyInfo &p_info, const godot::StringName &p_getter_name) {
+	godot::ClassDB::bind_method(D_METHOD(p_getter_name), Getter);
+	godot::ClassDB::add_property(p_class, p_info, "", p_getter_name);
 }
 
 } //namespace sentry::bind
@@ -28,5 +35,16 @@ _FORCE_INLINE_ void bind_property(const godot::StringName &p_class, godot::Prope
 // A simplified version of the previous macro, for basic cases.
 #define BIND_PROPERTY_SIMPLE(m_class, m_type, m_property) \
 	sentry::bind::bind_property<&m_class::set_##m_property, &m_class::get_##m_property>(m_class::get_class_static(), PropertyInfo(m_type, #m_property), "set_" #m_property, "get_" #m_property)
+
+// Macro to bind a read-only property and its getter.
+#define BIND_PROPERTY_READONLY(m_class, m_prop_info, m_getter) \
+	sentry::bind::bind_property_readonly<&m_class::m_getter>(m_class::get_class_static(), m_prop_info, #m_getter)
+
+// Macro to define a simple property with accessors and a default value.
+// Note: The property will be compatible with BIND_PROPERTY_SIMPLE macro.
+#define SIMPLE_PROPERTY(m_type, m_property, m_default)              \
+	m_type m_property = m_default;                                  \
+	void set_##m_property(m_type p_value) { m_property = p_value; } \
+	m_type get_##m_property() { return m_property; }
 
 #endif // SIMPLE_BIND_H

--- a/src/sentry/simple_bind.h
+++ b/src/sentry/simple_bind.h
@@ -1,0 +1,32 @@
+#ifndef SIMPLE_BIND_H
+#define SIMPLE_BIND_H
+
+#include "godot_cpp/core/property_info.hpp"
+#include "godot_cpp/variant/string.hpp"
+#include <godot_cpp/core/class_db.hpp>
+
+// This file contains macros to simplify the binding of properties from a C++ class to the Godot ClassDB,
+// which makes them accessible from GDScript and the Godot editor.
+
+namespace sentry::bind {
+
+// Registers the specified property and its accessors in the ClassDB.
+// Note: This function is used in the macros defined below.
+template <auto Setter, auto Getter>
+_FORCE_INLINE_ void bind_property(const godot::StringName &p_class, godot::PropertyInfo p_info, const godot::StringName &p_setter_name, const godot::StringName &p_getter_name) {
+	godot::ClassDB::bind_method(D_METHOD(p_setter_name, p_info.name), Setter);
+	godot::ClassDB::bind_method(D_METHOD(p_getter_name), Getter);
+	godot::ClassDB::add_property(p_class, p_info, p_setter_name, p_getter_name);
+}
+
+} //namespace sentry::bind
+
+// Macro to bind a property and its getter and setter.
+#define BIND_PROPERTY(m_class, m_prop_info, m_setter, m_getter) \
+	sentry::bind::bind_property<&m_class::m_setter, &m_class::m_getter>(m_class::get_class_static(), m_prop_info, #m_setter, #m_getter)
+
+// A simplified version of the previous macro, for basic cases.
+#define BIND_PROPERTY_SIMPLE(m_class, m_type, m_property) \
+	sentry::bind::bind_property<&m_class::set_##m_property, &m_class::get_##m_property>(m_class::get_class_static(), PropertyInfo(m_type, #m_property), "set_" #m_property, "get_" #m_property)
+
+#endif // SIMPLE_BIND_H

--- a/src/sentry/simple_bind.h
+++ b/src/sentry/simple_bind.h
@@ -1,8 +1,6 @@
 #ifndef SIMPLE_BIND_H
 #define SIMPLE_BIND_H
 
-#include "godot_cpp/core/property_info.hpp"
-#include "godot_cpp/variant/string.hpp"
 #include <godot_cpp/core/class_db.hpp>
 
 // This file contains macros to simplify the binding of properties from a C++ class to the Godot ClassDB,

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -57,9 +57,9 @@ void SentryLogger::_process_log_file() {
 	frame_events = 0;
 
 	// Get limits.
-	SentryOptions::LoggerLimits limits = SentryOptions::get_singleton()->get_error_logger_limits();
-	auto repeated_error_window = std::chrono::milliseconds{ limits.repeated_error_window_ms };
-	auto throttle_window = std::chrono::milliseconds{ limits.throttle_window_ms };
+	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
+	auto repeated_error_window = std::chrono::milliseconds{ limits->repeated_error_window_ms };
+	auto throttle_window = std::chrono::milliseconds{ limits->throttle_window_ms };
 
 	{
 		// Throttling: Remove time points outside of the throttling window.
@@ -81,7 +81,7 @@ void SentryLogger::_process_log_file() {
 	//   while still registering them as breadcrumbs.
 	// - We also have a limit on events per frame, and on the number of lines that can be parsed
 	//   in each frame. These limits are mainly here to protect the frametime budget.
-	while (num_lines_read < limits.parse_lines && log_file.getline(first_line, MAX_LINE_LENGTH)) {
+	while (num_lines_read < limits->parse_lines && log_file.getline(first_line, MAX_LINE_LENGTH)) {
 		num_lines_read++;
 
 		for (int i = 0; i < num_error_types; i++) {
@@ -131,11 +131,11 @@ void SentryLogger::_process_log_file() {
 }
 
 void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType p_error_type) {
-	SentryOptions::LoggerLimits limits = SentryOptions::get_singleton()->get_error_logger_limits();
+	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
 	bool as_breadcrumb = SentryOptions::get_singleton()->is_error_logger_breadcrumb_enabled(p_error_type);
 	bool as_event = SentryOptions::get_singleton()->is_error_logger_event_enabled(p_error_type) &&
-			frame_events < limits.events_per_frame &&
-			event_times.size() < limits.throttle_events;
+			frame_events < limits->events_per_frame &&
+			event_times.size() < limits->throttle_events;
 
 	if (!as_breadcrumb && !as_event) {
 		// Bail out if capture is disabled for this error type.

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -1,4 +1,5 @@
 #include "sentry_options.h"
+#include "sentry/simple_bind.h"
 
 #include <godot_cpp/classes/project_settings.hpp>
 
@@ -84,6 +85,23 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_window_ms);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.throttle_events);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.throttle_window_ms);
+}
+
+void SentryOptions::_bind_methods() {
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enabled"), set_enabled, is_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "disabled_in_editor"), set_disabled_in_editor, is_disabled_in_editor);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "dsn"), set_dsn, get_dsn);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "release"), set_release, get_release);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "debug"), set_debug_enabled, is_debug_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_breadcrumbs"), set_max_breadcrumbs, get_max_breadcrumbs);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "send_default_pii"), set_send_default_pii, is_send_default_pii_enabled);
+
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_event_mask"), set_error_logger_event_mask, get_error_logger_event_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_breadcrumb_mask"), set_error_logger_breadcrumb_mask, get_error_logger_breadcrumb_mask);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -92,8 +92,8 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/enabled", p_options->error_logger_enabled);
 	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", p_options->error_logger_include_source);
-	p_options->error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", p_options->error_logger_event_mask);
-	p_options->error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
+	p_options->error_logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", p_options->error_logger_event_mask);
+	p_options->error_logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
 
 	p_options->error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
 	p_options->error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", p_options->error_logger_limits->events_per_frame);
@@ -143,6 +143,15 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_breadcrumb_mask"), set_error_logger_breadcrumb_mask, get_error_logger_breadcrumb_mask);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "error_logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_error_logger_limits, get_error_logger_limits);
+
+	{
+		using namespace sentry;
+		BIND_BITFIELD_FLAG(MASK_NONE);
+		BIND_BITFIELD_FLAG(MASK_ERROR);
+		BIND_BITFIELD_FLAG(MASK_WARNING);
+		BIND_BITFIELD_FLAG(MASK_SCRIPT);
+		BIND_BITFIELD_FLAG(MASK_SHADER);
+	}
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -45,6 +45,7 @@ Ref<SentryOptions> SentryOptions::singleton = nullptr;
 
 void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options) {
 	ERR_FAIL_COND(p_options.is_null());
+	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
 	_define_setting("sentry/config/enabled", p_options->enabled);
 	_define_setting("sentry/config/disabled_in_editor", p_options->disabled_in_editor);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -3,6 +3,17 @@
 
 #include <godot_cpp/classes/project_settings.hpp>
 
+// *** SentryLoggerLimits
+
+void SentryLoggerLimits::_bind_methods() {
+	BIND_PROPERTY_SIMPLE(SentryLoggerLimits, Variant::INT, events_per_frame);
+	BIND_PROPERTY_SIMPLE(SentryLoggerLimits, Variant::INT, repeated_error_window_ms);
+	BIND_PROPERTY_SIMPLE(SentryLoggerLimits, Variant::INT, throttle_events);
+	BIND_PROPERTY_SIMPLE(SentryLoggerLimits, Variant::INT, throttle_window_ms);
+}
+
+// *** SentryOptions
+
 SentryOptions *SentryOptions::singleton = nullptr;
 
 void SentryOptions::_load_project_settings() {
@@ -31,11 +42,11 @@ void SentryOptions::_load_project_settings() {
 	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
 	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
 
-	error_logger_limits.parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
-	error_logger_limits.events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits.events_per_frame);
-	error_logger_limits.repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", error_logger_limits.repeated_error_window_ms);
-	error_logger_limits.throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_events", error_logger_limits.throttle_events);
-	error_logger_limits.throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_window_ms", error_logger_limits.throttle_window_ms);
+	error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits->parse_lines);
+	error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits->events_per_frame);
+	error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", error_logger_limits->repeated_error_window_ms);
+	error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_events", error_logger_limits->throttle_events);
+	error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_window_ms", error_logger_limits->throttle_window_ms);
 }
 
 void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
@@ -80,11 +91,19 @@ void SentryOptions::_define_project_settings() {
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
 
-	_define_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits.parse_lines);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.events_per_frame);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.repeated_error_window_ms);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits.throttle_events);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits.throttle_window_ms);
+	_define_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits->parse_lines);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits->events_per_frame);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits->repeated_error_window_ms);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits->throttle_events);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits->throttle_window_ms);
+}
+
+void SentryOptions::set_error_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
+	error_logger_limits = p_limits;
+	// Ensure limits are initialized.
+	if (error_logger_limits.is_null()) {
+		error_logger_limits.instantiate();
+	}
 }
 
 void SentryOptions::_bind_methods() {
@@ -102,10 +121,13 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_event_mask"), set_error_logger_event_mask, get_error_logger_event_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_breadcrumb_mask"), set_error_logger_breadcrumb_mask, get_error_logger_breadcrumb_mask);
+
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "error_logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_error_logger_limits, get_error_logger_limits);
 }
 
 SentryOptions::SentryOptions() {
 	singleton = this;
+	error_logger_limits.instantiate(); // Ensure limits are initialized.
 
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -3,6 +3,33 @@
 
 #include <godot_cpp/classes/project_settings.hpp>
 
+namespace {
+
+void _define_setting(const String &p_setting, const Variant &p_default, bool p_basic = true) {
+	if (!ProjectSettings::get_singleton()->has_setting(p_setting)) {
+		ProjectSettings::get_singleton()->set(p_setting, p_default);
+	}
+	ProjectSettings::get_singleton()->set_initial_value(p_setting, p_default);
+	ProjectSettings::get_singleton()->set_as_basic(p_setting, p_basic);
+	ProjectSettings::get_singleton()->set_restart_if_changed(p_setting, false);
+
+	// Preserve order of the defined settings.
+	static int32_t config_value_order = 0;
+	if (config_value_order == 0) {
+		config_value_order = ProjectSettings::get_singleton()->get_order(p_setting);
+	}
+	ProjectSettings::get_singleton()->set_order(p_setting, config_value_order);
+	config_value_order++;
+}
+
+void _define_setting(const godot::PropertyInfo &p_info, const godot::Variant &p_default, bool p_basic = true) {
+	_define_setting(p_info.name, p_default, p_basic);
+	Dictionary info = (Dictionary)p_info;
+	ProjectSettings::get_singleton()->add_property_info(info);
+}
+
+} // unnamed namespace
+
 // *** SentryLoggerLimits
 
 void SentryLoggerLimits::_bind_methods() {
@@ -14,88 +41,80 @@ void SentryLoggerLimits::_bind_methods() {
 
 // *** SentryOptions
 
-SentryOptions *SentryOptions::singleton = nullptr;
+Ref<SentryOptions> SentryOptions::singleton = nullptr;
 
-void SentryOptions::_load_project_settings() {
+void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options) {
+	ERR_FAIL_COND(p_options.is_null());
+
+	_define_setting("sentry/config/enabled", p_options->enabled);
+	_define_setting("sentry/config/disabled_in_editor", p_options->disabled_in_editor);
+	_define_setting("sentry/config/dsn", String(p_options->dsn));
+	_define_setting("sentry/config/release", String(p_options->release));
+	_define_setting("sentry/config/debug", p_options->debug);
+	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/config/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate);
+	_define_setting("sentry/config/attach_log", p_options->attach_log);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs);
+	_define_setting("sentry/config/send_default_pii", p_options->send_default_pii);
+
+	_define_setting("sentry/config/error_logger/enabled", p_options->error_logger_enabled);
+	_define_setting("sentry/config/error_logger/include_source", p_options->error_logger_include_source);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask);
+
+	_define_setting("sentry/config/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms);
+}
+
+void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) {
+	ERR_FAIL_COND(p_options.is_null());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
-	// Prepare release name.
 	String app_name = ProjectSettings::get_singleton()->get_setting("application/config/name", "Unknown Godot project");
 	String app_version = ProjectSettings::get_singleton()->get_setting("application/config/version", "noversion");
-	String release_str = ProjectSettings::get_singleton()->get_setting("application/config/release", String(release));
+	String release_str = ProjectSettings::get_singleton()->get_setting("application/config/release", String(p_options->release));
 	Dictionary format_params;
 	format_params["app_name"] = app_name;
 	format_params["app_version"] = app_version;
-	release = release_str.format(format_params).utf8();
+	p_options->release = release_str.format(format_params).utf8();
 
-	enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/enabled", enabled);
-	disabled_in_editor = ProjectSettings::get_singleton()->get_setting("sentry/config/disabled_in_editor", disabled_in_editor);
-	dsn = String(ProjectSettings::get_singleton()->get_setting("sentry/config/dsn", String(dsn))).utf8();
-	debug = ProjectSettings::get_singleton()->get_setting("sentry/config/debug", debug);
-	sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/config/sample_rate", sample_rate);
-	attach_log = ProjectSettings::get_singleton()->get_setting("sentry/config/attach_log", attach_log);
-	max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/config/max_breadcrumbs", max_breadcrumbs);
-	send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/config/send_default_pii", send_default_pii);
+	p_options->enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/enabled", p_options->enabled);
+	p_options->disabled_in_editor = ProjectSettings::get_singleton()->get_setting("sentry/config/disabled_in_editor", p_options->disabled_in_editor);
+	p_options->dsn = String(ProjectSettings::get_singleton()->get_setting("sentry/config/dsn", String(p_options->dsn))).utf8();
+	p_options->debug = ProjectSettings::get_singleton()->get_setting("sentry/config/debug", p_options->debug);
+	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/config/sample_rate", p_options->sample_rate);
+	p_options->attach_log = ProjectSettings::get_singleton()->get_setting("sentry/config/attach_log", p_options->attach_log);
+	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/config/max_breadcrumbs", p_options->max_breadcrumbs);
+	p_options->send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/config/send_default_pii", p_options->send_default_pii);
 
-	error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/enabled", error_logger_enabled);
-	error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", error_logger_include_source);
-	error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", error_logger_event_mask);
-	error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", error_logger_breadcrumb_mask);
+	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/enabled", p_options->error_logger_enabled);
+	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/include_source", p_options->error_logger_include_source);
+	p_options->error_logger_event_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/events", p_options->error_logger_event_mask);
+	p_options->error_logger_breadcrumb_mask = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
 
-	error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits->parse_lines);
-	error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", error_logger_limits->events_per_frame);
-	error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", error_logger_limits->repeated_error_window_ms);
-	error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_events", error_logger_limits->throttle_events);
-	error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_window_ms", error_logger_limits->throttle_window_ms);
+	p_options->error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
+	p_options->error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/events_per_frame", p_options->error_logger_limits->events_per_frame);
+	p_options->error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/repeated_error_window_ms", p_options->error_logger_limits->repeated_error_window_ms);
+	p_options->error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_events", p_options->error_logger_limits->throttle_events);
+	p_options->error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/config/error_logger/limits/throttle_window_ms", p_options->error_logger_limits->throttle_window_ms);
 }
 
-void SentryOptions::_define_setting(const String &p_setting, const Variant &p_default, bool p_basic) {
-	ERR_FAIL_NULL(ProjectSettings::get_singleton());
+void SentryOptions::create_singleton() {
+	singleton = Ref(memnew(SentryOptions));
 
-	if (!ProjectSettings::get_singleton()->has_setting(p_setting)) {
-		ProjectSettings::get_singleton()->set(p_setting, p_default);
+	static bool are_settings_defined = false;
+	if (!are_settings_defined) {
+		_define_project_settings(singleton);
+		are_settings_defined = true;
 	}
-	ProjectSettings::get_singleton()->set_initial_value(p_setting, p_default);
-	ProjectSettings::get_singleton()->set_as_basic(p_setting, p_basic);
-	ProjectSettings::get_singleton()->set_restart_if_changed(p_setting, false);
 
-	// Preserve order of the defined settings.
-	if (config_value_order == 0) {
-		config_value_order = ProjectSettings::get_singleton()->get_order(p_setting);
-	}
-	ProjectSettings::get_singleton()->set_order(p_setting, config_value_order);
-	config_value_order++;
+	_load_project_settings(singleton);
 }
 
-void SentryOptions::_define_setting(const godot::PropertyInfo &p_info, const godot::Variant &p_default, bool p_basic) {
-	ERR_FAIL_NULL(ProjectSettings::get_singleton());
-
-	_define_setting(p_info.name, p_default, p_basic);
-	Dictionary info = (Dictionary)p_info;
-	ProjectSettings::get_singleton()->add_property_info(info);
-}
-
-void SentryOptions::_define_project_settings() {
-	_define_setting("sentry/config/enabled", enabled);
-	_define_setting("sentry/config/disabled_in_editor", disabled_in_editor);
-	_define_setting("sentry/config/dsn", String(dsn));
-	_define_setting("sentry/config/release", String(release));
-	_define_setting("sentry/config/debug", debug);
-	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/config/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), sample_rate);
-	_define_setting("sentry/config/attach_log", attach_log);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), max_breadcrumbs);
-	_define_setting("sentry/config/send_default_pii", send_default_pii);
-
-	_define_setting("sentry/config/error_logger/enabled", error_logger_enabled);
-	_define_setting("sentry/config/error_logger/include_source", error_logger_include_source);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_event_mask);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), error_logger_breadcrumb_mask);
-
-	_define_setting("sentry/config/error_logger/limits/parse_lines", error_logger_limits->parse_lines);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits->events_per_frame);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits->repeated_error_window_ms);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), error_logger_limits->throttle_events);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/config/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), error_logger_limits->throttle_window_ms);
+void SentryOptions::destroy_singleton() {
+	singleton = Ref<SentryOptions>();
 }
 
 void SentryOptions::set_error_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
@@ -126,15 +145,8 @@ void SentryOptions::_bind_methods() {
 }
 
 SentryOptions::SentryOptions() {
-	singleton = this;
 	error_logger_limits.instantiate(); // Ensure limits are initialized.
-
-	ERR_FAIL_NULL(ProjectSettings::get_singleton());
-
-	_define_project_settings();
-	_load_project_settings();
 }
 
 SentryOptions::~SentryOptions() {
-	singleton = nullptr;
 }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -37,9 +37,7 @@ class SentryOptions : public RefCounted {
 	using GodotErrorMask = sentry::GodotErrorMask;
 
 private:
-	static SentryOptions *singleton;
-
-	int32_t config_value_order = 0;
+	static Ref<SentryOptions> singleton;
 
 	bool enabled = true;
 	bool disabled_in_editor = true;
@@ -57,16 +55,16 @@ private:
 	int error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
 	Ref<SentryLoggerLimits> error_logger_limits;
 
-	void _define_setting(const String &p_setting, const Variant &p_default, bool p_basic = true);
-	void _define_setting(const PropertyInfo &p_info, const Variant &p_default, bool p_basic = true);
-	void _define_project_settings();
-	void _load_project_settings();
+	static void _define_project_settings(const Ref<SentryOptions> &p_options);
+	static void _load_project_settings(const Ref<SentryOptions> &p_options);
 
 protected:
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ static SentryOptions *get_singleton() { return singleton; }
+	static void create_singleton();
+	static void destroy_singleton();
+	_FORCE_INLINE_ static Ref<SentryOptions> get_singleton() { return singleton; }
 
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }
 	_FORCE_INLINE_ void set_enabled(bool p_enabled) { enabled = p_enabled; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -33,6 +33,7 @@ protected:
 class SentryOptions : public RefCounted {
 	GDCLASS(SentryOptions, RefCounted);
 
+public:
 	using GodotErrorType = sentry::GodotErrorType;
 	using GodotErrorMask = sentry::GodotErrorMask;
 
@@ -51,8 +52,8 @@ private:
 
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;
-	int error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
-	int error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
+	BitField<GodotErrorMask> error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
+	BitField<GodotErrorMask> error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
 	Ref<SentryLoggerLimits> error_logger_limits;
 
 	static void _define_project_settings(const Ref<SentryOptions> &p_options);
@@ -99,14 +100,14 @@ public:
 	_FORCE_INLINE_ bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
 	_FORCE_INLINE_ void set_error_logger_include_source(bool p_error_logger_include_source) { error_logger_include_source = p_error_logger_include_source; }
 
-	_FORCE_INLINE_ bool get_error_logger_event_mask() const { return error_logger_event_mask; }
-	_FORCE_INLINE_ void set_error_logger_event_mask(int p_error_logger_event_mask) { error_logger_event_mask = p_error_logger_event_mask; }
+	_FORCE_INLINE_ BitField<GodotErrorMask> get_error_logger_event_mask() const { return error_logger_event_mask; }
+	_FORCE_INLINE_ void set_error_logger_event_mask(BitField<GodotErrorMask> p_error_logger_event_mask) { error_logger_event_mask = p_error_logger_event_mask; }
 
-	_FORCE_INLINE_ int get_error_logger_breadcrumb_mask() const { return error_logger_breadcrumb_mask; }
-	_FORCE_INLINE_ void set_error_logger_breadcrumb_mask(int p_error_logger_breadcrumb_mask) { error_logger_breadcrumb_mask = p_error_logger_breadcrumb_mask; }
+	_FORCE_INLINE_ BitField<GodotErrorMask> get_error_logger_breadcrumb_mask() const { return error_logger_breadcrumb_mask; }
+	_FORCE_INLINE_ void set_error_logger_breadcrumb_mask(BitField<GodotErrorMask> p_error_logger_breadcrumb_mask) { error_logger_breadcrumb_mask = p_error_logger_breadcrumb_mask; }
 
-	_FORCE_INLINE_ bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask & sentry::godot_error_type_as_mask(p_error_type); }
-	_FORCE_INLINE_ bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask & sentry::godot_error_type_as_mask(p_error_type); }
+	_FORCE_INLINE_ bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
 
 	_FORCE_INLINE_ Ref<SentryLoggerLimits> get_error_logger_limits() const { return error_logger_limits; }
 	void set_error_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
@@ -114,5 +115,7 @@ public:
 	SentryOptions();
 	~SentryOptions();
 };
+
+VARIANT_BITFIELD_CAST(SentryOptions::GodotErrorMask);
 
 #endif // SENTRY_OPTIONS_H

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -3,21 +3,19 @@
 
 #include "sentry/godot_error_types.h"
 
-#include <godot_cpp/core/property_info.hpp>
-#include <godot_cpp/variant/char_string.hpp>
-#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/variant/variant.hpp>
 
 using namespace godot;
 
-class SentryOptions {
+class SentryOptions : public RefCounted {
+	GDCLASS(SentryOptions, RefCounted);
+
 	using GodotErrorType = sentry::GodotErrorType;
 	using GodotErrorMask = sentry::GodotErrorMask;
 
 public:
 	struct LoggerLimits {
-		// TODO: Establish proper default limits with the Sentry team.
-
 		// Limit the number of lines that can be parsed per frame.
 		int parse_lines = 100;
 
@@ -35,14 +33,15 @@ public:
 private:
 	static SentryOptions *singleton;
 
+	int32_t config_value_order = 0;
+
 	bool enabled = true;
 	bool disabled_in_editor = true;
-	CharString dsn = "";
-	CharString release = "{app_name}@{app_version}";
+	String dsn = "";
+	String release = "{app_name}@{app_version}";
 	bool debug = false;
 	double sample_rate = 1.0;
 	bool attach_log = true;
-	int32_t config_value_order = 0;
 	int max_breadcrumbs = 100;
 	bool send_default_pii = false;
 
@@ -57,23 +56,54 @@ private:
 	void _define_project_settings();
 	void _load_project_settings();
 
+protected:
+	static void _bind_methods();
+
 public:
 	_FORCE_INLINE_ static SentryOptions *get_singleton() { return singleton; }
 
 	_FORCE_INLINE_ bool is_enabled() const { return enabled; }
-	_FORCE_INLINE_ bool is_disabled_in_editor() const { return disabled_in_editor; }
-	CharString get_dsn() const { return dsn; }
-	CharString get_release() const { return release; }
-	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }
-	double get_sample_rate() const { return sample_rate; }
-	bool is_attach_log_enabled() const { return attach_log; }
-	int get_max_breadcrumbs() const { return max_breadcrumbs; }
-	bool is_send_default_pii_enabled() const { return send_default_pii; }
+	_FORCE_INLINE_ void set_enabled(bool p_enabled) { enabled = p_enabled; }
 
-	bool is_error_logger_enabled() const { return error_logger_enabled; }
-	bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
-	bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask & sentry::godot_error_type_as_mask(p_error_type); }
-	bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask & sentry::godot_error_type_as_mask(p_error_type); }
+	_FORCE_INLINE_ bool is_disabled_in_editor() const { return disabled_in_editor; }
+	_FORCE_INLINE_ void set_disabled_in_editor(bool p_disabled_in_editor) { disabled_in_editor = p_disabled_in_editor; }
+
+	_FORCE_INLINE_ String get_dsn() const { return dsn; }
+	_FORCE_INLINE_ void set_dsn(const String &p_dsn) { dsn = p_dsn; }
+
+	_FORCE_INLINE_ String get_release() const { return release; }
+	_FORCE_INLINE_ void set_release(const String &p_release) { release = p_release; }
+
+	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }
+	_FORCE_INLINE_ void set_debug_enabled(bool p_debug) { debug = p_debug; }
+
+	_FORCE_INLINE_ double get_sample_rate() const { return sample_rate; }
+	_FORCE_INLINE_ void set_sample_rate(double p_sample_rate) { sample_rate = p_sample_rate; }
+
+	_FORCE_INLINE_ bool is_attach_log_enabled() const { return attach_log; }
+	_FORCE_INLINE_ void set_attach_log(bool p_enabled) { attach_log = p_enabled; }
+
+	_FORCE_INLINE_ int get_max_breadcrumbs() const { return max_breadcrumbs; }
+	_FORCE_INLINE_ void set_max_breadcrumbs(int p_max_breadcrumbs) { max_breadcrumbs = p_max_breadcrumbs; }
+
+	_FORCE_INLINE_ bool is_send_default_pii_enabled() const { return send_default_pii; }
+	_FORCE_INLINE_ void set_send_default_pii(bool p_enabled) { send_default_pii = p_enabled; }
+
+	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
+	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }
+
+	_FORCE_INLINE_ bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
+	_FORCE_INLINE_ void set_error_logger_include_source(bool p_error_logger_include_source) { error_logger_include_source = p_error_logger_include_source; }
+
+	_FORCE_INLINE_ bool get_error_logger_event_mask() const { return error_logger_event_mask; }
+	_FORCE_INLINE_ void set_error_logger_event_mask(int p_error_logger_event_mask) { error_logger_event_mask = p_error_logger_event_mask; }
+
+	_FORCE_INLINE_ int get_error_logger_breadcrumb_mask() const { return error_logger_breadcrumb_mask; }
+	_FORCE_INLINE_ void set_error_logger_breadcrumb_mask(int p_error_logger_breadcrumb_mask) { error_logger_breadcrumb_mask = p_error_logger_breadcrumb_mask; }
+
+	_FORCE_INLINE_ bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask & sentry::godot_error_type_as_mask(p_error_type); }
+	_FORCE_INLINE_ bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask & sentry::godot_error_type_as_mask(p_error_type); }
+
 	LoggerLimits get_error_logger_limits() const { return error_logger_limits; }
 
 	SentryOptions();


### PR DESCRIPTION
This PR improves `SentryOptions` and exposes it in the public API. This is needed for event hooks, in-code configuration support, integration tests and probably more.

Includes:
- Expose `SentryOptions` in the public API
- Add setters & bind properties
- New macros to streamline property binding in `ClassDB` (reduce boilerplate)
- Extract limits into its own public API class -- `SentryLoggerLimits`
- Refactor `SentryOptions` loading from project settings

Reviewer tip: it might be easier to look at changes commit-by-commit.

Resolves #55

Dependency for:
- #47
- #48 
