### PR TITLE
ci: Run unit tests on macos-latest

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -48,7 +48,7 @@ jobs:
           url=https://github.com/godotengine/godot/releases/download/${version}/${archive_file}
           if [[ "${{matrix.runner}}" == "macos-latest" ]]; then
             bin=${GITHUB_WORKSPACE}/godot/Godot.app/Contents/MacOS/Godot
-          else:
+          else
             bin=${GITHUB_WORKSPACE}/godot/Godot_v${version}_${{matrix.godot-suffix}}
           fi
           mkdir godot/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,8 @@ jobs:
             godot-suffix: win64.exe
           - runner: ubuntu-latest
             godot-suffix: linux.x86_64
+          - runner: macos-latest
+            godot-suffix: macos.universal
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -42,8 +44,13 @@ jobs:
         shell: bash
         run: |
           version=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1-stable/p' project/addons/sentrysdk/bin/sentrysdk.gdextension)
-          bin=Godot_v${version}_${{matrix.godot-suffix}}
-          url=https://github.com/godotengine/godot/releases/download/${version}/${bin}.zip
+          archive_file=Godot_v${version}_${{matrix.godot-suffix}}.zip
+          url=https://github.com/godotengine/godot/releases/download/${version}/${archive_file}
+          if [[ "${{matrix.runner}}" == "macos-latest" ]]; then
+            bin=${GITHUB_WORKSPACE}/godot/Godot.app/Contents/MacOS/Godot
+          else:
+            bin=${GITHUB_WORKSPACE}/godot/Godot_v${version}_${{matrix.godot-suffix}}
+          fi
           mkdir godot/
           cd godot/
           curl -L -o godot.zip "${url}"
@@ -51,8 +58,8 @@ jobs:
           rm godot.zip
           chmod u+x ${bin}
           ls -l
-          ./${bin} --version
-          echo "GODOT=${GITHUB_WORKSPACE}/godot/${bin}" >> $GITHUB_ENV
+          ${bin} --version
+          echo "GODOT=${bin}" >> $GITHUB_ENV
 
       - name: Diagnostic info
         shell: bash

--- a/project/test/isolated/test_limit_repeating_error_window.gd
+++ b/project/test/isolated/test_limit_repeating_error_window.gd
@@ -33,8 +33,8 @@ func test_repeating_error_window_limit() -> void:
 	await assert_signal(monitor).is_emitted("callback_processed")
 	assert_int(_num_events).is_equal(1)
 
-	# Wait for 1 second window to expire.
-	await get_tree().create_timer(1.0).timeout
+	# Wait for window to expire.
+	await get_tree().create_timer(1.5).timeout
 
 	push_error("dummy-error")
 	push_error("dummy-error")


### PR DESCRIPTION
Run tests in CI using macos-latest runner to detect issues related to Mac builds. In addition, fix flaky logger test.