### PR TITLE
fix: Crash on macOS with GodotSteam

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # Default SCons flags applied to each build.
-  SCONSFLAGS: verbose=yes debug_symbols=yes symbols_visibility=visible
+  SCONSFLAGS: verbose=yes debug_symbols=yes
   EM_VERSION: 3.1.45
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix crashes on macOS with GodotSteam in the same project ([#92](https://github.com/getsentry/sentry-godot/pull/92))
+
 ## 0.1.0
 
 ### Features


### PR DESCRIPTION
Fix #87
Looks like `symbols_visibility=visible` causes issues with other extensions.
