### PR TITLE
fix: Demo output not updating in exported project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fixed error logger not working properly on macOS and not showing debug output in the Output panel ([#138](https://github.com/getsentry/sentry-godot/pull/138))
+- Fixed demo output not updating in exported project ([#142](https://github.com/getsentry/sentry-godot/pull/142))
 
 ## 0.2.0
 

--- a/project/project.godot
+++ b/project/project.godot
@@ -14,6 +14,7 @@ config/name="Sentry demo project"
 config/version="0.2.0"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.3")
+run/flush_stdout_on_print=true
 
 [debug]
 
@@ -33,6 +34,10 @@ enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg")
 [gdunit4]
 
 ui/toolbar/run_overall=true
+
+[rendering]
+
+textures/vram_compression/import_etc2_astc=true
 
 [sentry]
 


### PR DESCRIPTION
Also, enable texture compression for Mac exports.