### PR TITLE
ref: Optimize screenshot feature to reduce stutters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Disable screenshot for non-crash events to address logger stutters ([#148](https://github.com/getsentry/sentry-godot/pull/148))
+- Optimize screenshot feature to reduce stutters ([#148](https://github.com/getsentry/sentry-godot/pull/148))
 - Don't process screenshot when `attach_screenshot` option is disabled ([#145](https://github.com/getsentry/sentry-godot/pull/145))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Disable screenshot for non-crash events to address logger stutters ([#148](https://github.com/getsentry/sentry-godot/pull/148))
+
 ### Dependencies
 
 - Bump Native SDK from v0.8.1 to v0.8.2 ([#144](https://github.com/getsentry/sentry-godot/pull/144))

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -14,7 +14,7 @@
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
-			If [code]true[/code], the SDK will try to capture and attach a screenshot to the event.
+			If [code]true[/code], the SDK will try to capture and attach a screenshot to the event. This may impact performance in the same frame the screenshot is taken.
 		</member>
 		<member name="before_send" type="Callable" setter="set_before_send" getter="get_before_send" default="Callable()">
 			If assigned, this callback runs before a message or error event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -16,10 +16,6 @@
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
-#ifdef DEBUG_ENABLED
-#include <godot_cpp/classes/time.hpp>
-#endif
-
 #define _SCREENSHOT_FN "screenshot.jpg"
 
 namespace {
@@ -58,10 +54,6 @@ inline void _save_screenshot() {
 		return;
 	}
 
-#ifdef DEBUG_ENABLED
-	auto start = Time::get_singleton()->get_ticks_usec();
-#endif
-
 	String screenshot_path = "user://" _SCREENSHOT_FN;
 	DirAccess::remove_absolute(screenshot_path);
 
@@ -74,11 +66,6 @@ inline void _save_screenshot() {
 	f->store_buffer(buffer);
 	f->flush();
 	f->close();
-
-#ifdef DEBUG_ENABLED
-	auto end = Time::get_singleton()->get_ticks_usec();
-	sentry::util::print_debug("Saving screenshot took ", end - start, " usec");
-#endif
 }
 
 inline void _inject_contexts(sentry_value_t p_event) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -17,7 +17,7 @@
 #include <godot_cpp/variant/utility_functions.hpp>
 
 #ifdef DEBUG_ENABLED
-#include <chrono>
+#include <godot_cpp/classes/time.hpp>
 #endif
 
 #define _SCREENSHOT_FN "screenshot.jpg"
@@ -59,7 +59,7 @@ inline void _save_screenshot() {
 	}
 
 #ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
+	auto start = Time::get_singleton()->get_ticks_usec();
 #endif
 
 	String screenshot_path = "user://" _SCREENSHOT_FN;
@@ -76,34 +76,21 @@ inline void _save_screenshot() {
 	f->close();
 
 #ifdef DEBUG_ENABLED
-	auto end = std::chrono::high_resolution_clock::now();
-	sentry::util::print_debug("Saving screenshot took ", std::chrono::duration_cast<std::chrono::microseconds>(end - start).count(), " usec");
+	auto end = Time::get_singleton()->get_ticks_usec();
+	sentry::util::print_debug("Saving screenshot took ", end - start, " usec");
 #endif
 }
 
 inline void _inject_contexts(sentry_value_t p_event) {
 	ERR_FAIL_COND(sentry_value_get_type(p_event) != SENTRY_VALUE_TYPE_OBJECT);
 
-#ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
-#endif
-
 	HashMap<String, Dictionary> contexts = sentry::contexts::make_event_contexts();
 	for (const auto &kv : contexts) {
 		sentry_event_set_context(p_event, kv.key.utf8(), kv.value);
 	}
-
-#ifdef DEBUG_ENABLED
-	auto end = std::chrono::high_resolution_clock::now();
-	sentry::util::print_debug("Injecting contexts took ", std::chrono::duration_cast<std::chrono::microseconds>(end - start).count(), " usec");
-#endif
 }
 
 sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closure) {
-#ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
-#endif
-
 	sentry::util::print_debug("handling before_send");
 
 	// Note: Saving image from the root viewport is too slow: ~20 ms for JPG, 40 ms for PNG.
@@ -112,9 +99,6 @@ sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closu
 
 	_inject_contexts(event);
 	if (const Callable &before_send = SentryOptions::get_singleton()->get_before_send(); before_send.is_valid()) {
-#ifdef DEBUG_ENABLED
-		auto cb_start = std::chrono::high_resolution_clock::now();
-#endif
 		Ref<NativeEvent> event_obj = memnew(NativeEvent(event));
 		Ref<NativeEvent> processed = before_send.call(event_obj);
 		ERR_FAIL_COND_V_MSG(processed.is_valid() && processed != event_obj, event, "Sentry: before_send callback must return the same event object or null.");
@@ -125,17 +109,7 @@ sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closu
 			return sentry_value_new_null();
 		}
 		sentry::util::print_debug("event processed by before_send callback: ", event_obj->get_id());
-#ifdef DEBUG_ENABLED
-		auto cb_end = std::chrono::high_resolution_clock::now();
-		sentry::util::print_debug("before_send callback took ", std::chrono::duration_cast<std::chrono::microseconds>(cb_end - cb_start).count(), " usec");
-#endif
 	}
-
-#ifdef DEBUG_ENABLED
-	auto end = std::chrono::high_resolution_clock::now();
-	sentry::util::print_debug("event processed by before_send handler in ", std::chrono::duration_cast<std::chrono::microseconds>(end - start).count(), " usec");
-#endif
-
 	return event;
 }
 
@@ -272,10 +246,6 @@ String NativeSDK::get_last_event_id() {
 }
 
 String NativeSDK::capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) {
-#ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
-#endif
-
 	sentry_value_t event = sentry_value_new_event();
 	sentry_value_set_by_key(event, "level",
 			sentry_value_new_string(sentry::level_as_cstring(p_level)));
@@ -300,23 +270,7 @@ String NativeSDK::capture_error(const String &p_type, const String &p_value, Lev
 	sentry_value_set_by_key(stack_trace, "frames", frames);
 	sentry_value_set_by_key(exception, "stacktrace", stack_trace);
 	sentry_event_add_exception(event, exception);
-
-#ifdef DEBUG_ENABLED
-	auto s2 = std::chrono::high_resolution_clock::now();
-#endif
 	last_uuid = sentry_capture_event(event);
-#ifdef DEBUG_ENABLED
-	auto e2 = std::chrono::high_resolution_clock::now();
-	auto d2 = std::chrono::duration_cast<std::chrono::microseconds>(e2 - s2).count();
-	sentry::util::print_debug("Sentry: sentry_capture_event() took ", d2, " usec");
-#endif
-
-#ifdef DEBUG_ENABLED
-	auto end = std::chrono::high_resolution_clock::now();
-	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-	sentry::util::print_debug("Sentry: NativeSDK::capture_error() took ", duration, " usec");
-#endif
-
 	return _uuid_as_string(last_uuid);
 }
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -84,11 +84,7 @@ inline void _inject_contexts(sentry_value_t p_event) {
 
 sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closure) {
 	sentry::util::print_debug("handling before_send");
-
-	// Note: Saving image from the root viewport is too slow: ~20 ms for JPG, 40 ms for PNG.
-	// Until we have a better solution, we can't use it for non-crash events.
-	// _save_screenshot();
-
+	_save_screenshot();
 	_inject_contexts(event);
 	if (const Callable &before_send = SentryOptions::get_singleton()->get_before_send(); before_send.is_valid()) {
 		Ref<NativeEvent> event_obj = memnew(NativeEvent(event));

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -11,6 +11,7 @@
 
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/display_server.hpp>
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
@@ -49,7 +50,15 @@ void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name
 	}
 }
 
-inline void _save_screenshot() {
+void _save_screenshot() {
+	static int32_t last_screenshot_frame = 0;
+	int32_t current_frame = Engine::get_singleton()->get_frames_drawn();
+	if (current_frame == last_screenshot_frame) {
+		// Screenshot already taken in this frame.
+		return;
+	}
+	last_screenshot_frame = current_frame;
+
 	String screenshot_path = "user://" _SCREENSHOT_FN;
 	DirAccess::remove_absolute(screenshot_path);
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -54,9 +54,14 @@ void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name
 }
 
 inline void _save_screenshot() {
+	if (!SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
+		return;
+	}
+
 #ifdef DEBUG_ENABLED
 	auto start = Time::get_singleton()->get_ticks_usec();
 #endif
+
 	String screenshot_path = "user://" _SCREENSHOT_FN;
 	DirAccess::remove_absolute(screenshot_path);
 
@@ -69,6 +74,7 @@ inline void _save_screenshot() {
 	f->store_buffer(buffer);
 	f->flush();
 	f->close();
+
 #ifdef DEBUG_ENABLED
 	auto end = Time::get_singleton()->get_ticks_usec();
 	sentry::util::print_debug("Saving screenshot took ", end - start, " usec");

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -58,7 +58,7 @@ void _save_screenshot() {
 	static int32_t last_screenshot_frame = 0;
 	int32_t current_frame = Engine::get_singleton()->get_frames_drawn();
 	if (current_frame == last_screenshot_frame) {
-		// Screenshot already taken in this frame.
+		// Screenshot already exists for this frame — nothing to do.
 		return;
 	}
 	last_screenshot_frame = current_frame;

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -50,10 +50,6 @@ void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name
 }
 
 inline void _save_screenshot() {
-	if (!SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
-		return;
-	}
-
 	String screenshot_path = "user://" _SCREENSHOT_FN;
 	DirAccess::remove_absolute(screenshot_path);
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -86,7 +86,11 @@ inline void _inject_contexts(sentry_value_t p_event) {
 
 sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closure) {
 	sentry::util::print_debug("handling before_send");
-	_save_screenshot();
+
+	// Note: Saving image from the root viewport is too slow: ~20 ms for JPG, 40 ms for PNG.
+	// Until we have a better solution, we can't use it for non-crash events.
+	// _save_screenshot();
+
 	_inject_contexts(event);
 	if (const Callable &before_send = SentryOptions::get_singleton()->get_before_send(); before_send.is_valid()) {
 		Ref<NativeEvent> event_obj = memnew(NativeEvent(event));

--- a/src/sentry/util/screenshot.cpp
+++ b/src/sentry/util/screenshot.cpp
@@ -18,9 +18,7 @@ PackedByteArray take_screenshot() {
 	ERR_FAIL_NULL_V_MSG(main_window, PackedByteArray(), "Sentry: Failed to capture screenshot - couldn't get main window.");
 
 	Ref<ViewportTexture> tex = main_window->get_texture();
-	Ref<Image> img = tex->get_image();
-	PackedByteArray bytes = img->save_png_to_buffer();
-	return bytes;
+	return tex->get_image()->save_jpg_to_buffer();
 }
 
 } //namespace sentry::util

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -53,11 +53,6 @@ void SentryLogger::_process_log_file() {
 		return;
 	}
 
-#ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
-	bool found_error = false;
-#endif
-
 	// Reset per-frame counter.
 	frame_events = 0;
 
@@ -110,9 +105,6 @@ void SentryLogger::_process_log_file() {
 					if (last_colon != NULL) {
 						*last_colon = '\0';
 						int line = atoi(last_colon + 1);
-#ifdef DEBUG_ENABLED
-						found_error = true;
-#endif
 
 						// Reject errors based on per-source-line throttling window to prevent
 						// repetitive logging caused by loops or recurring errors in each frame.
@@ -138,20 +130,9 @@ void SentryLogger::_process_log_file() {
 
 	// Seek to the end of file - don't process the rest of the lines.
 	log_file.seekg(0, std::ios::end);
-
-#ifdef DEBUG_ENABLED
-	if (found_error) {
-		auto end = std::chrono::high_resolution_clock::now();
-		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-		sentry::util::print_debug("!!!!!! Log processed in ", duration, " usec.");
-	}
-#endif
 }
 
 void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType p_error_type) {
-#ifdef DEBUG_ENABLED
-	auto start = std::chrono::high_resolution_clock::now();
-#endif
 	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
 	bool as_breadcrumb = SentryOptions::get_singleton()->is_error_logger_breadcrumb_enabled(p_error_type);
 	bool as_event = SentryOptions::get_singleton()->is_error_logger_event_enabled(p_error_type) &&
@@ -221,11 +202,6 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 				"error",
 				data);
 	}
-#ifdef DEBUG_ENABLED
-	auto end = std::chrono::high_resolution_clock::now();
-	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
-	sentry::util::print_debug("Error processed in ", duration, " usec");
-#endif
 }
 
 void SentryLogger::_trim_error_timepoints() {

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -53,6 +53,11 @@ void SentryLogger::_process_log_file() {
 		return;
 	}
 
+#ifdef DEBUG_ENABLED
+	auto start = std::chrono::high_resolution_clock::now();
+	bool found_error = false;
+#endif
+
 	// Reset per-frame counter.
 	frame_events = 0;
 
@@ -105,6 +110,9 @@ void SentryLogger::_process_log_file() {
 					if (last_colon != NULL) {
 						*last_colon = '\0';
 						int line = atoi(last_colon + 1);
+#ifdef DEBUG_ENABLED
+						found_error = true;
+#endif
 
 						// Reject errors based on per-source-line throttling window to prevent
 						// repetitive logging caused by loops or recurring errors in each frame.
@@ -130,9 +138,20 @@ void SentryLogger::_process_log_file() {
 
 	// Seek to the end of file - don't process the rest of the lines.
 	log_file.seekg(0, std::ios::end);
+
+#ifdef DEBUG_ENABLED
+	if (found_error) {
+		auto end = std::chrono::high_resolution_clock::now();
+		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+		sentry::util::print_debug("!!!!!! Log processed in ", duration, " usec.");
+	}
+#endif
 }
 
 void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType p_error_type) {
+#ifdef DEBUG_ENABLED
+	auto start = std::chrono::high_resolution_clock::now();
+#endif
 	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
 	bool as_breadcrumb = SentryOptions::get_singleton()->is_error_logger_breadcrumb_enabled(p_error_type);
 	bool as_event = SentryOptions::get_singleton()->is_error_logger_event_enabled(p_error_type) &&
@@ -202,6 +221,11 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 				"error",
 				data);
 	}
+#ifdef DEBUG_ENABLED
+	auto end = std::chrono::high_resolution_clock::now();
+	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+	sentry::util::print_debug("Error processed in ", duration, " usec");
+#endif
 }
 
 void SentryLogger::_trim_error_timepoints() {


### PR DESCRIPTION
Note: Saving image from the root viewport is a slow operation: ~20 ms for JPG, 40 ms for PNG.

* ~~Don't take screenshots on non-crash events as it's too expensive.~~
* Use JPG format to speed up compression.
* Ensure that a screenshot is taken no more than once per frame drawn.
* Mention performance impact in the built-in documentation.

Addressing https://github.com/getsentry/sentry-godot/issues/110#issuecomment-2743714520

CI fails because of #147.

### Tasks
- [ ] Mention in docs.