### PR TITLE
ref: Restructure options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - Renamed `debug_verbosity` => `diagnostic_level` to better align with established Sentry features ([#154](https://github.com/getsentry/sentry-godot/pull/154))
+- Mark options as basic and advanced to have a cleaner interface, and move error logger tunables into their own sub-page. This is a BREAKING change so make sure to reapply those error logger values if you're changing the defaults. ([#155](https://github.com/getsentry/sentry-godot/pull/155))
 
 ### Features
 

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -71,7 +71,7 @@
 		<member name="logger_event_mask" type="int" setter="set_logger_event_mask" getter="get_logger_event_mask" enum="SentryOptions.GodotErrorMask" is_bitfield="true" default="13">
 			Specifies the types of errors captured as events. Accepts a single value or a bitwise combination of [enum GodotErrorMask] masks.
 		</member>
-		<member name="logger_include_source" type="bool" setter="set_logger_include_source" getter="should_logger_include_source" default="true">
+		<member name="logger_include_source" type="bool" setter="set_logger_include_source" getter="is_logger_include_source_enabled" default="true">
 			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
 		</member>
 		<member name="logger_limits" type="SentryLoggerLimits" setter="set_logger_limits" getter="get_logger_limits">

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -62,19 +62,19 @@
 			Environments indicate where an error occurred, such as in a release export, headless server, QA build, or another deployment. The SDK automatically detects Godot-specific environments, such as [code]headless_server[/code] and [code]export_release[/code], but you can also assign it in a [SentryConfiguration] script.
 			To learn more, visit [url=https://docs.sentry.io/platforms/godot/configuration/environments/]Environments documentation[/url].
 		</member>
-		<member name="error_logger_breadcrumb_mask" type="int" setter="set_error_logger_breadcrumb_mask" getter="get_error_logger_breadcrumb_mask" enum="SentryOptions.GodotErrorMask" is_bitfield="true" default="15">
+		<member name="logger_breadcrumb_mask" type="int" setter="set_logger_breadcrumb_mask" getter="get_logger_breadcrumb_mask" enum="SentryOptions.GodotErrorMask" is_bitfield="true" default="15">
 			Specifies the types of errors captured as breadcrumbs. Accepts a single value or a bitwise combination of [enum GodotErrorMask] masks.
 		</member>
-		<member name="error_logger_enabled" type="bool" setter="set_error_logger_enabled" getter="is_error_logger_enabled" default="true">
-			If [code]true[/code], the SDK will capture logged errors as events and/or breadcrumbs, as defined by [member error_logger_event_mask] and [member error_logger_breadcrumb_mask]. Crashes are always captured.
+		<member name="logger_enabled" type="bool" setter="set_logger_enabled" getter="is_logger_enabled" default="true">
+			If [code]true[/code], the SDK will capture logged errors as events and/or breadcrumbs, as defined by [member logger_event_mask] and [member logger_breadcrumb_mask]. Crashes are always captured.
 		</member>
-		<member name="error_logger_event_mask" type="int" setter="set_error_logger_event_mask" getter="get_error_logger_event_mask" enum="SentryOptions.GodotErrorMask" is_bitfield="true" default="13">
+		<member name="logger_event_mask" type="int" setter="set_logger_event_mask" getter="get_logger_event_mask" enum="SentryOptions.GodotErrorMask" is_bitfield="true" default="13">
 			Specifies the types of errors captured as events. Accepts a single value or a bitwise combination of [enum GodotErrorMask] masks.
 		</member>
-		<member name="error_logger_include_source" type="bool" setter="set_error_logger_include_source" getter="is_error_logger_include_source_enabled" default="true">
+		<member name="logger_include_source" type="bool" setter="set_logger_include_source" getter="should_logger_include_source" default="true">
 			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
 		</member>
-		<member name="error_logger_limits" type="SentryLoggerLimits" setter="set_error_logger_limits" getter="get_error_logger_limits">
+		<member name="logger_limits" type="SentryLoggerLimits" setter="set_logger_limits" getter="get_logger_limits">
 			Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending too many non-critical and repeating error events. See [SentryLoggerLimits].
 		</member>
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">

--- a/project/project.godot
+++ b/project/project.godot
@@ -42,5 +42,5 @@ textures/vram_compression/import_etc2_astc=true
 [sentry]
 
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
-options/attach_screenshot=true
 options/configuration_script="res://example_configuration.gd"
+options/attach_screenshot=true

--- a/project/test/isolated/test_limit_events_per_frame.gd
+++ b/project/test/isolated/test_limit_events_per_frame.gd
@@ -9,10 +9,10 @@ var _num_events: int = 0
 
 static func configure_options(options: SentryOptions) -> void:
 	# Only one error is allowed to be logged as event per processed frame.
-	options.error_logger_limits.events_per_frame = 1
+	options.logger_limits.events_per_frame = 1
 	# Make sure other limits are not interfering.
-	options.error_logger_limits.repeated_error_window_ms = 0
-	options.error_logger_limits.throttle_events = 88
+	options.logger_limits.repeated_error_window_ms = 0
+	options.logger_limits.throttle_events = 88
 
 
 func before_test() -> void:

--- a/project/test/isolated/test_limit_repeating_error_window.gd
+++ b/project/test/isolated/test_limit_repeating_error_window.gd
@@ -9,10 +9,10 @@ var _num_events: int = 0
 
 static func configure_options(options: SentryOptions) -> void:
 	# Ignore duplicate errors within 1 second window.
-	options.error_logger_limits.repeated_error_window_ms = 1000
+	options.logger_limits.repeated_error_window_ms = 1000
 	# Make sure other limits are not interfering.
-	options.error_logger_limits.events_per_frame = 88
-	options.error_logger_limits.throttle_events = 88
+	options.logger_limits.events_per_frame = 88
+	options.logger_limits.throttle_events = 88
 
 
 func before_test() -> void:

--- a/project/test/isolated/test_limit_throttling.gd
+++ b/project/test/isolated/test_limit_throttling.gd
@@ -9,11 +9,11 @@ var _num_events: int = 0
 
 static func configure_options(options: SentryOptions) -> void:
 	# Allow only two errors to be logged as events within 1 second time window.
-	options.error_logger_limits.throttle_events = 2
-	options.error_logger_limits.throttle_window_ms = 1000
+	options.logger_limits.throttle_events = 2
+	options.logger_limits.throttle_window_ms = 1000
 	# Make sure other limits are not interfering.
-	options.error_logger_limits.events_per_frame = 88
-	options.error_logger_limits.repeated_error_window_ms = 0
+	options.logger_limits.events_per_frame = 88
+	options.logger_limits.repeated_error_window_ms = 0
 
 
 func before_test() -> void:

--- a/project/test/isolated/test_logger_disabled.gd
+++ b/project/test/isolated/test_logger_disabled.gd
@@ -8,13 +8,13 @@ var _num_events: int = 0
 
 
 static func configure_options(options: SentryOptions) -> void:
-    options.error_logger_enabled = false
+    options.logger_enabled = false
 
     # Make sure other limits are not interfering.
-    options.error_logger_limits.events_per_frame = 88
-    options.error_logger_limits.throttle_events = 88
-    options.error_logger_limits.repeated_error_window_ms = 0
-    options.error_logger_limits.throttle_window_ms = 0
+    options.logger_limits.events_per_frame = 88
+    options.logger_limits.throttle_events = 88
+    options.logger_limits.repeated_error_window_ms = 0
+    options.logger_limits.throttle_window_ms = 0
 
 
 func before_test() -> void:

--- a/project/test/isolated/test_logger_with_masks.gd
+++ b/project/test/isolated/test_logger_with_masks.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
-## Events and breadcrumbs should be logged when "error_logger_event_mask" and
-## "error_logger_breadcrumb_mask" are configured to include all categories.
+## Events and breadcrumbs should be logged when "logger_event_mask" and
+## "logger_breadcrumb_mask" are configured to include all categories.
 
 
 signal callback_processed
@@ -10,14 +10,14 @@ var _num_events: int = 0
 
 static func configure_options(options: SentryOptions) -> void:
     var mask = SentryOptions.MASK_ERROR | SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER | SentryOptions.MASK_WARNING
-    options.error_logger_event_mask = mask
-    options.error_logger_breadcrumb_mask = mask
+    options.logger_event_mask = mask
+    options.logger_breadcrumb_mask = mask
 
     # Make sure other limits are not interfering.
-    options.error_logger_limits.events_per_frame = 88
-    options.error_logger_limits.throttle_events = 88
-    options.error_logger_limits.repeated_error_window_ms = 0
-    options.error_logger_limits.throttle_window_ms = 0
+    options.logger_limits.events_per_frame = 88
+    options.logger_limits.throttle_events = 88
+    options.logger_limits.repeated_error_window_ms = 0
+    options.logger_limits.throttle_window_ms = 0
 
 
 func before_test() -> void:

--- a/project/test/isolated/test_logger_with_masks_empty.gd
+++ b/project/test/isolated/test_logger_with_masks_empty.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
-## Events and breadcrumbs should not be logged when both "error_logger_event_mask"
-## and "error_logger_breadcrumb_mask" are set to zero.
+## Events and breadcrumbs should not be logged when both "logger_event_mask"
+## and "logger_breadcrumb_mask" are set to zero.
 
 
 signal callback_processed
@@ -9,8 +9,8 @@ var _num_events: int = 0
 
 
 static func configure_options(options: SentryOptions) -> void:
-    options.error_logger_event_mask = 0
-    options.error_logger_breadcrumb_mask = 0
+    options.logger_event_mask = 0
+    options.logger_breadcrumb_mask = 0
 
 
 func before_test() -> void:

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -18,8 +18,8 @@ func test_bool_properties(property: String, test_parameters := [
 		["attach_log"],
 		["attach_screenshot"],
 		["send_default_pii"],
-		["error_logger_enabled"],
-		["error_logger_include_source"],
+		["logger_enabled"],
+		["logger_include_source"],
 ]) -> void:
 	options.set(property, true)
 	assert_bool(options.get(property)).is_true()
@@ -51,30 +51,30 @@ func test_max_breadcrumbs() -> void:
 	assert_int(options.max_breadcrumbs).is_equal(42)
 
 
-## SentryOptions.error_logger_event_mask should be set to the specified value.
-func test_error_logger_event_mask() -> void:
+## SentryOptions.logger_event_mask should be set to the specified value.
+func test_logger_event_mask() -> void:
 	var mask := SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER
-	options.error_logger_event_mask = mask
-	assert_int(options.error_logger_event_mask).is_equal(mask)
+	options.logger_event_mask = mask
+	assert_int(options.logger_event_mask).is_equal(mask)
 
 
-## SentryOptions.error_logger_breadcrumb_mask should be set to the specified value.
-func test_error_logger_breadcrumb_mask() -> void:
+## SentryOptions.logger_breadcrumb_mask should be set to the specified value.
+func test_logger_breadcrumb_mask() -> void:
 	var mask := SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER
-	options.error_logger_breadcrumb_mask = mask
-	assert_int(options.error_logger_breadcrumb_mask).is_equal(mask)
+	options.logger_breadcrumb_mask = mask
+	assert_int(options.logger_breadcrumb_mask).is_equal(mask)
 
 
 ## Test integer error logger limit properties.
 @warning_ignore("unused_parameter")
-func test_error_logger_limit_properties(property: String, test_parameters := [
+func test_logger_limit_properties(property: String, test_parameters := [
 		["events_per_frame"],
 		["repeated_error_window_ms"],
 		["throttle_events"],
 		["throttle_window_ms"],
 ]) -> void:
-	options.error_logger_limits.set(property, 42)
-	assert_int(options.error_logger_limits.get(property)).is_equal(42)
+	options.logger_limits.set(property, 42)
+	assert_int(options.logger_limits.get(property)).is_equal(42)
 
 
 ## Test properties with SentrySDK.Level type.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -21,7 +21,7 @@ using namespace godot;
 namespace {
 
 void _init_logger() {
-	if (!SentryOptions::get_singleton()->is_error_logger_enabled()) {
+	if (!SentryOptions::get_singleton()->is_logger_enabled()) {
 		// If error logger is disabled, don't add it to the scene tree.
 		sentry::util::print_debug("error logger is disabled in options");
 		return;

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -57,7 +57,7 @@ void SentryLogger::_process_log_file() {
 	frame_events = 0;
 
 	// Get limits.
-	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
+	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_logger_limits();
 	auto repeated_error_window = std::chrono::milliseconds{ limits->repeated_error_window_ms };
 	auto throttle_window = std::chrono::milliseconds{ limits->throttle_window_ms };
 
@@ -133,9 +133,9 @@ void SentryLogger::_process_log_file() {
 }
 
 void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line, const char *p_rationale, GodotErrorType p_error_type) {
-	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_error_logger_limits();
-	bool as_breadcrumb = SentryOptions::get_singleton()->is_error_logger_breadcrumb_enabled(p_error_type);
-	bool as_event = SentryOptions::get_singleton()->is_error_logger_event_enabled(p_error_type) &&
+	Ref<SentryLoggerLimits> limits = SentryOptions::get_singleton()->get_logger_limits();
+	bool as_breadcrumb = SentryOptions::get_singleton()->should_capture_breadcrumb(p_error_type);
+	bool as_event = SentryOptions::get_singleton()->should_capture_event(p_error_type) &&
 			frame_events < limits->events_per_frame &&
 			event_times.size() < limits->throttle_events;
 
@@ -162,7 +162,7 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 		sentry::InternalSDK::StackFrame stack_frame{ p_file, p_func, p_line };
 
 		// Provide script source code context for script errors if available.
-		if (p_error_type == GodotErrorType::ERROR_TYPE_SCRIPT && SentryOptions::get_singleton()->is_error_logger_include_source_enabled()) {
+		if (p_error_type == GodotErrorType::ERROR_TYPE_SCRIPT && SentryOptions::get_singleton()->should_logger_include_source()) {
 			// Provide script source code context for script errors if available.
 			// TODO: Should it be optional?
 			String context_line;

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -162,9 +162,8 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 		sentry::InternalSDK::StackFrame stack_frame{ p_file, p_func, p_line };
 
 		// Provide script source code context for script errors if available.
-		if (p_error_type == GodotErrorType::ERROR_TYPE_SCRIPT && SentryOptions::get_singleton()->should_logger_include_source()) {
+		if (p_error_type == GodotErrorType::ERROR_TYPE_SCRIPT && SentryOptions::get_singleton()->is_logger_include_source_enabled()) {
 			// Provide script source code context for script errors if available.
-			// TODO: Should it be optional?
 			String context_line;
 			PackedStringArray pre_context;
 			PackedStringArray post_context;

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -52,32 +52,32 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
 	_define_setting("sentry/options/enabled", p_options->enabled);
-	_define_setting("sentry/options/disabled_in_editor", p_options->disabled_in_editor);
+	_define_setting("sentry/options/disabled_in_editor", p_options->disabled_in_editor, false);
 	_define_setting("sentry/options/dsn", p_options->dsn);
-	_define_setting("sentry/options/release", p_options->release);
-	_define_setting("sentry/options/dist", p_options->dist);
+	_define_setting("sentry/options/release", p_options->release, false);
+	_define_setting("sentry/options/dist", p_options->dist, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/debug_printing", PROPERTY_HINT_ENUM, "Off,On,Auto"), (int)SentryOptions::DEBUG_DEFAULT);
 	_define_setting(sentry::make_level_enum_property("sentry/options/diagnostic_level"), p_options->diagnostic_level);
-	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs);
-	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii);
+	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
+	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii, false);
 
-	_define_setting("sentry/options/attach_log", p_options->attach_log);
-	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
-	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level);
+	_define_setting("sentry/options/attach_log", p_options->attach_log, false);
+	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot, false);
+	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level, false);
 
-	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
-	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask);
+	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled, false);
+	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask, false);
 
-	_define_setting("sentry/options/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms);
+	_define_setting("sentry/options/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms, false);
 
-	_define_setting(PropertyInfo(Variant::STRING, "sentry/options/configuration_script", PROPERTY_HINT_FILE, "*.gd"), p_options->configuration_script);
+	_define_setting(PropertyInfo(Variant::STRING, "sentry/options/configuration_script", PROPERTY_HINT_FILE, "*.gd"), p_options->configuration_script, false);
 }
 
 void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -170,7 +170,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, should_logger_include_source);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_event_mask"), set_logger_event_mask, get_logger_event_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), set_logger_breadcrumb_mask, get_logger_breadcrumb_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_logger_limits, get_logger_limits);

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -67,16 +67,16 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot, false);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level, false);
 
-	_define_setting("sentry/error_logger/enabled", p_options->error_logger_enabled);
-	_define_setting("sentry/error_logger/include_source", p_options->error_logger_include_source, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask, false);
+	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
+	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_event_mask, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_breadcrumb_mask, false);
 
-	_define_setting("sentry/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms, false);
+	_define_setting("sentry/logger/limits/parse_lines", p_options->logger_limits->parse_lines, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->events_per_frame, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->repeated_error_window_ms, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->throttle_events, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->throttle_window_ms, false);
 }
 
 void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) {
@@ -111,16 +111,16 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
 
-	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/enabled", p_options->error_logger_enabled);
-	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/include_source", p_options->error_logger_include_source);
-	p_options->error_logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/error_logger/events", p_options->error_logger_event_mask);
-	p_options->error_logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
+	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
+	p_options->logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", p_options->logger_include_source);
+	p_options->logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", p_options->logger_event_mask);
+	p_options->logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", p_options->logger_breadcrumb_mask);
 
-	p_options->error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
-	p_options->error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/events_per_frame", p_options->error_logger_limits->events_per_frame);
-	p_options->error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/repeated_error_window_ms", p_options->error_logger_limits->repeated_error_window_ms);
-	p_options->error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_events", p_options->error_logger_limits->throttle_events);
-	p_options->error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_window_ms", p_options->error_logger_limits->throttle_window_ms);
+	p_options->logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/parse_lines", p_options->logger_limits->parse_lines);
+	p_options->logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", p_options->logger_limits->events_per_frame);
+	p_options->logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", p_options->logger_limits->repeated_error_window_ms);
+	p_options->logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", p_options->logger_limits->throttle_events);
+	p_options->logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", p_options->logger_limits->throttle_window_ms);
 }
 
 void SentryOptions::_init_debug_option(DebugMode p_mode) {
@@ -144,11 +144,11 @@ void SentryOptions::destroy_singleton() {
 	singleton = Ref<SentryOptions>();
 }
 
-void SentryOptions::set_error_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
-	error_logger_limits = p_limits;
+void SentryOptions::set_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
+	logger_limits = p_limits;
 	// Ensure limits are initialized.
-	if (error_logger_limits.is_null()) {
-		error_logger_limits.instantiate();
+	if (logger_limits.is_null()) {
+		logger_limits.instantiate();
 	}
 }
 
@@ -169,12 +169,11 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_enabled"), set_error_logger_enabled, is_error_logger_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "error_logger_include_source"), set_error_logger_include_source, is_error_logger_include_source_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_event_mask"), set_error_logger_event_mask, get_error_logger_event_mask);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "error_logger_breadcrumb_mask"), set_error_logger_breadcrumb_mask, get_error_logger_breadcrumb_mask);
-
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "error_logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_error_logger_limits, get_error_logger_limits);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, should_logger_include_source);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_event_mask"), set_logger_event_mask, get_logger_event_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), set_logger_breadcrumb_mask, get_logger_breadcrumb_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_logger_limits, get_logger_limits);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send"), set_before_send, get_before_send);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "on_crash"), set_on_crash, get_on_crash);
@@ -191,7 +190,7 @@ void SentryOptions::_bind_methods() {
 }
 
 SentryOptions::SentryOptions() {
-	error_logger_limits.instantiate(); // Ensure limits are initialized.
+	logger_limits.instantiate(); // Ensure limits are initialized.
 	environment = sentry::environment::detect_godot_environment();
 	_init_debug_option(DEBUG_DEFAULT);
 }

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -58,6 +58,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/dist", p_options->dist, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/debug_printing", PROPERTY_HINT_ENUM, "Off,On,Auto"), (int)SentryOptions::DEBUG_DEFAULT);
 	_define_setting(sentry::make_level_enum_property("sentry/options/diagnostic_level"), p_options->diagnostic_level);
