### PR TITLE
fix: `user.id` not assigned to `installation_id` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix `user.id` not assigned to `installation_id` by default ([#118](https://github.com/getsentry/sentry-godot/pull/118))
+
 ## 0.1.2
 
 ### Breaking changes

--- a/project/test/suites/test_sentry_user.gd
+++ b/project/test/suites/test_sentry_user.gd
@@ -20,6 +20,13 @@ func _assert_users_are_equal(user1: SentryUser, user2: SentryUser) -> void:
 	assert_str(user1.ip_address).is_equal(user2.ip_address)
 
 
+## Default SentryUser should have non-empty ID initialized to installation_id.
+func test_default_user() -> void:
+	var user := SentrySDK.get_user()
+	assert_str(user.id).is_not_empty()
+	assert_bool(user.is_empty()).is_false()
+
+
 ## SentryUser data should be correctly saved.
 func test_sentry_user_assignment() -> void:
 	SentrySDK.set_user(_make_test_user())

--- a/src/runtime_config.cpp
+++ b/src/runtime_config.cpp
@@ -1,5 +1,7 @@
 #include "runtime_config.h"
 
+#include "sentry/uuid.h"
+
 namespace {
 
 inline String _ensure_string(const Variant &p_value, const String &p_fallback) {
@@ -23,6 +25,9 @@ void RuntimeConfig::load_file(const String &p_conf_path) {
 	conf->load(conf_path);
 
 	installation_id = _ensure_string(conf->get_value("main", "installation_id", ""), "");
+	if (installation_id.is_empty()) {
+		set_installation_id(sentry::uuid::make_uuid());
+	}
 }
 
 RuntimeConfig::RuntimeConfig() {

--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -101,10 +101,6 @@ Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config) {
 
 	// Read/initialize installation id.
 	String installation_id = p_runtime_config->get_installation_id();
-	if (installation_id.length() == 0) {
-		installation_id = sentry::uuid::make_uuid();
-		p_runtime_config->set_installation_id(installation_id);
-	}
 	device_context["device_unique_identifier"] = installation_id;
 
 	return device_context;

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -140,10 +140,12 @@ void SentrySDK::_initialize() {
 	}
 
 	// Initialize user if it wasn't set explicitly in the configuration script.
-	if (user.is_null() && SentryOptions::get_singleton()->is_send_default_pii_enabled()) {
+	if (user.is_null()) {
 		user.instantiate();
-		user->generate_new_id();
-		user->infer_ip_address();
+		user->set_id(runtime_config->get_installation_id());
+		if (SentryOptions::get_singleton()->is_send_default_pii_enabled()) {
+			user->infer_ip_address();
+		}
 	}
 	set_user(user);
 


### PR DESCRIPTION
This PR fixes regression: user ID is no longer assigned to installation ID by default.