### PR TITLE
feat: Screenshot level option & `before_capture_screenshot` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Introduce `screenshot_level` option and `before_capture_screenshot` hook to provide fine-grained control over when screenshots are taken. ([#153](https://github.com/getsentry/sentry-godot/pull/153))
+
 ## 0.3.1
 
 ### Fixes

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -14,7 +14,7 @@
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
-			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may affect performance in the frames the screenshots are captured.
+			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may impact performance in the frames the screenshots are taken.
 		</member>
 		<member name="before_capture_screenshot" type="Callable" setter="set_before_capture_screenshot" getter="get_before_capture_screenshot" default="Callable()">
 			If assigned, this callback runs before a screenshot is captured. It takes [SentryEvent] as a parameter and returns [code]false[/code] to skip capturing the screenshot, or [code]true[/code] to capture the screenshot.
@@ -101,7 +101,7 @@
 			Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0, which means that 100% of error events will be sent. If set to 0.1, only 10% of error events will be sent. Events are picked randomly.
 		</member>
 		<member name="screenshot_level" type="int" setter="set_screenshot_level" getter="get_screenshot_level" enum="SentrySDK.Level" default="4">
-			Configures the level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.
+			Specifies the minimum level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.
 		</member>
 		<member name="send_default_pii" type="bool" setter="set_send_default_pii" getter="is_send_default_pii_enabled" default="false">
 			If [code]true[/code], the SDK will include PII (Personally Identifiable Information) with the events.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -16,6 +16,15 @@
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
 			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may affect performance in the frames the screenshots are captured.
 		</member>
+		<member name="before_capture_screenshot" type="Callable" setter="set_before_capture_screenshot" getter="get_before_capture_screenshot" default="Callable()">
+			If assigned, this callback runs before a screenshot is captured. It takes [SentryEvent] as a parameter and returns [code]false[/code] to skip capturing the screenshot, or [code]true[/code] to capture the screenshot.
+			[codeblock]
+			func _before_capture_screenshot(event: SentryEvent) -> bool:
+			    if is_showing_sensitive_info():
+			        return false
+			    return true
+			[/codeblock]
+		</member>
 		<member name="before_send" type="Callable" setter="set_before_send" getter="get_before_send" default="Callable()">
 			If assigned, this callback runs before a message or error event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.
 			[codeblock]

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -14,7 +14,7 @@
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
 		</member>
 		<member name="attach_screenshot" type="bool" setter="set_attach_screenshot" getter="is_attach_screenshot_enabled" default="false">
-			If [code]true[/code], the SDK will try to capture and attach a screenshot to the event. This may impact performance in the same frame the screenshot is taken.
+			If [code]true[/code], enables automatic screenshot capture for events meeting or exceeding the [member screenshot_level] threshold. By default, only fatal events trigger screenshots. Setting a lower [member screenshot_level] threshold may affect performance in the frames the screenshots are captured.
 		</member>
 		<member name="before_send" type="Callable" setter="set_before_send" getter="get_before_send" default="Callable()">
 			If assigned, this callback runs before a message or error event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.
@@ -90,6 +90,9 @@
 		</member>
 		<member name="sample_rate" type="float" setter="set_sample_rate" getter="get_sample_rate" default="1.0">
 			Configures the sample rate for error events, in the range of 0.0 to 1.0. The default is 1.0, which means that 100% of error events will be sent. If set to 0.1, only 10% of error events will be sent. Events are picked randomly.
+		</member>
+		<member name="screenshot_level" type="int" setter="set_screenshot_level" getter="get_screenshot_level" enum="SentrySDK.Level" default="4">
+			Configures the level of events for which screenshots will be captured. By default, screenshots are captured for fatal events. Changing this option may impact performance in the frames the screenshots are taken.
 		</member>
 		<member name="send_default_pii" type="bool" setter="set_send_default_pii" getter="is_send_default_pii_enabled" default="false">
 			If [code]true[/code], the SDK will include PII (Personally Identifiable Information) with the events.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -19,7 +19,7 @@
 		<member name="before_capture_screenshot" type="Callable" setter="set_before_capture_screenshot" getter="get_before_capture_screenshot" default="Callable()">
 			If assigned, this callback runs before a screenshot is captured. It takes [SentryEvent] as a parameter and returns [code]false[/code] to skip capturing the screenshot, or [code]true[/code] to capture the screenshot.
 			[codeblock]
-			func _before_capture_screenshot(event: SentryEvent) -> bool:
+			func _before_capture_screenshot(event: SentryEvent) -&gt; bool:
 			    if is_showing_sensitive_info():
 			        return false
 			    return true

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -77,7 +77,7 @@ func test_error_logger_limit_properties(property: String, test_parameters := [
 	assert_int(options.error_logger_limits.get(property)).is_equal(42)
 
 
-## Test various callback properties.
+## Test assigning various callback properties.
 @warning_ignore("unused_parameter")
 func test_callback_properties(property: String, test_parameters := [
 	["before_send"],

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -16,6 +16,7 @@ func test_bool_properties(property: String, test_parameters := [
 		["disabled_in_editor"],
 		["debug"],
 		["attach_log"],
+		["attach_screenshot"],
 		["send_default_pii"],
 		["error_logger_enabled"],
 		["error_logger_include_source"],
@@ -74,3 +75,26 @@ func test_error_logger_limit_properties(property: String, test_parameters := [
 ]) -> void:
 	options.error_logger_limits.set(property, 42)
 	assert_int(options.error_logger_limits.get(property)).is_equal(42)
+
+
+## Test various callback properties.
+@warning_ignore("unused_parameter")
+func test_callback_properties(property: String, test_parameters := [
+	["before_send"],
+	["on_crash"],
+	["before_capture_screenshot"]
+]) -> void:
+	var callback := func(a1): pass
+	var prev: Callable = options.get(property)
+	options.set(property, callback)
+	assert_that(options.get(property)).is_equal(callback)
+	options.set(property, prev)
+
+
+## Screenshot level should be set to specified level.
+func test_screenshot_level() -> void:
+	var prev := options.screenshot_level
+	options.screenshot_level = SentrySDK.LEVEL_DEBUG
+	assert_int(options.screenshot_level).is_equal(SentrySDK.LEVEL_DEBUG)
+	options.screenshot_level = prev
+	assert_int(options.screenshot_level).is_equal(prev)

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -50,7 +50,7 @@ void sentry_event_set_context(sentry_value_t p_event, const char *p_context_name
 	}
 }
 
-void _save_screenshot() {
+void _save_screenshot(const Ref<SentryEvent> &p_event) {
 	if (!SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
 		return;
 	}
@@ -67,6 +67,11 @@ void _save_screenshot() {
 	DirAccess::remove_absolute(screenshot_path);
 
 	if (!DisplayServer::get_singleton() || DisplayServer::get_singleton()->get_name() == "headless") {
+		return;
+	}
+
+	if (p_event->get_level() < SentryOptions::get_singleton()->get_screenshot_level()) {
+		// This check needs to happen after we remove the outdated screenshot file from the drive.
 		return;
 	}
 
@@ -88,10 +93,10 @@ inline void _inject_contexts(sentry_value_t p_event) {
 
 sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closure) {
 	sentry::util::print_debug("handling before_send");
-	_save_screenshot();
+	Ref<NativeEvent> event_obj = memnew(NativeEvent(event));
+	_save_screenshot(event_obj);
 	_inject_contexts(event);
 	if (const Callable &before_send = SentryOptions::get_singleton()->get_before_send(); before_send.is_valid()) {
-		Ref<NativeEvent> event_obj = memnew(NativeEvent(event));
 		Ref<NativeEvent> processed = before_send.call(event_obj);
 		ERR_FAIL_COND_V_MSG(processed.is_valid() && processed != event_obj, event, "Sentry: before_send callback must return the same event object or null.");
 		if (processed.is_null()) {
@@ -107,10 +112,10 @@ sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closu
 
 sentry_value_t _handle_on_crash(const sentry_ucontext_t *uctx, sentry_value_t event, void *closure) {
 	sentry::util::print_debug("handling on_crash");
-	_save_screenshot();
+	Ref<NativeEvent> event_obj = memnew(NativeEvent(event));
+	_save_screenshot(event_obj);
 	_inject_contexts(event);
 	if (const Callable &on_crash = SentryOptions::get_singleton()->get_on_crash(); on_crash.is_valid()) {
-		Ref<NativeEvent> event_obj = memnew(NativeEvent(event));
 		Ref<NativeEvent> processed = on_crash.call(event_obj);
 		ERR_FAIL_COND_V_MSG(processed.is_valid() && processed != event_obj, event, "Sentry: on_crash callback must return the same event object or null.");
 		if (processed.is_null()) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -78,7 +78,8 @@ void _save_screenshot(const Ref<SentryEvent> &p_event) {
 	if (SentryOptions::get_singleton()->get_before_capture_screenshot().is_valid()) {
 		Variant result = SentryOptions::get_singleton()->get_before_capture_screenshot().call(p_event);
 		if (result.get_type() != Variant::BOOL) {
-			ERR_PRINT_ONCE("before_capture_screenshot callback failed: expected a boolean return value");
+			// Note: Using PRINT_ONCE to avoid feedback loop in case of error event.
+			ERR_PRINT_ONCE("Sentry: before_capture_screenshot callback failed: expected a boolean return value");
 			return;
 		}
 		if (result.operator bool() == false) {
@@ -97,8 +98,6 @@ void _save_screenshot(const Ref<SentryEvent> &p_event) {
 }
 
 inline void _inject_contexts(sentry_value_t p_event) {
-	ERR_FAIL_COND(sentry_value_get_type(p_event) != SENTRY_VALUE_TYPE_OBJECT);
-
 	HashMap<String, Dictionary> contexts = sentry::contexts::make_event_contexts();
 	for (const auto &kv : contexts) {
 		sentry_event_set_context(p_event, kv.key.utf8(), kv.value);
@@ -112,7 +111,11 @@ sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closu
 	_inject_contexts(event);
 	if (const Callable &before_send = SentryOptions::get_singleton()->get_before_send(); before_send.is_valid()) {
 		Ref<NativeEvent> processed = before_send.call(event_obj);
-		ERR_FAIL_COND_V_MSG(processed.is_valid() && processed != event_obj, event, "Sentry: before_send callback must return the same event object or null.");
+		if (processed.is_valid() && processed != event_obj) {
+			// Note: Using PRINT_ONCE to avoid feedback loop in case of error event.
+			ERR_PRINT_ONCE("Sentry: before_send callback must return the same event object or null.");
+			return event;
+		}
 		if (processed.is_null()) {
 			// Discard event.
 			sentry::util::print_debug("event discarded by before_send callback: ", event_obj->get_id());
@@ -131,7 +134,11 @@ sentry_value_t _handle_on_crash(const sentry_ucontext_t *uctx, sentry_value_t ev
 	_inject_contexts(event);
 	if (const Callable &on_crash = SentryOptions::get_singleton()->get_on_crash(); on_crash.is_valid()) {
 		Ref<NativeEvent> processed = on_crash.call(event_obj);
-		ERR_FAIL_COND_V_MSG(processed.is_valid() && processed != event_obj, event, "Sentry: on_crash callback must return the same event object or null.");
+		if (processed.is_valid() && processed != event_obj) {
+			// Note: Using PRINT_ONCE to avoid feedback loop in case of error event.
+			ERR_PRINT_ONCE("Sentry: on_crash callback must return the same event object or null.");
+			return event;
+		}
 		if (processed.is_null()) {
 			// Discard event.
 			sentry::util::print_debug("event discarded by on_crash callback: ", event_obj->get_id());

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -64,6 +64,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 
 	_define_setting("sentry/options/attach_log", p_options->attach_log);
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
+	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
 
 	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -108,6 +109,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->attach_log = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_log", p_options->attach_log);
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
+	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
 
 	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
 	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
@@ -167,6 +169,7 @@ void SentryOptions::_bind_methods() {
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_log"), set_attach_log, is_attach_log_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
+	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -178,8 +178,9 @@ void SentryOptions::_bind_methods() {
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "error_logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_error_logger_limits, get_error_logger_limits);
 
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "before_send"), set_before_send, get_before_send);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "on_crash"), set_on_crash, get_on_crash);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send"), set_before_send, get_before_send);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "on_crash"), set_on_crash, get_on_crash);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_capture_screenshot"), set_before_capture_screenshot, get_before_capture_screenshot);
 
 	{
 		using namespace sentry;

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -62,6 +62,7 @@ private:
 
 	bool attach_log = true;
 	bool attach_screenshot = false;
+	sentry::Level screenshot_level = sentry::Level::LEVEL_FATAL;
 
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;
@@ -124,6 +125,9 @@ public:
 
 	_FORCE_INLINE_ bool is_attach_screenshot_enabled() const { return attach_screenshot; }
 	_FORCE_INLINE_ void set_attach_screenshot(bool p_attach_screenshot) { attach_screenshot = p_attach_screenshot; }
+
+	_FORCE_INLINE_ sentry::Level get_screenshot_level() const { return screenshot_level; }
+	_FORCE_INLINE_ void set_screenshot_level(sentry::Level p_level) { screenshot_level = p_level; }
 
 	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
 	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -73,6 +73,7 @@ private:
 	String configuration_script;
 	Callable before_send;
 	Callable on_crash;
+	Callable before_capture_screenshot;
 
 	static void _define_project_settings(const Ref<SentryOptions> &p_options);
 	static void _load_project_settings(const Ref<SentryOptions> &p_options);
@@ -154,6 +155,9 @@ public:
 
 	_FORCE_INLINE_ Callable get_on_crash() const { return on_crash; }
 	_FORCE_INLINE_ void set_on_crash(const Callable &p_on_crash) { on_crash = p_on_crash; }
+
+	_FORCE_INLINE_ Callable get_before_capture_screenshot() const { return before_capture_screenshot; }
+	_FORCE_INLINE_ void set_before_capture_screenshot(const Callable &p_before_capture_screenshot) { before_capture_screenshot = p_before_capture_screenshot; }
 
 	SentryOptions();
 	~SentryOptions();

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -62,7 +62,7 @@ private:
 
 	bool attach_log = true;
 	bool attach_screenshot = false;
-	sentry::Level screenshot_level = sentry::Level::LEVEL_FATAL;
+	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
 
 	bool error_logger_enabled = true;
 	bool error_logger_include_source = true;


### PR DESCRIPTION
This PR introduces `screenshot_level` option and `before_capture_screenshot` hook to provide fine-grained control over when screenshots are taken. 

- Add `screenshot_level` option to specify minimum event level threshold for screenshot capturing, defaulting to `FATAL`
- Add `before_capture_screenshot` hook for fine-grained control
- Fix potential feedback looping in event processing

Supersedes:
- #151 