### PR TITLE
fix: Issues with exporting crashpad_handler dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 - New method `SentrySDK.is_enabled()` ([#82](https://github.com/getsentry/sentry-godot/pull/82))
 - Explicitly set `user.ip_address` to "{{auto}}" if `options.send_default_pii` is enabled and the user data is not set in a configuration script ([#101](https://github.com/getsentry/sentry-godot/pull/101))
 
+### Fixes
+
+- Fix issues with exporting crashpad_handler dependency and resolving path to crashpad_handler on macOS in exported projects ([#108](https://github.com/getsentry/sentry-godot/pull/108))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.19 to v0.7.20 ([#84](https://github.com/getsentry/sentry-godot/pull/84))

--- a/src/manifest.gdextension
+++ b/src/manifest.gdextension
@@ -31,9 +31,13 @@ linux.release.x86_64 = "res://addons/{name}/bin/linux/lib{name}.linux.release.x8
 [dependencies]
 
 linux.x86_64 = {
-	"res://addons/{name}/bin/crashpad_handler" : ""
+	"res://addons/{name}/bin/linux/crashpad_handler" : ""
 }
 
 windows.x86_64 = {
-	"res://addons/{name}/bin/crashpad_handler.exe" : ""
+	"res://addons/{name}/bin/windows/crashpad_handler.exe" : ""
+}
+
+macos = {
+	"res://addons/{name}/bin/macos/crashpad_handler" : ""
 }

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -239,7 +239,7 @@ void NativeSDK::initialize() {
 #elif MACOS_ENABLED
 	handler_fn = "crashpad_handler";
 	platform_dir = "macos";
-	export_subdir = "Contents/Frameworks";
+	export_subdir = "../Frameworks";
 #elif WINDOWS_ENABLED
 	handler_fn = "crashpad_handler.exe";
 	platform_dir = "windows";

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -232,21 +232,26 @@ void NativeSDK::initialize() {
 	// Establish handler path.
 	String handler_fn;
 	String platform_dir;
+	String export_subdir;
 #ifdef LINUX_ENABLED
 	handler_fn = "crashpad_handler";
 	platform_dir = "linux";
 #elif MACOS_ENABLED
 	handler_fn = "crashpad_handler";
 	platform_dir = "macos";
+	export_subdir = "Contents/Frameworks";
 #elif WINDOWS_ENABLED
 	handler_fn = "crashpad_handler.exe";
 	platform_dir = "windows";
 #else
 	ERR_PRINT("Sentry: Internal Error: NativeSDK should not be initialized on an unsupported platform (this should not happen).");
 #endif
-	String handler_path = OS::get_singleton()->get_executable_path().get_base_dir() + "/" + handler_fn;
+	String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+	String handler_path = exe_dir.path_join(export_subdir).path_join(handler_fn);
 	if (!FileAccess::file_exists(handler_path)) {
-		handler_path = ProjectSettings::get_singleton()->globalize_path("res://addons/sentrysdk/bin/" + platform_dir + "/" + handler_fn);
+		const String addon_bin_dir = "res://addons/sentrysdk/bin/";
+		handler_path = ProjectSettings::get_singleton()->globalize_path(
+				addon_bin_dir.path_join(platform_dir).path_join(handler_fn));
 	}
 	if (FileAccess::file_exists(handler_path)) {
 		sentry_options_set_handler_path(options, handler_path.utf8());


### PR DESCRIPTION
Fix issues with crashpad_handler not copied on export alongside the executable.
And fix expected handler path on macOS: it is located in Contents/Frameworks.

Addressing #107