### PR TITLE
feat: View Hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Features
 
 - Introduce `screenshot_level` option and `before_capture_screenshot` hook to provide fine-grained control over when screenshots are taken. ([#153](https://github.com/getsentry/sentry-godot/pull/153))
+- Capture scene tree hierarchy data by enabling `attach_scene_tree` option ([#143](https://github.com/getsentry/sentry-godot/pull/143))
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Capture scene tree hierarchy data by enabling `attach_scene_tree` option ([#143](https://github.com/getsentry/sentry-godot/pull/143))
+
 ## 0.4.0
 
 ### Breaking changes
@@ -10,7 +16,6 @@
 ### Features
 
 - Introduce `screenshot_level` option and `before_capture_screenshot` hook to provide fine-grained control over when screenshots are taken. ([#153](https://github.com/getsentry/sentry-godot/pull/153))
-- Capture scene tree hierarchy data by enabling `attach_scene_tree` option ([#143](https://github.com/getsentry/sentry-godot/pull/143))
 
 ## 0.3.1
 

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -17,7 +17,16 @@
 			If [code]true[/code], the SDK will attach scene tree information to the event. You can specify additional node properties to be included via [member scene_tree_extra_properties].
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
-			If [code]true[/code], the SDK will try to capture and attach a screenshot to the event. This may impact performance in the same frame the screenshot is taken.
+			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may impact performance in the frames the screenshots are taken.
+		</member>
+		<member name="before_capture_screenshot" type="Callable" setter="set_before_capture_screenshot" getter="get_before_capture_screenshot" default="Callable()">
+			If assigned, this callback runs before a screenshot is captured. It takes [SentryEvent] as a parameter and returns [code]false[/code] to skip capturing the screenshot, or [code]true[/code] to capture the screenshot.
+			[codeblock]
+			func _before_capture_screenshot(event: SentryEvent) -&gt; bool:
+			    if is_showing_sensitive_info():
+			        return false
+			    return true
+			[/codeblock]
 		</member>
 		<member name="before_send" type="Callable" setter="set_before_send" getter="get_before_send" default="Callable()">
 			If assigned, this callback runs before a message or error event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.
@@ -35,8 +44,9 @@
 		</member>
 		<member name="debug" type="bool" setter="set_debug_enabled" getter="is_debug_enabled" default="true">
 			If [code]true[/code], the SDK will print useful debugging information to standard output. These messages do not appear in the Godot console but can be seen when launching Godot from a terminal.
+			You can control the verbosity using the [member diagnostic_level] option.
 		</member>
-		<member name="debug_verbosity" type="int" setter="set_debug_verbosity" getter="get_debug_verbosity" enum="SentrySDK.Level" default="0">
+		<member name="diagnostic_level" type="int" setter="set_diagnostic_level" getter="get_diagnostic_level" enum="SentrySDK.Level" default="0">
 			Specifies the minimum level of messages to be printed if [member debug] is enabled.
 		</member>
 		<member name="disabled_in_editor" type="bool" setter="set_disabled_in_editor" getter="is_disabled_in_editor" default="true">
@@ -96,6 +106,9 @@
 		</member>
 		<member name="scene_tree_extra_properties" type="PackedStringArray" setter="_set_scene_tree_extra_properties" getter="_get_scene_tree_extra_properties" default="PackedStringArray()">
 			Specifies additional node properties to be included in the scene tree data if [member attach_scene_tree_info] is enabled.
+		</member>
+		<member name="screenshot_level" type="int" setter="set_screenshot_level" getter="get_screenshot_level" enum="SentrySDK.Level" default="4">
+			Specifies the minimum level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.
 		</member>
 		<member name="send_default_pii" type="bool" setter="set_send_default_pii" getter="is_send_default_pii_enabled" default="false">
 			If [code]true[/code], the SDK will include PII (Personally Identifiable Information) with the events.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -13,6 +13,9 @@
 		<member name="attach_log" type="bool" setter="set_attach_log" getter="is_attach_log_enabled" default="true">
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
+		<member name="attach_scene_tree_info" type="bool" setter="set_attach_scene_tree_info" getter="is_attach_scene_tree_info_enabled" default="false">
+			If [code]true[/code], the SDK will attach scene tree information to the event. You can specify additional node properties to be included via [member scene_tree_extra_properties].
+		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
 			If [code]true[/code], the SDK will try to capture and attach a screenshot to the event.
 		</member>
@@ -87,6 +90,9 @@
 		</member>
 		<member name="sample_rate" type="float" setter="set_sample_rate" getter="get_sample_rate" default="1.0">
 			Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0, which means that 100% of error events will be sent. If set to 0.1, only 10% of error events will be sent. Events are picked randomly.
+		</member>
+		<member name="scene_tree_extra_properties" type="PackedStringArray" setter="_set_scene_tree_extra_properties" getter="_get_scene_tree_extra_properties" default="PackedStringArray()">
+			Specifies additional node properties to be included in the scene tree data if [member attach_scene_tree_info] is enabled.
 		</member>
 		<member name="send_default_pii" type="bool" setter="set_send_default_pii" getter="is_send_default_pii_enabled" default="false">
 			If [code]true[/code], the SDK will include PII (Personally Identifiable Information) with the events.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -13,7 +13,7 @@
 		<member name="attach_log" type="bool" setter="set_attach_log" getter="is_attach_log_enabled" default="true">
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
-		<member name="attach_scene_tree_info" type="bool" setter="set_attach_scene_tree_info" getter="is_attach_scene_tree_info_enabled" default="false">
+		<member name="attach_scene_tree" type="bool" setter="set_attach_scene_tree" getter="is_attach_scene_tree_enabled" default="false">
 			If [code]true[/code], the SDK will attach scene tree information to the event. You can specify additional node properties to be included via [member scene_tree_extra_properties].
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
@@ -105,7 +105,7 @@
 			Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0, which means that 100% of error events will be sent. If set to 0.1, only 10% of error events will be sent. Events are picked randomly.
 		</member>
 		<member name="scene_tree_extra_properties" type="PackedStringArray" setter="_set_scene_tree_extra_properties" getter="_get_scene_tree_extra_properties" default="PackedStringArray()">
-			Specifies additional node properties to be included in the scene tree data if [member attach_scene_tree_info] is enabled.
+			Specifies additional node properties to be included in the scene tree data if [member attach_scene_tree] is enabled.
 		</member>
 		<member name="screenshot_level" type="int" setter="set_screenshot_level" getter="get_screenshot_level" enum="SentrySDK.Level" default="4">
 			Specifies the minimum level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -14,7 +14,7 @@
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
 		<member name="attach_scene_tree" type="bool" setter="set_attach_scene_tree" getter="is_attach_scene_tree_enabled" default="false">
-			If [code]true[/code], the SDK will attach scene tree information to the event. You can specify additional node properties to be included via [member scene_tree_extra_properties].
+			If [code]true[/code], enables automatic capture of scene tree hierarchy data with each event.
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
 			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may impact performance in the frames the screenshots are taken.
@@ -103,9 +103,6 @@
 		</member>
 		<member name="sample_rate" type="float" setter="set_sample_rate" getter="get_sample_rate" default="1.0">
 			Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0, which means that 100% of error events will be sent. If set to 0.1, only 10% of error events will be sent. Events are picked randomly.
-		</member>
-		<member name="scene_tree_extra_properties" type="PackedStringArray" setter="_set_scene_tree_extra_properties" getter="_get_scene_tree_extra_properties" default="PackedStringArray()">
-			Specifies additional node properties to be included in the scene tree data if [member attach_scene_tree] is enabled.
 		</member>
 		<member name="screenshot_level" type="int" setter="set_screenshot_level" getter="get_screenshot_level" enum="SentrySDK.Level" default="4">
 			Specifies the minimum level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.

--- a/project/main.gd
+++ b/project/main.gd
@@ -20,6 +20,20 @@ func _ready() -> void:
 	level_choice.get_popup().id_pressed.connect(_on_level_choice_id_pressed)
 	_init_level_choice_popup()
 	_update_user_info()
+	
+	var thread := Thread.new()
+	thread.start(thread_message)
+	thread.wait_to_finish()
+
+
+func thread_message() -> void:
+	print("Capturing message from thread")
+	SentrySDK.capture_message("message from thread", SentrySDK.LEVEL_FATAL)
+
+
+func thread_crash() -> void:
+	print("Crashing from thread!")
+	OS.crash("crashing from thread")
 
 
 func _init_level_choice_popup() -> void:

--- a/project/main.gd
+++ b/project/main.gd
@@ -20,20 +20,6 @@ func _ready() -> void:
 	level_choice.get_popup().id_pressed.connect(_on_level_choice_id_pressed)
 	_init_level_choice_popup()
 	_update_user_info()
-	
-	var thread := Thread.new()
-	thread.start(thread_message)
-	thread.wait_to_finish()
-
-
-func thread_message() -> void:
-	print("Capturing message from thread")
-	SentrySDK.capture_message("message from thread", SentrySDK.LEVEL_FATAL)
-
-
-func thread_crash() -> void:
-	print("Crashing from thread!")
-	OS.crash("crashing from thread")
 
 
 func _init_level_choice_popup() -> void:

--- a/project/project.godot
+++ b/project/project.godot
@@ -43,5 +43,5 @@ textures/vram_compression/import_etc2_astc=true
 
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 options/attach_screenshot=true
-options/attach_scene_tree_info=true
+options/attach_scene_tree=true
 options/configuration_script="res://example_configuration.gd"

--- a/project/project.godot
+++ b/project/project.godot
@@ -43,4 +43,5 @@ textures/vram_compression/import_etc2_astc=true
 
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 options/configuration_script="res://example_configuration.gd"
+options/attach_screenshot=true
 options/attach_scene_tree=true

--- a/project/project.godot
+++ b/project/project.godot
@@ -43,4 +43,5 @@ textures/vram_compression/import_etc2_astc=true
 
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 options/attach_screenshot=true
+options/attach_scene_tree_info=true
 options/configuration_script="res://example_configuration.gd"

--- a/project/project.godot
+++ b/project/project.godot
@@ -44,4 +44,3 @@ textures/vram_compression/import_etc2_astc=true
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 options/configuration_script="res://example_configuration.gd"
 options/attach_scene_tree=true
-options/attach_screenshot=true

--- a/project/project.godot
+++ b/project/project.godot
@@ -42,7 +42,6 @@ textures/vram_compression/import_etc2_astc=true
 [sentry]
 
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
-options/attach_screenshot=true
-options/attach_scene_tree=true
 options/configuration_script="res://example_configuration.gd"
+options/attach_scene_tree=true
 options/attach_screenshot=true

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -17,6 +17,7 @@ func test_bool_properties(property: String, test_parameters := [
 		["debug"],
 		["attach_log"],
 		["attach_screenshot"],
+		["attach_scene_tree"],
 		["send_default_pii"],
 		["error_logger_enabled"],
 		["error_logger_include_source"],

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -416,12 +416,14 @@ void NativeSDK::initialize() {
 	// Attach screenshot.
 	if (SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
 		String path = OS::get_singleton()->get_user_data_dir().path_join(_SCREENSHOT_FN);
+		DirAccess::remove_absolute(path);
 		sentry_options_add_attachment(options, path.utf8());
 	}
 
 	// Attach view hierarchy (aka scene tree info).
 	if (SentryOptions::get_singleton()->is_attach_scene_tree_enabled()) {
 		String path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
+		DirAccess::remove_absolute(path);
 		sentry_options_add_view_hierarchy(options, path.utf8());
 	}
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -384,14 +384,14 @@ void NativeSDK::initialize() {
 
 	// Attach screenshot.
 	if (SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
-		String screenshot_path = OS::get_singleton()->get_user_data_dir().path_join(_SCREENSHOT_FN);
-		sentry_options_add_attachment(options, screenshot_path.utf8());
+		String path = OS::get_singleton()->get_user_data_dir().path_join(_SCREENSHOT_FN);
+		sentry_options_add_attachment(options, path.utf8());
 	}
 
 	// Attach view hierarchy (aka scene tree info).
 	if (SentryOptions::get_singleton()->is_attach_scene_tree_info_enabled()) {
-		String scene_tree_json_path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
-		sentry_options_add_typed_attachment(options, scene_tree_json_path.utf8(), VIEW_HIERARCHY, "application/json");
+		String path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
+		sentry_options_add_typed_attachment(options, path.utf8(), VIEW_HIERARCHY, "application/json");
 	}
 
 	// Hooks.

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -130,7 +130,7 @@ inline void _save_view_hierarchy() {
 
 #ifdef DEBUG_ENABLED
 	uint64_t end = Time::get_singleton()->get_ticks_usec();
-	sentry::util::print_debug("gathering scene tree info took ", end - start, " usec");
+	sentry::util::print_debug("gathering scene tree hierarchy data took ", end - start, " usec");
 #endif
 }
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -378,7 +378,7 @@ void NativeSDK::initialize() {
 	// Attach view hierarchy (aka scene tree info).
 	if (SentryOptions::get_singleton()->is_attach_scene_tree_info_enabled()) {
 		String scene_tree_json_path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
-		sentry_options_add_attachment(options, scene_tree_json_path.utf8());
+		sentry_options_add_typed_attachment(options, scene_tree_json_path.utf8(), VIEW_HIERARCHY, "application/json");
 	}
 
 	// Hooks.

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -108,7 +108,7 @@ void _save_screenshot(const Ref<SentryEvent> &p_event) {
 }
 
 inline void _save_view_hierarchy() {
-	if (!SentryOptions::get_singleton()->is_attach_scene_tree_info_enabled()) {
+	if (!SentryOptions::get_singleton()->is_attach_scene_tree_enabled()) {
 		return;
 	}
 
@@ -415,7 +415,7 @@ void NativeSDK::initialize() {
 	}
 
 	// Attach view hierarchy (aka scene tree info).
-	if (SentryOptions::get_singleton()->is_attach_scene_tree_info_enabled()) {
+	if (SentryOptions::get_singleton()->is_attach_scene_tree_enabled()) {
 		String path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
 		sentry_options_add_view_hierarchy(options, path.utf8());
 	}

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -118,6 +118,12 @@ inline void _save_view_hierarchy() {
 
 	String path = "user://" _VIEW_HIERARCHY_FN;
 	DirAccess::remove_absolute(path);
+
+	if (OS::get_singleton()->get_thread_caller_id() != OS::get_singleton()->get_main_thread_id()) {
+		sentry::util::print_debug("skipping scene tree capture - can only be performed on the main thread");
+		return;
+	}
+
 	String json_content = sentry::build_view_hierarchy_json();
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
 	if (f.is_valid()) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -136,7 +136,7 @@ inline void _save_view_hierarchy() {
 
 #ifdef DEBUG_ENABLED
 	uint64_t end = Time::get_singleton()->get_ticks_usec();
-	sentry::util::print_debug("gathering scene tree hierarchy data took ", end - start, " usec");
+	sentry::util::print_debug("capturing scene tree data took ", end - start, " usec");
 #endif
 }
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -118,8 +118,7 @@ inline void _save_view_hierarchy() {
 
 	String path = "user://" _VIEW_HIERARCHY_FN;
 	DirAccess::remove_absolute(path);
-	String json_content = sentry::build_view_hierarchy_json(
-			SentryOptions::get_singleton()->get_scene_tree_extra_properties());
+	String json_content = sentry::build_view_hierarchy_json();
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE);
 	if (f.is_valid()) {
 		f->store_string(json_content);

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -391,7 +391,7 @@ void NativeSDK::initialize() {
 	// Attach view hierarchy (aka scene tree info).
 	if (SentryOptions::get_singleton()->is_attach_scene_tree_info_enabled()) {
 		String path = OS::get_singleton()->get_user_data_dir().path_join(_VIEW_HIERARCHY_FN);
-		sentry_options_add_typed_attachment(options, path.utf8(), VIEW_HIERARCHY, "application/json");
+		sentry_options_add_view_hierarchy(options, path.utf8());
 	}
 
 	// Hooks.

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -83,7 +83,7 @@ void _save_screenshot() {
 		f->flush();
 		f->close();
 	} else {
-		sentry::util::print_error("Failed to save screenshot to file");
+		sentry::util::print_error("failed to save ", screenshot_path);
 	}
 }
 
@@ -106,12 +106,12 @@ inline void _save_view_hierarchy() {
 		f->flush();
 		f->close();
 	} else {
-		sentry::util::print_error("Failed to save view hierarchy to file");
+		sentry::util::print_error("failed to save ", path);
 	}
 
 #ifdef DEBUG_ENABLED
 	uint64_t end = Time::get_singleton()->get_ticks_usec();
-	sentry::util::print_debug("Gathering scene tree data took ", end - start, " usec");
+	sentry::util::print_debug("gathering scene tree info took ", end - start, " usec");
 #endif
 }
 

--- a/src/sentry/view_hierarchy.cpp
+++ b/src/sentry/view_hierarchy.cpp
@@ -1,0 +1,61 @@
+#include "view_hierarchy.h"
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+
+using namespace godot;
+
+namespace {
+
+Dictionary _build_view_hierarchy_recursive(Node *p_node) {
+	if (p_node == nullptr) {
+		return Dictionary();
+	}
+
+	Dictionary dict;
+	dict["identifier"] = p_node->get_name();
+	dict["type"] = p_node->get_class();
+
+	String scene_path = p_node->get_scene_file_path();
+	if (!scene_path.is_empty()) {
+		dict["scene"] = scene_path;
+	}
+
+	Ref<Script> scr = p_node->get_script();
+	dict["script"] = scr.is_valid() ? scr->get_path() : String();
+
+	Array children;
+	children.resize(p_node->get_child_count());
+	dict["children"] = children;
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		Dictionary child_dict = _build_view_hierarchy_recursive(p_node->get_child(i));
+		children[i] = child_dict;
+	}
+	return dict;
+}
+
+} // unnamed namespace
+namespace sentry {
+
+String build_view_hierarchy_json() {
+	SceneTree *sml = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+	ERR_FAIL_NULL_V(sml, String());
+	Dictionary root_window = _build_view_hierarchy_recursive(sml->get_root());
+
+	Array windows = Array();
+	windows.append(root_window);
+
+	Dictionary view_hierarchy;
+	view_hierarchy["rendering_system"] = "Godot";
+	view_hierarchy["windows"] = windows;
+
+	return JSON::stringify(view_hierarchy);
+}
+
+} //namespace sentry

--- a/src/sentry/view_hierarchy.cpp
+++ b/src/sentry/view_hierarchy.cpp
@@ -50,8 +50,8 @@ String build_view_hierarchy_json(const Vector<StringName> &p_extra_properties) {
 		Node *node = stack.back()->get();
 		stack.pop_back();
 
-		_start_name_value_pair(json, "identifier", node->get_name());
-		_next_name_value_pair(json, "type", node->get_class());
+		_start_name_value_pair(json, "name", node->get_name());
+		_next_name_value_pair(json, "class", node->get_class());
 
 		String scene_path = node->get_scene_file_path();
 		if (!scene_path.is_empty()) {

--- a/src/sentry/view_hierarchy.cpp
+++ b/src/sentry/view_hierarchy.cpp
@@ -74,7 +74,7 @@ String build_view_hierarchy_json(const Vector<StringName> &p_extra_properties) {
 		}
 
 		if (node->get_child_count()) {
-			json += R"(,"children":[)";
+			json += ",\"children\":[";
 			for (int i = node->get_child_count() - 1; i >= 0; i--) {
 				stack.push_back(node->get_child(i));
 			}

--- a/src/sentry/view_hierarchy.cpp
+++ b/src/sentry/view_hierarchy.cpp
@@ -28,7 +28,7 @@ inline void _next_name_value_pair_raw(String &p_arr, const String &p_name, const
 
 namespace sentry {
 
-String build_view_hierarchy_json(const Vector<StringName> &p_extra_properties) {
+String build_view_hierarchy_json() {
 	SceneTree *sml = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
 	ERR_FAIL_NULL_V(sml, String());
 
@@ -61,16 +61,6 @@ String build_view_hierarchy_json(const Vector<StringName> &p_extra_properties) {
 		const Ref<Script> &scr = node->get_script();
 		if (scr.is_valid()) {
 			_next_name_value_pair(json, "script", scr.is_valid() ? scr->get_path() : String());
-		}
-
-		for (const StringName &prop_name : p_extra_properties) {
-			Variant value = node->get(prop_name);
-			Variant::Type value_type = value.get_type();
-			if (value_type != Variant::NIL && value_type < Variant::DICTIONARY) {
-				_next_name_value_pair_raw(json, prop_name, JSON::stringify(value));
-			} else if (value_type >= Variant::DICTIONARY) {
-				_next_name_value_pair(json, prop_name, value.operator String().json_escape());
-			}
 		}
 
 		if (node->get_child_count()) {

--- a/src/sentry/view_hierarchy.h
+++ b/src/sentry/view_hierarchy.h
@@ -1,0 +1,12 @@
+#ifndef SENTRY_VIEW_HIERARCHY_H
+#define SENTRY_VIEW_HIERARCHY_H
+
+#include <godot_cpp/variant/string.hpp>
+
+namespace sentry {
+
+godot::String build_view_hierarchy_json();
+
+}
+
+#endif // SENTRY_VIEW_HIERARCHY_H

--- a/src/sentry/view_hierarchy.h
+++ b/src/sentry/view_hierarchy.h
@@ -7,7 +7,7 @@
 
 namespace sentry {
 
-godot::String build_view_hierarchy_json(const godot::Vector<godot::StringName> &p_extra_properties);
+godot::String build_view_hierarchy_json();
 
 } //namespace sentry
 

--- a/src/sentry/view_hierarchy.h
+++ b/src/sentry/view_hierarchy.h
@@ -7,6 +7,6 @@ namespace sentry {
 
 godot::String build_view_hierarchy_json();
 
-}
+} //namespace sentry
 
 #endif // SENTRY_VIEW_HIERARCHY_H

--- a/src/sentry/view_hierarchy.h
+++ b/src/sentry/view_hierarchy.h
@@ -1,11 +1,13 @@
 #ifndef SENTRY_VIEW_HIERARCHY_H
 #define SENTRY_VIEW_HIERARCHY_H
 
+#include <godot_cpp/templates/vector.hpp>
 #include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/string_name.hpp>
 
 namespace sentry {
 
-godot::String build_view_hierarchy_json();
+godot::String build_view_hierarchy_json(const godot::Vector<godot::StringName> &p_extra_properties);
 
 } //namespace sentry
 

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -65,8 +65,8 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_log", p_options->attach_log);
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
-	_define_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
-	_define_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties());
+	_define_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info, false);
+	_define_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties(), false);
 
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -66,6 +66,8 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	_define_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
 
+	_define_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties());
+
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask);
@@ -111,6 +113,8 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->attach_scene_tree_info = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
 
+	p_options->_set_scene_tree_extra_properties(ProjectSettings::get_singleton()->get_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties()));
+
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
 	p_options->error_logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/events", p_options->error_logger_event_mask);
@@ -128,6 +132,21 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 void SentryOptions::_init_debug_option(DebugMode p_mode) {
 	ERR_FAIL_NULL(OS::get_singleton());
 	debug = (p_mode == DebugMode::DEBUG_ON) || (p_mode == DebugMode::DEBUG_AUTO && OS::get_singleton()->is_debug_build());
+}
+
+void SentryOptions::_set_scene_tree_extra_properties(const PackedStringArray &p_scene_tree_extra_properties) {
+	scene_tree_extra_properties.clear();
+	for (const String &prop : p_scene_tree_extra_properties) {
+		scene_tree_extra_properties.push_back(StringName(prop));
+	}
+}
+
+PackedStringArray SentryOptions::_get_scene_tree_extra_properties() const {
+	PackedStringArray properties;
+	for (const StringName &prop : scene_tree_extra_properties) {
+		properties.push_back(prop);
+	}
+	return properties;
 }
 
 void SentryOptions::create_singleton() {
@@ -170,6 +189,8 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree_info"), set_attach_scene_tree_info, is_attach_scene_tree_info_enabled);
+
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::PACKED_STRING_ARRAY, "scene_tree_extra_properties"), _set_scene_tree_extra_properties, _get_scene_tree_extra_properties);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -63,12 +63,9 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
 	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii);
 
-	_define_setting("sentry/options/attach_log", p_options->attach_log);
-	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
-	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
-	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree, false);
 	_define_setting("sentry/options/attach_log", p_options->attach_log, false);
-	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot, false);
+	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
+	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level, false);
 
 	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -66,7 +66,6 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
 	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree, false);
-	_define_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties(), false);
 
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -113,7 +112,6 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
 	p_options->attach_scene_tree = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
-	p_options->_set_scene_tree_extra_properties(ProjectSettings::get_singleton()->get_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties()));
 
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -132,21 +130,6 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 void SentryOptions::_init_debug_option(DebugMode p_mode) {
 	ERR_FAIL_NULL(OS::get_singleton());
 	debug = (p_mode == DebugMode::DEBUG_ON) || (p_mode == DebugMode::DEBUG_AUTO && OS::get_singleton()->is_debug_build());
-}
-
-void SentryOptions::_set_scene_tree_extra_properties(const PackedStringArray &p_scene_tree_extra_properties) {
-	scene_tree_extra_properties.clear();
-	for (const String &prop : p_scene_tree_extra_properties) {
-		scene_tree_extra_properties.push_back(StringName(prop));
-	}
-}
-
-PackedStringArray SentryOptions::_get_scene_tree_extra_properties() const {
-	PackedStringArray properties;
-	for (const StringName &prop : scene_tree_extra_properties) {
-		properties.push_back(prop);
-	}
-	return properties;
 }
 
 void SentryOptions::create_singleton() {
@@ -190,7 +173,6 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree"), set_attach_scene_tree, is_attach_scene_tree_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::PACKED_STRING_ARRAY, "scene_tree_extra_properties"), _set_scene_tree_extra_properties, _get_scene_tree_extra_properties);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -65,7 +65,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_log", p_options->attach_log);
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
-	_define_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info, false);
+	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree, false);
 	_define_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties(), false);
 
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
@@ -112,7 +112,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_log = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_log", p_options->attach_log);
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
-	p_options->attach_scene_tree_info = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
+	p_options->attach_scene_tree = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
 	p_options->_set_scene_tree_extra_properties(ProjectSettings::get_singleton()->get_setting("sentry/options/scene_tree_extra_properties", p_options->_get_scene_tree_extra_properties()));
 
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
@@ -189,7 +189,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree_info"), set_attach_scene_tree_info, is_attach_scene_tree_info_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree"), set_attach_scene_tree, is_attach_scene_tree_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::PACKED_STRING_ARRAY, "scene_tree_extra_properties"), _set_scene_tree_extra_properties, _get_scene_tree_extra_properties);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -64,6 +64,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 
 	_define_setting("sentry/options/attach_log", p_options->attach_log);
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
+	_define_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
 
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -108,6 +109,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->attach_log = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_log", p_options->attach_log);
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
+	p_options->attach_scene_tree_info = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree_info", p_options->attach_scene_tree_info);
 
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -167,6 +169,7 @@ void SentryOptions::_bind_methods() {
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree_info"), set_attach_scene_tree_info, is_attach_scene_tree_info_enabled);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -64,7 +64,6 @@ private:
 	bool attach_screenshot = false;
 	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
 	bool attach_scene_tree = false;
-	Vector<StringName> scene_tree_extra_properties;
 
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;
@@ -81,9 +80,6 @@ private:
 	static void _load_project_settings(const Ref<SentryOptions> &p_options);
 
 	void _init_debug_option(DebugMode p_debug_mode);
-
-	void _set_scene_tree_extra_properties(const PackedStringArray &p_scene_tree_extra_properties);
-	PackedStringArray _get_scene_tree_extra_properties() const;
 
 protected:
 	static void _bind_methods();
@@ -137,8 +133,6 @@ public:
 
 	_FORCE_INLINE_ void set_attach_scene_tree(bool p_enable) { attach_scene_tree = p_enable; }
 	_FORCE_INLINE_ bool is_attach_scene_tree_enabled() const { return attach_scene_tree; }
-
-	_FORCE_INLINE_ Vector<StringName> get_scene_tree_extra_properties() const { return scene_tree_extra_properties; }
 
 	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
 	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -63,7 +63,7 @@ private:
 	bool attach_log = true;
 	bool attach_screenshot = false;
 	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
-	bool attach_scene_tree_info = false;
+	bool attach_scene_tree = false;
 	Vector<StringName> scene_tree_extra_properties;
 
 	bool error_logger_enabled = true;
@@ -135,8 +135,8 @@ public:
 	_FORCE_INLINE_ sentry::Level get_screenshot_level() const { return screenshot_level; }
 	_FORCE_INLINE_ void set_screenshot_level(sentry::Level p_level) { screenshot_level = p_level; }
 
-	_FORCE_INLINE_ void set_attach_scene_tree_info(bool p_attach_scene_tree_info) { attach_scene_tree_info = p_attach_scene_tree_info; }
-	_FORCE_INLINE_ bool is_attach_scene_tree_info_enabled() const { return attach_scene_tree_info; }
+	_FORCE_INLINE_ void set_attach_scene_tree(bool p_enable) { attach_scene_tree = p_enable; }
+	_FORCE_INLINE_ bool is_attach_scene_tree_enabled() const { return attach_scene_tree; }
 
 	_FORCE_INLINE_ Vector<StringName> get_scene_tree_extra_properties() const { return scene_tree_extra_properties; }
 

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -64,6 +64,8 @@ private:
 	bool attach_screenshot = false;
 	bool attach_scene_tree_info = false;
 
+	Vector<StringName> scene_tree_extra_properties;
+
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;
 	BitField<GodotErrorMask> error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
@@ -78,6 +80,9 @@ private:
 	static void _load_project_settings(const Ref<SentryOptions> &p_options);
 
 	void _init_debug_option(DebugMode p_debug_mode);
+
+	void _set_scene_tree_extra_properties(const PackedStringArray &p_scene_tree_extra_properties);
+	PackedStringArray _get_scene_tree_extra_properties() const;
 
 protected:
 	static void _bind_methods();
@@ -128,6 +133,8 @@ public:
 
 	_FORCE_INLINE_ void set_attach_scene_tree_info(bool p_attach_scene_tree_info) { attach_scene_tree_info = p_attach_scene_tree_info; }
 	_FORCE_INLINE_ bool is_attach_scene_tree_info_enabled() const { return attach_scene_tree_info; }
+
+	_FORCE_INLINE_ Vector<StringName> get_scene_tree_extra_properties() const { return scene_tree_extra_properties; }
 
 	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
 	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -62,6 +62,7 @@ private:
 
 	bool attach_log = true;
 	bool attach_screenshot = false;
+	bool attach_scene_tree_info = false;
 
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;
@@ -124,6 +125,9 @@ public:
 
 	_FORCE_INLINE_ bool is_attach_screenshot_enabled() const { return attach_screenshot; }
 	_FORCE_INLINE_ void set_attach_screenshot(bool p_attach_screenshot) { attach_screenshot = p_attach_screenshot; }
+
+	_FORCE_INLINE_ void set_attach_scene_tree_info(bool p_attach_scene_tree_info) { attach_scene_tree_info = p_attach_scene_tree_info; }
+	_FORCE_INLINE_ bool is_attach_scene_tree_info_enabled() const { return attach_scene_tree_info; }
 
 	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
 	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }


### PR DESCRIPTION
This PR implements automatic capturing of scene tree hierarchy data. In Sentry, this feature is more commonly known as View Hierarchy. It's an opt-in feature that can be enabled by setting the `attach_scene_tree` option to `true`.

Implements #113
Resolves #166

Waiting for the product changes:
- https://github.com/getsentry/sentry/issues/88788

Depends on:
- https://github.com/getsentry/sentry-native/pull/1191

Documentation PR:
- https://github.com/getsentry/sentry-docs/pull/13531

Remaining tasks:
- [x] Add docs

<img width="915" alt="Screenshot 2025-04-28 at 09 36 55" src="https://github.com/user-attachments/assets/225fef73-7172-47e4-96cd-cf027a946a66" />

