### PR TITLE
feat: Expose `SentrySDK.is_enabled()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
+### Features
+
 - Add auto debug mode ([#73](https://github.com/getsentry/sentry-godot/pull/73))
+- New method `SentrySDK.is_enabled()` ([#82](https://github.com/getsentry/sentry-godot/pull/82))
 
 ## 0.1.1
 
@@ -29,7 +32,6 @@
 - New `dist` property in `SentryOptions` ([#74](https://github.com/getsentry/sentry-godot/pull/74))
 - Click to copy UUIDs in the demo project ([#78](https://github.com/getsentry/sentry-godot/pull/78))
 - Customize `SentryEvent` tags ([#72](https://github.com/getsentry/sentry-godot/pull/72))
-- New method `SentrySDK.is_enabled()` ([#82](https://github.com/getsentry/sentry-godot/pull/82))
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - New `dist` property in `SentryOptions` ([#74](https://github.com/getsentry/sentry-godot/pull/74))
 - Click to copy UUIDs in the demo project ([#78](https://github.com/getsentry/sentry-godot/pull/78))
 - Customize `SentryEvent` tags ([#72](https://github.com/getsentry/sentry-godot/pull/72))
+- New method `SentrySDK.is_enabled()` ([#82](https://github.com/getsentry/sentry-godot/pull/82))
 
 ### Improvements
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -26,7 +26,7 @@ void _init_logger() {
 		sentry::util::print_debug("error logger is disabled in options");
 		return;
 	}
-	if (!SentrySDK::get_singleton()->is_initialized()) {
+	if (!SentrySDK::get_singleton()->is_enabled()) {
 		sentry::util::print_debug("error logger is not started because SDK is not initialized");
 		return;
 	}

--- a/src/sentry/disabled_sdk.h
+++ b/src/sentry/disabled_sdk.h
@@ -28,7 +28,6 @@ class DisabledSDK : public InternalSDK {
 	virtual String capture_event(const Ref<SentryEvent> &p_event) override { return ""; }
 
 	virtual void initialize() override {}
-	virtual bool is_initialized() override { return false; }
 };
 
 } // namespace sentry

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -47,7 +47,6 @@ public:
 	virtual Ref<SentryEvent> create_event() = 0;
 	virtual String capture_event(const Ref<SentryEvent> &p_event) = 0;
 
-	virtual bool is_initialized() = 0;
 	virtual void initialize() = 0;
 
 	virtual ~InternalSDK() = default;

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -34,7 +34,6 @@ public:
 	virtual String capture_event(const Ref<SentryEvent> &p_event) override;
 
 	virtual void initialize() override;
-	virtual bool is_initialized() override { return initialized; }
 
 	virtual ~NativeSDK() override;
 };

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -95,15 +95,14 @@ void SentrySDK::_init_contexts() {
 void SentrySDK::_initialize() {
 	sentry::util::print_debug("starting Sentry SDK version " + String(SENTRY_GODOT_SDK_VERSION));
 
-	if (enabled) {
 #ifdef NATIVE_SDK
-		internal_sdk = std::make_shared<NativeSDK>();
+	internal_sdk = std::make_shared<NativeSDK>();
+	enabled = true;
 #else
-		// Unsupported platform
-		sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
-		enabled = false;
+	// Unsupported platform
+	sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
+	enabled = false;
 #endif
-	}
 
 	if (!enabled) {
 		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
@@ -141,6 +140,7 @@ void SentrySDK::_bind_methods() {
 	BIND_ENUM_CONSTANT(LEVEL_ERROR);
 	BIND_ENUM_CONSTANT(LEVEL_FATAL);
 
+	ClassDB::bind_method(D_METHOD("is_enabled"), &SentrySDK::is_enabled);
 	ClassDB::bind_method(D_METHOD("capture_message", "message", "level", "logger"), &SentrySDK::capture_message, DEFVAL(LEVEL_INFO), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("add_breadcrumb", "message", "category", "level", "type", "data"), &SentrySDK::add_breadcrumb, DEFVAL(LEVEL_INFO), DEFVAL("default"), DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("get_last_event_id"), &SentrySDK::get_last_event_id);
@@ -170,18 +170,18 @@ SentrySDK::SentrySDK() {
 	runtime_config.instantiate();
 	runtime_config->load_file(OS::get_singleton()->get_user_data_dir() + "/sentry.dat");
 
-	enabled = SentryOptions::get_singleton()->is_enabled();
+	bool should_enable = SentryOptions::get_singleton()->is_enabled();
 
-	if (!enabled) {
+	if (!should_enable) {
 		sentry::util::print_debug("Sentry SDK is disabled in the project settings.");
 	}
 
-	if (enabled && Engine::get_singleton()->is_editor_hint() && SentryOptions::get_singleton()->is_disabled_in_editor()) {
+	if (should_enable && Engine::get_singleton()->is_editor_hint() && SentryOptions::get_singleton()->is_disabled_in_editor()) {
 		sentry::util::print_debug("Sentry SDK is disabled in the editor. Tip: This can be changed in the project settings.");
-		enabled = false;
+		should_enable = false;
 	}
 
-	if (enabled) {
+	if (should_enable) {
 		if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
 			_initialize();
 			// Delay contexts initialization until the engine singletons are ready.

--- a/src/sentry_sdk.h
+++ b/src/sentry_sdk.h
@@ -48,7 +48,6 @@ public:
 	// * Exported API
 
 	bool is_enabled() const { return enabled; }
-	bool is_initialized() const { return internal_sdk->is_initialized(); }
 
 	void add_breadcrumb(const String &p_message, const String &p_category, sentry::Level p_level,
 			const String &p_type = "default", const Dictionary &p_data = Dictionary());


### PR DESCRIPTION
Also, remove unnecessary `is_initialized()` method.

Resolves #81 
