### PR TITLE
feat: Explicitly set `user.ip_address` to `{{auto}}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- The SDK no longer automatically persists user data on disk. If you want to persist user data, make sure to save it manually.
+
 ### Features
 
-- Explicitly set `user.ip_address` to "{{auto}}" if `options.send_default_pii` is enabled and the user data is not set in a configuration script.
+- Explicitly set `user.ip_address` to "{{auto}}" if `options.send_default_pii` is enabled and the user data is not set in a configuration script ([#101](https://github.com/getsentry/sentry-godot/pull/101))
 
 ## 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - The SDK no longer automatically persists user data on disk. If you want to persist user data, make sure to save it manually.
+- `SentryUser.is_user_valid()` was replaces in favor of `SentryUser.is_empty()`.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Explicitly set `user.ip_address` to "{{auto}}" if `options.send_default_pii` is enabled and the user data is not set in a configuration script.
+
 ## 0.1.0
 
 ### Features

--- a/project/test/test_sentry_user.gd
+++ b/project/test/test_sentry_user.gd
@@ -22,8 +22,8 @@ func _assert_users_are_equal(user1: SentryUser, user2: SentryUser) -> void:
 ## SentryUser data should be correctly saved.
 func test_sentry_user_assignment() -> void:
 	SentrySDK.set_user(_make_test_user())
+	assert_bool(SentrySDK.get_user().is_empty()).is_false()
 	_assert_users_are_equal(SentrySDK.get_user(), _make_test_user())
-	assert_bool(SentrySDK.get_user().is_user_valid()).is_true()
 
 
 ## SentryUser data should be properly removed.
@@ -36,7 +36,7 @@ func test_sentry_user_remove() -> void:
 	assert_str(user.username).is_empty()
 	assert_str(user.ip_address).is_empty()
 	assert_str(user.id).is_empty()
-	assert_bool(user.is_user_valid()).is_false()
+	assert_bool(user.is_empty()).is_true()
 
 
 ## Setting new user data should not contain leftovers from previous data.

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -1,5 +1,7 @@
 #include "runtime_config.h"
 
+#include "sentry_options.h"
+
 namespace {
 
 inline String _ensure_string(const Variant &p_value, const String &p_fallback) {
@@ -8,18 +10,9 @@ inline String _ensure_string(const Variant &p_value, const String &p_fallback) {
 
 } // unnamed namespace
 
-void RuntimeConfig::set_user(const Ref<SentryUser> &p_user) {
-	ERR_FAIL_COND(p_user.is_null());
-	user = p_user;
-
-	conf->set_value("user", "id", p_user->get_id());
-	conf->set_value("user", "email", p_user->get_email());
-	conf->set_value("user", "username", p_user->get_username());
-	conf->save(conf_path);
-}
-
 void RuntimeConfig::set_installation_id(const String &p_id) {
 	ERR_FAIL_COND(p_id.length() == 0);
+
 	installation_id = p_id;
 	conf->set_value("main", "installation_id", (String)installation_id);
 	conf->save(conf_path);
@@ -30,11 +23,6 @@ void RuntimeConfig::load_file(const String &p_conf_path) {
 
 	conf_path = p_conf_path;
 	conf->load(conf_path);
-
-	user = Ref(memnew(SentryUser));
-	user->set_id(_ensure_string(conf->get_value("user", "id", ""), ""));
-	user->set_email(_ensure_string(conf->get_value("user", "email", ""), ""));
-	user->set_username(_ensure_string(conf->get_value("user", "username", ""), ""));
 
 	installation_id = _ensure_string(conf->get_value("main", "installation_id", ""), "");
 }

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -1,7 +1,5 @@
 #include "runtime_config.h"
 
-#include "sentry_options.h"
-
 namespace {
 
 inline String _ensure_string(const Variant &p_value, const String &p_fallback) {

--- a/src/runtime_config.h
+++ b/src/runtime_config.h
@@ -16,16 +16,12 @@ private:
 	Ref<ConfigFile> conf;
 
 	// Cached values.
-	Ref<SentryUser> user;
 	String installation_id;
 
 protected:
 	static void _bind_methods() {}
 
 public:
-	Ref<SentryUser> get_user() const { return user; }
-	void set_user(const Ref<SentryUser> &p_user);
-
 	String get_installation_id() const { return installation_id; }
 	void set_installation_id(const String &p_id);
 

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -56,22 +56,12 @@ void SentrySDK::remove_tag(const String &p_key) {
 void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 	ERR_FAIL_NULL_MSG(p_user, "Sentry: Setting user failed - user object is null. Please, use Sentry.remove_user() to clear user info.");
 
-	// Initialize user ID if not supplied.
-	if (p_user->get_id().is_empty()) {
-		if (get_user()->get_id().is_empty() && SentryOptions::get_singleton()->is_send_default_pii_enabled()) {
-			p_user->generate_new_id();
-		}
-	}
-
-	// Save user in a runtime conf-file.
-	// TODO: Make saving optional?
-	runtime_config->set_user(p_user);
+	user = p_user;
 	internal_sdk->set_user(p_user);
 }
 
 void SentrySDK::remove_user() {
 	internal_sdk->remove_user();
-	runtime_config->set_user(memnew(SentryUser));
 }
 
 void SentrySDK::set_context(const godot::String &p_key, const godot::Dictionary &p_value) {
@@ -111,10 +101,15 @@ void SentrySDK::_initialize() {
 		return;
 	}
 
-	internal_sdk->initialize();
+	// Initialize user if it wasn't set explicitly in the configuration script.
+	if (user.is_null() && SentryOptions::get_singleton()->is_send_default_pii_enabled()) {
+		user.instantiate();
+		user->generate_new_id();
+		user->infer_ip_address();
+		set_user(user);
+	}
 
-	// Initialize user.
-	set_user(runtime_config->get_user());
+	internal_sdk->initialize();
 }
 
 void SentrySDK::_check_if_configuration_succeeded() {

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -61,6 +61,7 @@ void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 }
 
 void SentrySDK::remove_user() {
+	user.instantiate();
 	internal_sdk->remove_user();
 }
 

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -54,10 +54,17 @@ void SentrySDK::remove_tag(const String &p_key) {
 }
 
 void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
-	ERR_FAIL_NULL_MSG(p_user, "Sentry: Setting user failed - user object is null. Please, use Sentry.remove_user() to clear user info.");
-
 	user = p_user;
-	internal_sdk->set_user(p_user);
+
+	if (user.is_null()) {
+		user.instantiate();
+	}
+
+	if (user->is_empty()) {
+		internal_sdk->remove_user();
+	} else {
+		internal_sdk->set_user(p_user);
+	}
 }
 
 void SentrySDK::remove_user() {
@@ -107,8 +114,8 @@ void SentrySDK::_initialize() {
 		user.instantiate();
 		user->generate_new_id();
 		user->infer_ip_address();
-		set_user(user);
 	}
+	set_user(user);
 
 	internal_sdk->initialize();
 }

--- a/src/sentry_sdk.h
+++ b/src/sentry_sdk.h
@@ -28,6 +28,7 @@ private:
 
 	std::shared_ptr<sentry::InternalSDK> internal_sdk;
 	Ref<RuntimeConfig> runtime_config;
+	Ref<SentryUser> user;
 	bool enabled = false;
 	bool configuration_succeeded = false;
 
@@ -58,7 +59,7 @@ public:
 	void remove_tag(const String &p_key);
 
 	void set_user(const Ref<SentryUser> &p_user);
-	Ref<SentryUser> get_user() const { return runtime_config->get_user(); }
+	Ref<SentryUser> get_user() const { return user; }
 	void remove_user();
 
 	String capture_message(const String &p_message, sentry::Level p_level = sentry::LEVEL_INFO, const String &p_logger = "");

--- a/src/sentry_user.cpp
+++ b/src/sentry_user.cpp
@@ -4,8 +4,8 @@
 
 #include <godot_cpp/variant/packed_string_array.hpp>
 
-bool SentryUser::is_user_valid() const {
-	return !id.is_empty() || !username.is_empty() || !email.is_empty() || !ip_address.is_empty();
+bool SentryUser::is_empty() const {
+	return id.is_empty() && username.is_empty() && email.is_empty() && ip_address.is_empty();
 }
 
 String SentryUser::_to_string() const {
@@ -47,6 +47,6 @@ void SentryUser::_bind_methods() {
 
 	// Other methods
 	ClassDB::bind_method(D_METHOD("infer_ip_address"), &SentryUser::infer_ip_address);
-	ClassDB::bind_method(D_METHOD("is_user_valid"), &SentryUser::is_user_valid);
+	ClassDB::bind_method(D_METHOD("is_empty"), &SentryUser::is_empty);
 	ClassDB::bind_method(D_METHOD("generate_new_id"), &SentryUser::generate_new_id);
 }

--- a/src/sentry_user.h
+++ b/src/sentry_user.h
@@ -35,7 +35,7 @@ public:
 
 	void infer_ip_address() { ip_address = "{{auto}}"; }
 
-	bool is_user_valid() const;
+	bool is_empty() const;
 
 	void generate_new_id();
 };


### PR DESCRIPTION
Explicitly set `user.ip_address` to "{{auto}}" if `options.send_default_pii` is enabled and the dev didn't set user data explicitly (i.e. in a configuration script).

Additionally:
- Ensure the user is properly set even if `set_user()` is called before initialization.
- User data is no longer saved to disk. This is a **breaking change**.
- Another **breaking change** is `user.is_user_valid()` is replaced in favor of `user.is_empty()`.

Resolves #95
Related to https://github.com/getsentry/team-sdks/issues/118