+	_define_setting(PropertyInfo(Variant::STRING, "sentry/options/configuration_script", PROPERTY_HINT_FILE, "*.gd"), p_options->configuration_script, false);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
 	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii, false);
@@ -76,8 +77,6 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms, false);
-
-	_define_setting(PropertyInfo(Variant::STRING, "sentry/options/configuration_script", PROPERTY_HINT_FILE, "*.gd"), p_options->configuration_script, false);
 }
 
 void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) {
@@ -103,6 +102,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->_init_debug_option(mode);
 	p_options->diagnostic_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/diagnostic_level", p_options->diagnostic_level);
 
+	p_options->configuration_script = ProjectSettings::get_singleton()->get_setting("sentry/options/configuration_script", p_options->configuration_script);
 	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/sample_rate", p_options->sample_rate);
 	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/options/max_breadcrumbs", p_options->max_breadcrumbs);
 	p_options->send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -121,8 +121,6 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/repeated_error_window_ms", p_options->error_logger_limits->repeated_error_window_ms);
 	p_options->error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_events", p_options->error_logger_limits->throttle_events);
 	p_options->error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_window_ms", p_options->error_logger_limits->throttle_window_ms);
-
-	p_options->configuration_script = ProjectSettings::get_singleton()->get_setting("sentry/options/configuration_script", p_options->configuration_script);
 }
 
 void SentryOptions::_init_debug_option(DebugMode p_mode) {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -66,16 +66,16 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot, false);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level, false);
 
