### PR TITLE
ref: Push error if initialization fails

### DIFF
--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -273,6 +273,10 @@ void NativeSDK::initialize() {
 
 	int err = sentry_init(options);
 	initialized = (err == 0);
+
+	if (err != 0) {
+		ERR_PRINT("Sentry: Failed to initialize native SDK. Error code: " + itos(err));
+	}
 }
 
 NativeSDK::~NativeSDK() {


### PR DESCRIPTION
Add an error to the Errors pane in Godot if initialization fails for some reason.

Broader alternative to #97.

#skip-changelog