### PR TITLE
ref: Remove `on_crash` hook in favor of `event.is_crash()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking changess
+### Breaking changes
 
 - Remove `on_crash` hook in favor of `SentryEvent.is_crash()`: `before_send` is now called for crash events too, and you can check if it's a crash event by calling `event.is_crash()` ([#181](https://github.com/getsentry/sentry-godot/pull/181))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changess
+
+- Remove `on_crash` hook in favor of `SentryEvent.is_crash()`: `before_send` is now called for crash events too, and you can check if it's a crash event by calling `event.is_crash()` ([#181](https://github.com/getsentry/sentry-godot/pull/181))
+
 ## 0.5.0
 
 ### Breaking changes

--- a/doc_classes/SentryConfiguration.xml
+++ b/doc_classes/SentryConfiguration.xml
@@ -16,7 +16,6 @@
 		        options.debug = true
 		    options.release = "mygame@1.0.0"
 		    options.before_send = _process_event
-		    options.on_crash = _process_event
 
 		func _process_event(event: SentryEvent) -&gt; SentryEvent:
 		    if event.environment == "debug":
@@ -35,7 +34,7 @@
 			<return type="void" />
 			<param index="0" name="options" type="SentryOptions" />
 			<description>
-				Called just before the Sentry SDK initializes. You can override SDK [param options] here and register [member SentryOptions.before_send] and [member SentryOptions.on_crash] callbacks if needed.
+				Called just before the Sentry SDK initializes. You can override SDK [param options] here and register [member SentryOptions.before_send] callback if needed.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentryEvent.xml
+++ b/doc_classes/SentryEvent.xml
@@ -16,6 +16,13 @@
 				Returns the value of the tag with the specified [param key].
 			</description>
 		</method>
+		<method name="is_crash" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this event is considered terminal, meaning it was triggered by a crash or unrecoverable failure.
+				Useful for distinguishing crash reports from other event types such as logs or script errors.
+			</description>
+		</method>
 		<method name="remove_tag">
 			<return type="void" />
 			<param index="0" name="key" type="String" />

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -29,7 +29,7 @@
 			[/codeblock]
 		</member>
 		<member name="before_send" type="Callable" setter="set_before_send" getter="get_before_send" default="Callable()">
-			If assigned, this callback runs before a message or error event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.
+			If assigned, this callback runs before an event is sent to Sentry. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script. To check if the event is a crash, use [method SentryEvent.is_crash].
 			[codeblock]
 			func _before_send(event: SentryEvent) -&gt; SentryEvent:
 			    if event.environment == "editor_dev_run":

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -83,20 +83,6 @@
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">
 			Maximum number of breadcrumbs to send with an event. You should be aware that Sentry has a maximum payload size and any events exceeding that payload size will be dropped.
 		</member>
-		<member name="on_crash" type="Callable" setter="set_on_crash" getter="get_on_crash" default="Callable()">
-			If assigned, this callback runs before a crash event is sent to Sentry. In contrast to [member before_send], it is only called when a crash occurred. It takes [SentryEvent] as a parameter and return either the same event object, with or without modifications, or [code]null[/code] to skip reporting the event. You can assign it in a [SentryConfiguration] script.
-			[codeblock]
-			func _on_crash(event: SentryEvent) -&gt; SentryEvent:
-			    if event.environment == "editor_dev_run":
-			        # Discard event if running from the editor.
-			        return null
-			    if event.message.contains("Bruno"):
-			        # Remove sensitive information from the event.
-			        event.message = event.message.replace("Bruno", "REDACTED")
-			    return event
-			[/codeblock]
-			To learn more, visit [url=https://docs.sentry.io/platforms/godot/configuration/filtering/]Filtering documentation[/url].
-		</member>
 		<member name="release" type="String" setter="set_release" getter="get_release" default="&quot;{app_name}@{app_version}&quot;">
 			Release version of the application. This value must be unique across all projects in your organization. Suggested format is [code]my-game@1.0.0[/code].
 			You can use the [code]{app_name}[/code] and [code]{app_version}[/code] placeholders to insert the application name and version from the Project Settings.

--- a/project/example_configuration.gd
+++ b/project/example_configuration.gd
@@ -29,9 +29,3 @@ func _before_send(ev: SentryEvent) -> SentryEvent:
 		print("INFO: [example_configuration.gd] Discarding event with message 'junk'")
 		return null
 	return ev
-
-
-## on_crash callback example
-func _on_crash(ev: SentryEvent) -> SentryEvent:
-	print("INFO: [example_configuration.gd] Crashing with event: ", ev.id)
-	return ev

--- a/project/example_configuration.gd
+++ b/project/example_configuration.gd
@@ -14,7 +14,6 @@ func _configure(options: SentryOptions) -> void:
 
 	# Set up event callbacks
 	options.before_send = _before_send
-	options.on_crash = _on_crash
 
 	# Unit testing hooks (if you're exploring the demo project, pretend the following line doesn't exist).
 	load("res://testing_configuration.gd").configure_options(options)

--- a/project/test/suites/test_event.gd
+++ b/project/test/suites/test_event.gd
@@ -81,6 +81,12 @@ func test_event_tags() -> void:
 	assert_str(event.get_tag("test_tag")).is_empty()
 
 
+## SentryEvent.is_crash() should return false on a custom-created event.
+func test_event_is_crash() -> void:
+	var event := SentrySDK.create_event()
+	assert_bool(event.is_crash()).is_false()
+
+
 ## SentrySDK.capture_event() should return a non-empty event ID, which must match the ID returned by the get_last_event_id() call.
 func test_capture_event() -> void:
 	var event := SentrySDK.create_event()

--- a/project/test/suites/test_event_integrity.gd
+++ b/project/test/suites/test_event_integrity.gd
@@ -47,5 +47,6 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 	assert_str(event.environment).is_equal("custom-environment")
 	assert_str(event.get_tag("custom-tag")).is_equal("custom-tag-value")
 	assert_str(event.id).is_equal(created_id)
+	assert_bool(event.is_crash()).is_false()
 	callback_processed.emit()
 	return null # discard event

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -95,7 +95,6 @@ func test_level_properties(property: String, test_parameters := [
 @warning_ignore("unused_parameter")
 func test_callback_properties(property: String, test_parameters := [
 	["before_send"],
-	["on_crash"],
 	["before_capture_screenshot"]
 ]) -> void:
 	var callback := func(a1): pass

--- a/src/sentry/disabled_event.h
+++ b/src/sentry/disabled_event.h
@@ -48,6 +48,8 @@ public:
 	virtual void set_tag(const String &p_key, const String &p_value) override {}
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
+
+	virtual bool is_crash() const override { return false; }
 };
 
 #endif // DISABLED_EVENT_H

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -139,7 +139,12 @@ String NativeEvent::get_tag(const String &p_key) {
 	return String();
 }
 
-NativeEvent::NativeEvent(sentry_value_t p_native_event) {
+bool NativeEvent::is_crash() const {
+	return _is_crash;
+}
+
+NativeEvent::NativeEvent(sentry_value_t p_native_event, bool p_is_crash) :
+		_is_crash(p_is_crash) {
 	if (sentry_value_refcount(p_native_event) > 0) {
 		sentry_value_incref(p_native_event); // acquire ownership
 		native_event = p_native_event;

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -11,6 +11,7 @@ class NativeEvent : public SentryEvent {
 
 private:
 	sentry_value_t native_event;
+	bool _is_crash = false;
 
 protected:
 	static void _bind_methods() {}
@@ -47,7 +48,9 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
-	NativeEvent(sentry_value_t p_event);
+	virtual bool is_crash() const override;
+
+	NativeEvent(sentry_value_t p_event, bool p_is_crash);
 	NativeEvent();
 	virtual ~NativeEvent() override;
 };

--- a/src/sentry_event.cpp
+++ b/src/sentry_event.cpp
@@ -24,6 +24,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tag", "key", "value"), &SentryEvent::set_tag);
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentryEvent::remove_tag);
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
+	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "id"), "", "get_id");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "message"), "set_message", "get_message");

--- a/src/sentry_event.h
+++ b/src/sentry_event.h
@@ -45,6 +45,8 @@ public:
 	virtual void remove_tag(const String &p_key) = 0;
 	virtual String get_tag(const String &p_key) = 0;
 
+	virtual bool is_crash() const = 0;
+
 	virtual ~SentryEvent() = default;
 };
 

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -179,7 +179,6 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_logger_limits, get_logger_limits);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send"), set_before_send, get_before_send);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "on_crash"), set_on_crash, get_on_crash);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_capture_screenshot"), set_before_capture_screenshot, get_before_capture_screenshot);
 
 	{

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -73,7 +73,6 @@ private:
 
 	String configuration_script;
 	Callable before_send;
-	Callable on_crash;
 	Callable before_capture_screenshot;
 
 	static void _define_project_settings(const Ref<SentryOptions> &p_options);
@@ -156,9 +155,6 @@ public:
 
 	_FORCE_INLINE_ Callable get_before_send() const { return before_send; }
 	_FORCE_INLINE_ void set_before_send(const Callable &p_before_send) { before_send = p_before_send; }
-
-	_FORCE_INLINE_ Callable get_on_crash() const { return on_crash; }
-	_FORCE_INLINE_ void set_on_crash(const Callable &p_on_crash) { on_crash = p_on_crash; }
 
 	_FORCE_INLINE_ Callable get_before_capture_screenshot() const { return before_capture_screenshot; }
 	_FORCE_INLINE_ void set_before_capture_screenshot(const Callable &p_before_capture_screenshot) { before_capture_screenshot = p_before_capture_screenshot; }

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -190,8 +190,6 @@ void SentrySDK::_bind_methods() {
 	// Hidden API methods -- used in testing.
 	ClassDB::bind_method(D_METHOD("_set_before_send", "callable"), &SentrySDK::set_before_send);
 	ClassDB::bind_method(D_METHOD("_unset_before_send"), &SentrySDK::unset_before_send);
-	ClassDB::bind_method(D_METHOD("_set_on_crash", "callable"), &SentrySDK::set_on_crash);
-	ClassDB::bind_method(D_METHOD("_unset_on_crash"), &SentrySDK::unset_on_crash);
 }
 
 SentrySDK::SentrySDK() {

--- a/src/sentry_sdk.h
+++ b/src/sentry_sdk.h
@@ -72,9 +72,6 @@ public:
 	void set_before_send(const Callable &p_callable) { SentryOptions::get_singleton()->set_before_send(p_callable); }
 	void unset_before_send() { SentryOptions::get_singleton()->set_before_send(Callable()); }
 
-	void set_on_crash(const Callable &p_callable) { SentryOptions::get_singleton()->set_on_crash(p_callable); }
-	void unset_on_crash() { SentryOptions::get_singleton()->set_on_crash(Callable()); }
-
 	SentrySDK();
 	~SentrySDK();
 };


### PR DESCRIPTION
- Remove `on_crash` callback, since it is practically the same as `before_send`.
- Call `before_send` for crash events instead.
- Add `SentryEvent.is_crash()` method.

Before merge:
- [ ] Update docs