### PR TITLE
ci: Fix post-release script failure

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -1,5 +1,5 @@
 Param(
-    [Parameter(Mandatory = $true)][String]$prevVersion,
+    [Parameter(Mandatory = $false)][String]$oldVersion,
     [Parameter(Mandatory = $true)][String]$newVersion
 )
 Set-StrictMode -Version latest

--- a/scripts/post-release.ps1
+++ b/scripts/post-release.ps1
@@ -1,5 +1,5 @@
 Param(
-    [Parameter(Mandatory = $true)][String]$prevVersion,
+    [Parameter(Mandatory = $false)][String]$oldVersion,
     [Parameter(Mandatory = $true)][String]$newVersion
 )
 Set-StrictMode -Version latest


### PR DESCRIPTION
Should fix https://github.com/getsentry/publish/issues/4986
The problem is with `oldVersion` parameter being mandatory while [receiving an empty string](https://github.com/getsentry/craft/blob/8dd907ecc67d9b399e1cf340031e3809f7a0108c/src/commands/publish.ts#L410).

#skip-changelog