### PR TITLE
ref: Rename `debug_verbosity` => `diagnostic_level`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- Renamed `debug_verbosity` => `diagnostic_level` to better align with established Sentry features ([#154](https://github.com/getsentry/sentry-godot/pull/154))
+
 ## 0.3.1
 
 ### Fixes

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -32,6 +32,7 @@
 		</member>
 		<member name="debug" type="bool" setter="set_debug_enabled" getter="is_debug_enabled" default="true">
 			If [code]true[/code], the SDK will print useful debugging information to standard output. These messages do not appear in the Godot console but can be seen when launching Godot from a terminal.
+			You can control the verbosity using the [member diagnostic_level] option.
 		</member>
 		<member name="diagnostic_level" type="int" setter="set_diagnostic_level" getter="get_diagnostic_level" enum="SentrySDK.Level" default="0">
 			Specifies the minimum level of messages to be printed if [member debug] is enabled.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -33,7 +33,7 @@
 		<member name="debug" type="bool" setter="set_debug_enabled" getter="is_debug_enabled" default="true">
 			If [code]true[/code], the SDK will print useful debugging information to standard output. These messages do not appear in the Godot console but can be seen when launching Godot from a terminal.
 		</member>
-		<member name="debug_verbosity" type="int" setter="set_debug_verbosity" getter="get_debug_verbosity" enum="SentrySDK.Level" default="0">
+		<member name="diagnostic_level" type="int" setter="set_diagnostic_level" getter="get_diagnostic_level" enum="SentrySDK.Level" default="0">
 			Specifies the minimum level of messages to be printed if [member debug] is enabled.
 		</member>
 		<member name="disabled_in_editor" type="bool" setter="set_disabled_in_editor" getter="is_disabled_in_editor" default="true">

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -74,3 +74,12 @@ func test_error_logger_limit_properties(property: String, test_parameters := [
 ]) -> void:
 	options.error_logger_limits.set(property, 42)
 	assert_int(options.error_logger_limits.get(property)).is_equal(42)
+
+
+## SentryOptions.diagnostic_level should be set to the specified value.
+func test_diagnostic_level() -> void:
+	var prev := options.diagnostic_level
+	options.diagnostic_level = SentrySDK.LEVEL_ERROR
+	assert_int(options.diagnostic_level).is_equal(SentrySDK.LEVEL_ERROR)
+	options.diagnostic_level = prev
+	assert_int(options.diagnostic_level).is_equal(prev)

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -77,13 +77,17 @@ func test_error_logger_limit_properties(property: String, test_parameters := [
 	assert_int(options.error_logger_limits.get(property)).is_equal(42)
 
 
-## SentryOptions.diagnostic_level should be set to the specified value.
-func test_diagnostic_level() -> void:
-	var prev := options.diagnostic_level
-	options.diagnostic_level = SentrySDK.LEVEL_ERROR
-	assert_int(options.diagnostic_level).is_equal(SentrySDK.LEVEL_ERROR)
-	options.diagnostic_level = prev
-	assert_int(options.diagnostic_level).is_equal(prev)
+## Test properties with SentrySDK.Level type.
+@warning_ignore("unused_parameter")
+func test_level_properties(property: String, test_parameters := [
+	["diagnostic_level"],
+	["screenshot_level"]
+]) -> void:
+	var prev: SentrySDK.Level = options.get(property)
+	options.set(property, SentrySDK.LEVEL_WARNING)
+	assert_int(options.get(property)).is_equal(SentrySDK.LEVEL_WARNING)
+	options.set(property, prev)
+	assert_int(options.get(property)).is_equal(prev)
 
 
 ## Test assigning various callback properties.
@@ -98,12 +102,3 @@ func test_callback_properties(property: String, test_parameters := [
 	options.set(property, callback)
 	assert_that(options.get(property)).is_equal(callback)
 	options.set(property, prev)
-
-
-## Screenshot level should be set to specified level.
-func test_screenshot_level() -> void:
-	var prev := options.screenshot_level
-	options.screenshot_level = SentrySDK.LEVEL_DEBUG
-	assert_int(options.screenshot_level).is_equal(SentrySDK.LEVEL_DEBUG)
-	options.screenshot_level = prev
-	assert_int(options.screenshot_level).is_equal(prev)

--- a/src/sentry/util/print.h
+++ b/src/sentry/util/print.h
@@ -16,7 +16,7 @@ void print(sentry::Level p_level, const Variant &p_arg1, const Args &...p_args) 
 	if (!SentryOptions::get_singleton()->is_debug_enabled() && p_level < sentry::LEVEL_ERROR) {
 		return;
 	}
-	if (SentryOptions::get_singleton()->get_debug_verbosity() > p_level) {
+	if (SentryOptions::get_singleton()->get_diagnostic_level() > p_level) {
 		return;
 	}
 

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -57,7 +57,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/release", p_options->release);
 	_define_setting("sentry/options/dist", p_options->dist);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/debug_printing", PROPERTY_HINT_ENUM, "Off,On,Auto"), (int)SentryOptions::DEBUG_DEFAULT);
-	_define_setting(sentry::make_level_enum_property("sentry/options/debug_verbosity"), p_options->debug_verbosity);
+	_define_setting(sentry::make_level_enum_property("sentry/options/diagnostic_level"), p_options->diagnostic_level);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs);
 	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -100,7 +100,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	// The user may also set the `debug` option explicitly in a configuration script.
 	DebugMode mode = (DebugMode)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/debug_printing", (int)SentryOptions::DEBUG_DEFAULT);
 	p_options->_init_debug_option(mode);
-	p_options->debug_verbosity = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/debug_verbosity", p_options->debug_verbosity);
+	p_options->diagnostic_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/diagnostic_level", p_options->diagnostic_level);
 
 	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/sample_rate", p_options->sample_rate);
 	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/options/max_breadcrumbs", p_options->max_breadcrumbs);
@@ -159,7 +159,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "release"), set_release, get_release);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "dist"), set_dist, get_dist);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "debug"), set_debug_enabled, is_debug_enabled);
-	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("debug_verbosity"), set_debug_verbosity, get_debug_verbosity);
+	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("diagnostic_level"), set_diagnostic_level, get_diagnostic_level);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "environment"), set_environment, get_environment);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_breadcrumbs"), set_max_breadcrumbs, get_max_breadcrumbs);

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -54,7 +54,7 @@ private:
 	String release = "{app_name}@{app_version}";
 	String dist = "";
 	bool debug = false;
