### PR TITLE
fix: Autofix crashpad handler executable bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Autofix crashpad handler executable bit permissions on macOS and Linux ([#96](https://github.com/getsentry/sentry-godot/pull/96))
+
 ## 0.1.0
 
 ### Features

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -201,8 +201,9 @@ SentrySDK::SentrySDK() {
 	runtime_config.instantiate();
 	runtime_config->load_file(OS::get_singleton()->get_user_data_dir() + "/sentry.dat");
 
-	// Fix crashpad handler permissions.
-	if (OS::get_singleton()->has_feature("editor")) {
+	// Fix crashpad handler executable bit permissions on Unix platforms if the
+	// user extracts the distribution archive without preserving such permissions.
+	if (OS::get_singleton()->is_debug_build()) {
 		_fix_unix_executable_permissions("res://addons/sentrysdk/bin/macos/crashpad_handler");
 		_fix_unix_executable_permissions("res://addons/sentrysdk/bin/linux/crashpad_handler");
 	}


### PR DESCRIPTION
Autofix crashpad handler executable bit permissions on Unix platforms if the user extracts the distribution archive without preserving such permissions. This fix is only applied in debug builds. I don't think we should be doing this in a release export.
