### PR TITLE
feat: Add environment property to `SentryOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Improve & expose `SentryOptions` class ([#56](https://github.com/getsentry/sentry-godot/pull/56))
 - Create or modify events using `SentryEvent` objects and new SDK methods: `SentrySDK.create_event()`, `SentrySDK.capture_event(event)` ([#51](https://github.com/getsentry/sentry-godot/pull/51))
-- New `environment` property in `SentryOptions` ([#66](https://github.com/getsentry/sentry-godot/pull/66))
+- New `environment` property in `SentryOptions` and better auto-naming to prioritize development environments ([#66](https://github.com/getsentry/sentry-godot/pull/66))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve & expose `SentryOptions` class ([#56](https://github.com/getsentry/sentry-godot/pull/56))
 - Create or modify events using `SentryEvent` objects and new SDK methods: `SentrySDK.create_event()`, `SentrySDK.capture_event(event)` ([#51](https://github.com/getsentry/sentry-godot/pull/51))
+- New `environment` property in `SentryOptions` ([#66](https://github.com/getsentry/sentry-godot/pull/66))
 
 ### Dependencies
 

--- a/project/example_configuration.gd
+++ b/project/example_configuration.gd
@@ -10,6 +10,7 @@ func _configure(options: SentryOptions) -> void:
 
 	options.debug = true
 	options.release = "sentry-godot-demo@" + ProjectSettings.get_setting("application/config/version")
+	options.environment = "demo"
 
 	# Set up event callbacks
 	options.before_send = _before_send

--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -268,7 +268,7 @@ Dictionary make_godot_engine_context() {
 	godot_context["version_commit"] = version_info.get("hash", "");
 	godot_context["debug_build"] = OS::get_singleton()->is_debug_build();
 	godot_context["command_line_arguments"] = OS::get_singleton()->get_cmdline_args();
-	godot_context["mode"] = String(sentry::environment::get_environment());
+	godot_context["mode"] = sentry::environment::detect_godot_environment();
 	godot_context["editor_build"] = OS::get_singleton()->has_feature("editor");
 	godot_context["godot_sdk_version"] = String(SENTRY_GODOT_SDK_VERSION);
 

--- a/src/sentry/environment.cpp
+++ b/src/sentry/environment.cpp
@@ -5,7 +5,7 @@
 
 namespace sentry::environment {
 
-CharString get_environment() {
+String detect_godot_environment() {
 	ERR_FAIL_NULL_V(Engine::get_singleton(), "production");
 	ERR_FAIL_NULL_V(OS::get_singleton(), "production");
 
@@ -14,11 +14,11 @@ CharString get_environment() {
 	} else if (Engine::get_singleton()->is_editor_hint()) {
 		return "editor";
 	} else if (OS::get_singleton()->has_feature("editor")) {
-		return "editor-run";
+		return "editor_run";
 	} else if (OS::get_singleton()->is_debug_build()) {
-		return "export-debug";
+		return "export_debug";
 	} else {
-		return "export-release";
+		return "export_release";
 	}
 }
 

--- a/src/sentry/environment.cpp
+++ b/src/sentry/environment.cpp
@@ -9,12 +9,14 @@ String detect_godot_environment() {
 	ERR_FAIL_NULL_V(Engine::get_singleton(), "production");
 	ERR_FAIL_NULL_V(OS::get_singleton(), "production");
 
+	// We need to have either "dev" or "debug" in the name to prioritize dev environments:
+	// https://develop.sentry.dev/application-architecture/dynamic-sampling/fidelity-and-biases/#prioritize-dev-environments
 	if (OS::get_singleton()->has_feature("dedicated_server")) {
 		return "dedicated_server";
 	} else if (Engine::get_singleton()->is_editor_hint()) {
-		return "editor";
+		return "editor_dev";
 	} else if (OS::get_singleton()->has_feature("editor")) {
-		return "editor_run";
+		return "editor_dev_run";
 	} else if (OS::get_singleton()->is_debug_build()) {
 		return "export_debug";
 	} else {

--- a/src/sentry/environment.h
+++ b/src/sentry/environment.h
@@ -4,6 +4,6 @@ using namespace godot;
 
 namespace sentry::environment {
 
-CharString get_environment();
+String detect_godot_environment();
 
 }

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -218,7 +218,16 @@ void NativeSDK::initialize() {
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
 	sentry_options_t *options = sentry_options_new();
+
 	sentry_options_set_dsn(options, SentryOptions::get_singleton()->get_dsn().utf8());
+	sentry_options_set_database_path(options, (OS::get_singleton()->get_user_data_dir() + "/sentry").utf8());
+	sentry_options_set_debug(options, SentryOptions::get_singleton()->is_debug_enabled());
+	sentry_options_set_release(options, SentryOptions::get_singleton()->get_release().utf8());
+	sentry_options_set_environment(options, SentryOptions::get_singleton()->get_environment().utf8());
+	// TODO: add dist
+	sentry_options_set_sample_rate(options, SentryOptions::get_singleton()->get_sample_rate());
+	sentry_options_set_max_breadcrumbs(options, SentryOptions::get_singleton()->get_max_breadcrumbs());
+	sentry_options_set_sdk_name(options, "sentry.native.godot");
 
 	// Establish handler path.
 	String handler_fn;
@@ -245,14 +254,6 @@ void NativeSDK::initialize() {
 		ERR_PRINT(vformat("Sentry: Failed to locate crash handler (crashpad) - backend disabled (%s)", handler_path));
 		sentry_options_set_backend(options, NULL);
 	}
-
-	sentry_options_set_database_path(options, (OS::get_singleton()->get_user_data_dir() + "/sentry").utf8());
-	sentry_options_set_sample_rate(options, SentryOptions::get_singleton()->get_sample_rate());
-	sentry_options_set_release(options, SentryOptions::get_singleton()->get_release().utf8());
-	sentry_options_set_debug(options, SentryOptions::get_singleton()->is_debug_enabled());
-	sentry_options_set_environment(options, SentryOptions::get_singleton()->get_environment().utf8());
-	sentry_options_set_sdk_name(options, "sentry.native.godot");
-	sentry_options_set_max_breadcrumbs(options, SentryOptions::get_singleton()->get_max_breadcrumbs());
 
 	// Attach LOG file.
 	// TODO: Decide whether log-file must be trimmed before send.

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -2,7 +2,6 @@
 
 #include "sentry.h"
 #include "sentry/contexts.h"
-#include "sentry/environment.h"
 #include "sentry/level.h"
 #include "sentry/native/native_event.h"
 #include "sentry/native/native_util.h"
@@ -225,7 +224,7 @@ void NativeSDK::initialize() {
 	sentry_options_set_sample_rate(options, SentryOptions::get_singleton()->get_sample_rate());
 	sentry_options_set_release(options, SentryOptions::get_singleton()->get_release().utf8());
 	sentry_options_set_debug(options, SentryOptions::get_singleton()->is_debug_enabled());
-	sentry_options_set_environment(options, sentry::environment::get_environment());
+	sentry_options_set_environment(options, SentryOptions::get_singleton()->get_environment().utf8());
 	sentry_options_set_sdk_name(options, "sentry.native.godot");
 	sentry_options_set_max_breadcrumbs(options, SentryOptions::get_singleton()->get_max_breadcrumbs());
 

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -1,4 +1,6 @@
 #include "sentry_options.h"
+
+#include "sentry/environment.h"
 #include "sentry/simple_bind.h"
 
 #include <godot_cpp/classes/project_settings.hpp>
@@ -131,6 +133,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "disabled_in_editor"), set_disabled_in_editor, is_disabled_in_editor);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "dsn"), set_dsn, get_dsn);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "release"), set_release, get_release);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "environment"), set_environment, get_environment);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "debug"), set_debug_enabled, is_debug_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
@@ -156,6 +159,7 @@ void SentryOptions::_bind_methods() {
 
 SentryOptions::SentryOptions() {
 	error_logger_limits.instantiate(); // Ensure limits are initialized.
+	environment = sentry::environment::detect_godot_environment();
 }
 
 SentryOptions::~SentryOptions() {

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -44,6 +44,7 @@ private:
 	bool disabled_in_editor = true;
 	String dsn = "";
 	String release = "{app_name}@{app_version}";
+	String environment;
 	bool debug = false;
 	double sample_rate = 1.0;
 	bool attach_log = true;
@@ -78,6 +79,9 @@ public:
 
 	_FORCE_INLINE_ String get_release() const { return release; }
 	_FORCE_INLINE_ void set_release(const String &p_release) { release = p_release; }
+
+	_FORCE_INLINE_ String get_environment() const { return environment; }
+	_FORCE_INLINE_ void set_environment(const String &p_environment) { environment = p_environment; }
 
 	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }
 	_FORCE_INLINE_ void set_debug_enabled(bool p_debug) { debug = p_debug; }


### PR DESCRIPTION
This PR adds `SentryOptions.environment` property. Environment is auto-detected for user convenience, and it will be possible to assign it after #60 is merged.

Also, change auto-detected environment names to [prioritize development environments](https://develop.sentry.dev/application-architecture/dynamic-sampling/fidelity-and-biases/#prioritize-dev-environments).

Resolves #64