-	_define_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled, false);
-	_define_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask, false);
+	_define_setting("sentry/error_logger/enabled", p_options->error_logger_enabled);
+	_define_setting("sentry/error_logger/include_source", p_options->error_logger_include_source, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_event_mask, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->error_logger_breadcrumb_mask, false);
 
-	_define_setting("sentry/options/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/options/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms, false);
+	_define_setting("sentry/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->events_per_frame, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->repeated_error_window_ms, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->error_logger_limits->throttle_events, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/error_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->error_logger_limits->throttle_window_ms, false);
 
 	_define_setting(PropertyInfo(Variant::STRING, "sentry/options/configuration_script", PROPERTY_HINT_FILE, "*.gd"), p_options->configuration_script, false);
 }
@@ -111,16 +111,16 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
 
-	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/enabled", p_options->error_logger_enabled);
-	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/include_source", p_options->error_logger_include_source);
-	p_options->error_logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/events", p_options->error_logger_event_mask);
-	p_options->error_logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
+	p_options->error_logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/enabled", p_options->error_logger_enabled);
+	p_options->error_logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/include_source", p_options->error_logger_include_source);
+	p_options->error_logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/error_logger/events", p_options->error_logger_event_mask);
+	p_options->error_logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/error_logger/breadcrumbs", p_options->error_logger_breadcrumb_mask);
 
-	p_options->error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
-	p_options->error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/limits/events_per_frame", p_options->error_logger_limits->events_per_frame);
-	p_options->error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/limits/repeated_error_window_ms", p_options->error_logger_limits->repeated_error_window_ms);
-	p_options->error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/limits/throttle_events", p_options->error_logger_limits->throttle_events);
-	p_options->error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/error_logger/limits/throttle_window_ms", p_options->error_logger_limits->throttle_window_ms);
+	p_options->error_logger_limits->parse_lines = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/parse_lines", p_options->error_logger_limits->parse_lines);
+	p_options->error_logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/events_per_frame", p_options->error_logger_limits->events_per_frame);
+	p_options->error_logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/repeated_error_window_ms", p_options->error_logger_limits->repeated_error_window_ms);
+	p_options->error_logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_events", p_options->error_logger_limits->throttle_events);
+	p_options->error_logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/error_logger/limits/throttle_window_ms", p_options->error_logger_limits->throttle_window_ms);
 
 	p_options->configuration_script = ProjectSettings::get_singleton()->get_setting("sentry/options/configuration_script", p_options->configuration_script);
 }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -133,7 +133,7 @@ public:
 	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
 	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }
 
