### PR TITLE
fix: Demo project fails to initialize in exported environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fixed error logger not working properly on macOS and not showing debug output in the Output panel ([#138](https://github.com/getsentry/sentry-godot/pull/138))
+- Fixed demo project failing to initialize in exported environment ([#141](https://github.com/getsentry/sentry-godot/pull/141))
 
 ## 0.2.0
 

--- a/project/example_configuration.gd
+++ b/project/example_configuration.gd
@@ -17,7 +17,7 @@ func _configure(options: SentryOptions) -> void:
 	options.on_crash = _on_crash
 
 	# Unit testing hooks (if you're exploring the demo project, pretend the following line doesn't exist).
-	TestingConfiguration.configure_options(options)
+	load("res://testing_configuration.gd").configure_options(options)
 
 
 ## before_send callback example

--- a/project/testing_configuration.gd
+++ b/project/testing_configuration.gd
@@ -1,4 +1,3 @@
-class_name TestingConfiguration
 extends RefCounted
 
 


### PR DESCRIPTION
This PR fixes an issue with the exported demo project failing to initialize.