-	sentry::Level debug_verbosity = sentry::LEVEL_DEBUG;
+	sentry::Level diagnostic_level = sentry::LEVEL_DEBUG;
 	String environment;
 	double sample_rate = 1.0;
 	int max_breadcrumbs = 100;
@@ -107,8 +107,8 @@ public:
 	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }
 	_FORCE_INLINE_ void set_debug_enabled(bool p_enabled) { debug = p_enabled; }
 
-	_FORCE_INLINE_ void set_debug_verbosity(sentry::Level p_debug_verbosity) { debug_verbosity = p_debug_verbosity; }
-	_FORCE_INLINE_ sentry::Level get_debug_verbosity() const { return debug_verbosity; }
+	_FORCE_INLINE_ void set_diagnostic_level(sentry::Level p_debug_verbosity) { diagnostic_level = p_debug_verbosity; }
+	_FORCE_INLINE_ sentry::Level get_diagnostic_level() const { return diagnostic_level; }
 
 	_FORCE_INLINE_ double get_sample_rate() const { return sample_rate; }
 	_FORCE_INLINE_ void set_sample_rate(double p_sample_rate) { sample_rate = p_sample_rate; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -107,7 +107,7 @@ public:
 	_FORCE_INLINE_ bool is_debug_enabled() const { return debug; }
 	_FORCE_INLINE_ void set_debug_enabled(bool p_enabled) { debug = p_enabled; }
 
-	_FORCE_INLINE_ void set_diagnostic_level(sentry::Level p_debug_verbosity) { diagnostic_level = p_debug_verbosity; }
+	_FORCE_INLINE_ void set_diagnostic_level(sentry::Level p_level) { diagnostic_level = p_level; }
 	_FORCE_INLINE_ sentry::Level get_diagnostic_level() const { return diagnostic_level; }
 
 	_FORCE_INLINE_ double get_sample_rate() const { return sample_rate; }


### PR DESCRIPTION
Rename `debug_verbosity` => `diagnostic_level` to better align with established Sentry features.
Also, add a test for `diagnostic_level`.