### PR TITLE
ci: Add post-release script

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,6 @@
 changelogPolicy: auto
 preReleaseCommand: pwsh scripts/bump-version.ps1
+postReleaseCommand: pwsh scripts/post-release.ps1
 targets:
   - name: github
   - name: registry

--- a/scripts/post-release.ps1
+++ b/scripts/post-release.ps1
@@ -1,0 +1,41 @@
+Param(
+    [Parameter(Mandatory = $true)][String]$prevVersion,
+    [Parameter(Mandatory = $true)][String]$newVersion
+)
+Set-StrictMode -Version latest
+
+git checkout main
+
+if ($newVersion -match '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<status>.*)?$') {
+    $major = [int]$matches['major']
+    $minor = [int]$matches['minor']
+    $patch = [int]$matches['patch']
+    $status = $matches['status']
+
+    if ($status -match "^-(?<prereleaseName>[a-zA-Z]+)\.?(?<prereleaseVersion>\d+)?$") {
+        # Increment prerelease version
+        $prereleaseName = $matches['prereleaseName']
+        $prereleaseVersion = [int]$matches['prereleaseVersion']
+        $prereleaseVersion += 1
+        $status = "-$prereleaseName.$prereleaseVersion"
+    } else {
+        # Increment minor version, reset patch version, and add -dev prerelease status
+        $minor += 1
+        $patch = 0
+        $status = "-dev"
+    }
+
+    $nextVersion = "$major.$minor.$patch$status"
+
+    & ".\scripts\bump-version.ps1" -prevVersion $newVersion -newVersion $nextVersion
+
+    git diff --quiet
+    if ($LASTEXITCODE -ne 0) {
+        git commit -anm 'meta: Bump new development version'
+        git pull --rebase
+        git push
+    }
+
+} else {`
+    Throw "Failed to find version in $sconsFile"
+}

--- a/scripts/post-release.ps1
+++ b/scripts/post-release.ps1
@@ -12,7 +12,7 @@ if ($newVersion -match '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<status>.*
     $patch = [int]$matches['patch']
     $status = $matches['status']
 
-    if ($status -match "^-(?<prerelease>[a-zA-Z]+)\.?(?<prereleaseNum>\d+)?$") {
+    if ($status -match '^-(?<prerelease>[a-zA-Z]+)\.?(?<prereleaseNum>\d+)?$') {
         # Increment prerelease version
         $prerelease = $matches['prerelease']
         $prereleaseNum = [int]$matches['prereleaseNum']
@@ -22,12 +22,12 @@ if ($newVersion -match '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<status>.*
         # Increment minor version, reset patch version, and add -dev prerelease status
         $minor += 1
         $patch = 0
-        $status = "-dev"
+        $status = '-dev'
     }
 
     $nextVersion = "$major.$minor.$patch$status"
 
-    & ".\scripts\bump-version.ps1" -prevVersion $newVersion -newVersion $nextVersion
+    & 'pwsh.\scripts\bump-version.ps1' -prevVersion $newVersion -newVersion $nextVersion
 
     git diff --quiet
     if ($LASTEXITCODE -ne 0) {

--- a/scripts/post-release.ps1
+++ b/scripts/post-release.ps1
@@ -12,12 +12,12 @@ if ($newVersion -match '^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?<status>.*
     $patch = [int]$matches['patch']
     $status = $matches['status']
 
-    if ($status -match "^-(?<prereleaseName>[a-zA-Z]+)\.?(?<prereleaseVersion>\d+)?$") {
+    if ($status -match "^-(?<prerelease>[a-zA-Z]+)\.?(?<prereleaseNum>\d+)?$") {
         # Increment prerelease version
-        $prereleaseName = $matches['prereleaseName']
-        $prereleaseVersion = [int]$matches['prereleaseVersion']
-        $prereleaseVersion += 1
-        $status = "-$prereleaseName.$prereleaseVersion"
+        $prerelease = $matches['prerelease']
+        $prereleaseNum = [int]$matches['prereleaseNum']
+        $prereleaseNum += 1
+        $status = "-$prerelease.$prereleaseNum"
     } else {
         # Increment minor version, reset patch version, and add -dev prerelease status
         $minor += 1


### PR DESCRIPTION
Add a postRelease script to bump version for development right after release, and commit and push such changes to the repo. This script will be executed by `craft` right after release is made.

Expected results:
- `0.1.4` => `0.2.0-dev`
- `0.2.0-rc.0` => `0.2.0-rc.1`

WARNING: Running this script will push the respective changes to the tracked remote of the `main` branch!

#skip-changelog