-	_FORCE_INLINE_ bool should_logger_include_source() const { return logger_include_source; }
+	_FORCE_INLINE_ bool is_logger_include_source_enabled() const { return logger_include_source; }
 	_FORCE_INLINE_ void set_logger_include_source(bool p_enable) { logger_include_source = p_enable; }
 
 	_FORCE_INLINE_ BitField<GodotErrorMask> get_logger_event_mask() const { return logger_event_mask; }

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -64,11 +64,11 @@ private:
 	bool attach_screenshot = false;
 	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
 
-	bool error_logger_enabled = true;
-	bool error_logger_include_source = true;
-	BitField<GodotErrorMask> error_logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
-	BitField<GodotErrorMask> error_logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
-	Ref<SentryLoggerLimits> error_logger_limits;
+	bool logger_enabled = true;
+	bool logger_include_source = true;
+	BitField<GodotErrorMask> logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
+	BitField<GodotErrorMask> logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
+	Ref<SentryLoggerLimits> logger_limits;
 
 	String configuration_script;
 	Callable before_send;
@@ -130,23 +130,23 @@ public:
 	_FORCE_INLINE_ sentry::Level get_screenshot_level() const { return screenshot_level; }
 	_FORCE_INLINE_ void set_screenshot_level(sentry::Level p_level) { screenshot_level = p_level; }
 
