### PR TITLE
fix: Don't process screenshot when `attach_screenshot` option is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Don't process screenshot when `attach_screenshot` option is disabled ([#145](https://github.com/getsentry/sentry-godot/pull/145))
+
 ### Dependencies
 
 - Bump Native SDK from v0.8.1 to v0.8.2 ([#144](https://github.com/getsentry/sentry-godot/pull/144))

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -50,6 +50,10 @@ void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name
 }
 
 inline void _save_screenshot() {
+	if (!SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
+		return;
+	}
+
 	String screenshot_path = "user://" _SCREENSHOT_FN;
 	DirAccess::remove_absolute(screenshot_path);
 


### PR DESCRIPTION
Previously, a screenshot was still taken and saved to a file if the option was disabled.

See also: 
- #148 