### PR TITLE
ref: Remove `logger` argument from `SentrySDK.capture_message(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+- Remove `logger` argument from `SentrySDK.capture_message(...)`. This shouldn't be disruptive as the logger argument is seldom used and it had a default value. ([#162](https://github.com/getsentry/sentry-godot/pull/162))
+
 ## 0.4.2
 
 ### Various fixes & improvements

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -36,7 +36,6 @@
 			<return type="String" />
 			<param index="0" name="message" type="String" />
 			<param index="1" name="level" type="int" enum="SentrySDK.Level" default="1" />
-			<param index="2" name="logger" type="String" default="&quot;&quot;" />
 			<description>
 				Captures an event with [param message] and sends it to Sentry, returning the event ID.
 			</description>

--- a/src/sentry/disabled_sdk.h
+++ b/src/sentry/disabled_sdk.h
@@ -20,7 +20,7 @@ class DisabledSDK : public InternalSDK {
 	virtual void add_breadcrumb(const String &p_message, const String &p_category, Level p_level,
 			const String &p_type = "default", const Dictionary &p_data = Dictionary()) override {}
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO, const String &p_logger = "") override { return ""; }
+	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override { return ""; }
 	virtual String get_last_event_id() override { return ""; }
 	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) override { return ""; }
 

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -40,7 +40,7 @@ public:
 	// TODO: Consider adding the following function.
 	// virtual void clear_breadcrumbs() = 0;
 
-	virtual String capture_message(const String &p_message, Level p_level, const String &p_logger = "") = 0;
+	virtual String capture_message(const String &p_message, Level p_level) = 0;
 	virtual String get_last_event_id() = 0;
 	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) = 0;
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -250,10 +250,10 @@ void NativeSDK::add_breadcrumb(const String &p_message, const String &p_category
 	sentry_add_breadcrumb(crumb);
 }
 
-String NativeSDK::capture_message(const String &p_message, Level p_level, const String &p_logger) {
+String NativeSDK::capture_message(const String &p_message, Level p_level) {
 	sentry_value_t event = sentry_value_new_message_event(
 			native::level_to_native(p_level),
-			p_logger.utf8().get_data(),
+			"", // logger
 			p_message.utf8().get_data());
 	last_uuid = sentry_capture_event(event);
 	return _uuid_as_string(last_uuid);

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -26,7 +26,7 @@ public:
 	virtual void add_breadcrumb(const String &p_message, const String &p_category, Level p_level,
 			const String &p_type = "default", const Dictionary &p_data = Dictionary()) override;
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO, const String &p_logger = "") override;
+	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
 	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) override;
 

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -50,8 +50,8 @@ void _fix_unix_executable_permissions(const String &p_path) {
 
 SentrySDK *SentrySDK::singleton = nullptr;
 
-String SentrySDK::capture_message(const String &p_message, Level p_level, const String &p_logger) {
-	return internal_sdk->capture_message(p_message, p_level, p_logger);
+String SentrySDK::capture_message(const String &p_message, Level p_level) {
+	return internal_sdk->capture_message(p_message, p_level);
 }
 
 void SentrySDK::add_breadcrumb(const String &p_message, const String &p_category, Level p_level,
@@ -175,7 +175,7 @@ void SentrySDK::_bind_methods() {
 	BIND_ENUM_CONSTANT(LEVEL_FATAL);
 
 	ClassDB::bind_method(D_METHOD("is_enabled"), &SentrySDK::is_enabled);
-	ClassDB::bind_method(D_METHOD("capture_message", "message", "level", "logger"), &SentrySDK::capture_message, DEFVAL(LEVEL_INFO), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("capture_message", "message", "level"), &SentrySDK::capture_message, DEFVAL(LEVEL_INFO));
 	ClassDB::bind_method(D_METHOD("add_breadcrumb", "message", "category", "level", "type", "data"), &SentrySDK::add_breadcrumb, DEFVAL(LEVEL_INFO), DEFVAL("default"), DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("get_last_event_id"), &SentrySDK::get_last_event_id);
 	ClassDB::bind_method(D_METHOD("set_context", "key", "value"), &SentrySDK::set_context);

--- a/src/sentry_sdk.h
+++ b/src/sentry_sdk.h
@@ -61,7 +61,7 @@ public:
 	Ref<SentryUser> get_user() const { return user; }
 	void remove_user();
 
-	String capture_message(const String &p_message, sentry::Level p_level = sentry::LEVEL_INFO, const String &p_logger = "");
+	String capture_message(const String &p_message, sentry::Level p_level = sentry::LEVEL_INFO);
 	String get_last_event_id() const;
 
 	Ref<SentryEvent> create_event() const;


### PR DESCRIPTION
Seeing that it had a default value and seldom used, it shouldn't be a disruptive change.

Resolves #160