-	_FORCE_INLINE_ bool is_error_logger_enabled() const { return error_logger_enabled; }
-	_FORCE_INLINE_ void set_error_logger_enabled(bool p_enabled) { error_logger_enabled = p_enabled; }
+	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
+	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }
 
-	_FORCE_INLINE_ bool is_error_logger_include_source_enabled() const { return error_logger_include_source; }
-	_FORCE_INLINE_ void set_error_logger_include_source(bool p_error_logger_include_source) { error_logger_include_source = p_error_logger_include_source; }
+	_FORCE_INLINE_ bool should_logger_include_source() const { return logger_include_source; }
+	_FORCE_INLINE_ void set_logger_include_source(bool p_enable) { logger_include_source = p_enable; }
 
-	_FORCE_INLINE_ BitField<GodotErrorMask> get_error_logger_event_mask() const { return error_logger_event_mask; }
-	_FORCE_INLINE_ void set_error_logger_event_mask(BitField<GodotErrorMask> p_error_logger_event_mask) { error_logger_event_mask = p_error_logger_event_mask; }
+	_FORCE_INLINE_ BitField<GodotErrorMask> get_logger_event_mask() const { return logger_event_mask; }
+	_FORCE_INLINE_ void set_logger_event_mask(BitField<GodotErrorMask> p_mask) { logger_event_mask = p_mask; }
 
-	_FORCE_INLINE_ BitField<GodotErrorMask> get_error_logger_breadcrumb_mask() const { return error_logger_breadcrumb_mask; }
-	_FORCE_INLINE_ void set_error_logger_breadcrumb_mask(BitField<GodotErrorMask> p_error_logger_breadcrumb_mask) { error_logger_breadcrumb_mask = p_error_logger_breadcrumb_mask; }
+	_FORCE_INLINE_ BitField<GodotErrorMask> get_logger_breadcrumb_mask() const { return logger_breadcrumb_mask; }
+	_FORCE_INLINE_ void set_logger_breadcrumb_mask(BitField<GodotErrorMask> p_mask) { logger_breadcrumb_mask = p_mask; }
 
-	_FORCE_INLINE_ bool is_error_logger_event_enabled(GodotErrorType p_error_type) { return error_logger_event_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
-	_FORCE_INLINE_ bool is_error_logger_breadcrumb_enabled(GodotErrorType p_error_type) { return error_logger_breadcrumb_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_event(GodotErrorType p_error_type) { return logger_event_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_breadcrumb(GodotErrorType p_error_type) { return logger_breadcrumb_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
 
-	_FORCE_INLINE_ Ref<SentryLoggerLimits> get_error_logger_limits() const { return error_logger_limits; }
-	void set_error_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
+	_FORCE_INLINE_ Ref<SentryLoggerLimits> get_logger_limits() const { return logger_limits; }
+	void set_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
 
 	_FORCE_INLINE_ String get_configuration_script() const { return configuration_script; }
 


### PR DESCRIPTION
This PR restructures options in the Project Settings:
- Mark options as basic and advanced to have a cleaner interface.
- Move error logger tunables into their own sub-page. This is a **BREAKING** change so make sure to reapply those error logger values if you're changing the defaults.
  - Rename options: `error_logger_*` => `logger_*`.

#### Basic options

<img width="718" alt="Screenshot 2025-04-04 at 17 40 51" src="https://github.com/user-attachments/assets/3e794274-2f2a-4f9f-ad21-d85e44c86910" />
<img width="716" alt="Screenshot 2025-04-04 at 17 41 02" src="https://github.com/user-attachments/assets/6a3fd2ee-a38a-4f9b-8211-b161cb924169" />

#### Advanced options

<img width="721" alt="Screenshot 2025-04-04 at 17 41 27" src="https://github.com/user-attachments/assets/2d286004-b793-497b-8782-fb28c42edd36" />

<img width="719" alt="Screenshot 2025-04-04 at 17 41 42" src="https://github.com/user-attachments/assets/5c7d6474-782f-4e68-8aab-da22c780e5a1" />

#### Options API

<img width="518" alt="Screenshot 2025-04-04 at 17 48 02" src="https://github.com/user-attachments/assets/05c7fc45-85fe-4498-97ea-67fa632a4bef" />
