### PR TITLE
ref: Improve thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Other changes
 
 - Rename "addons/sentrysdk" to "addons/sentry" ([#180](https://github.com/getsentry/sentry-godot/pull/180))
+- Improve thread safety ([#186](https://github.com/getsentry/sentry-godot/pull/186))
 
 ### Dependencies
 

--- a/SConstruct
+++ b/SConstruct
@@ -155,6 +155,7 @@ if env["platform"] in ["linux", "macos", "windows"]:
         env.Append(
             LIBS=[
                 "curl",
+                "atomic"
             ]
         )
     elif env["platform"] == "macos":

--- a/doc_classes/SentryUser.xml
+++ b/doc_classes/SentryUser.xml
@@ -11,6 +11,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="duplicate">
+			<return type="SentryUser" />
+			<description>
+				Creates a copy of this user data, returning a new [SentryUser] instance.
+			</description>
+		</method>
 		<method name="generate_new_id">
 			<return type="void" />
 			<description>

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -300,12 +300,14 @@ String NativeSDK::capture_message(const String &p_message, Level p_level) {
 			native::level_to_native(p_level),
 			"", // logger
 			p_message.utf8().get_data());
-	last_uuid = sentry_capture_event(event);
-	return _uuid_as_string(last_uuid);
+
+	sentry_uuid_t uuid = sentry_capture_event(event);
+	last_uuid.store(uuid, std::memory_order_release);
+	return _uuid_as_string(uuid);
 }
 
 String NativeSDK::get_last_event_id() {
-	return _uuid_as_string(last_uuid);
+	return _uuid_as_string(last_uuid.load(std::memory_order_acquire));
 }
 
 String NativeSDK::capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) {
@@ -333,8 +335,9 @@ String NativeSDK::capture_error(const String &p_type, const String &p_value, Lev
 	sentry_value_set_by_key(stack_trace, "frames", frames);
 	sentry_value_set_by_key(exception, "stacktrace", stack_trace);
 	sentry_event_add_exception(event, exception);
-	last_uuid = sentry_capture_event(event);
-	return _uuid_as_string(last_uuid);
+	sentry_uuid_t uuid = sentry_capture_event(event);
+	last_uuid.store(uuid, std::memory_order_release);
+	return _uuid_as_string(uuid);
 }
 
 Ref<SentryEvent> NativeSDK::create_event() {
@@ -344,14 +347,14 @@ Ref<SentryEvent> NativeSDK::create_event() {
 }
 
 String NativeSDK::capture_event(const Ref<SentryEvent> &p_event) {
-	last_uuid = sentry_uuid_nil();
-	ERR_FAIL_COND_V_MSG(p_event.is_null(), _uuid_as_string(last_uuid), "Sentry: Can't capture event - event object is null.");
+	ERR_FAIL_COND_V_MSG(p_event.is_null(), _uuid_as_string(sentry_uuid_nil()), "Sentry: Can't capture event - event object is null.");
 	NativeEvent *native_event = Object::cast_to<NativeEvent>(p_event.ptr());
-	ERR_FAIL_NULL_V(native_event, _uuid_as_string(last_uuid)); // Sanity check - this should never happen.
+	ERR_FAIL_NULL_V(native_event, _uuid_as_string(sentry_uuid_nil())); // Sanity check - this should never happen.
 	sentry_value_t event = native_event->get_native_value();
 	sentry_value_incref(event); // Keep ownership.
-	last_uuid = sentry_capture_event(event);
-	return _uuid_as_string(last_uuid);
+	sentry_uuid_t uuid = sentry_capture_event(event);
+	last_uuid.store(uuid, std::memory_order_release);
+	return _uuid_as_string(uuid);
 }
 
 void NativeSDK::initialize() {

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -4,13 +4,14 @@
 #include "sentry/internal_sdk.h"
 
 #include <sentry.h>
+#include <atomic>
 
 namespace sentry {
 
 // Internal SDK utilizing sentry-native.
 class NativeSDK : public InternalSDK {
 private:
-	sentry_uuid_t last_uuid;
+	std::atomic<sentry_uuid_t> last_uuid;
 	bool initialized = false;
 
 public:

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -101,7 +101,7 @@ void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 
 Ref<SentryUser> SentrySDK::get_user() const {
 	MutexLock lock(*user_mutex.ptr());
-	return user;
+	return user->duplicate();
 }
 
 void SentrySDK::remove_user() {

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -9,6 +9,7 @@
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/core/mutex_lock.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
 #ifdef NATIVE_SDK
@@ -83,6 +84,8 @@ void SentrySDK::remove_tag(const String &p_key) {
 }
 
 void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
+	MutexLock lock(*user_mutex.ptr());
+
 	user = p_user;
 
 	if (user.is_null()) {
@@ -96,7 +99,13 @@ void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 	}
 }
 
+Ref<SentryUser> SentrySDK::get_user() const {
+	MutexLock lock(*user_mutex.ptr());
+	return user;
+}
+
 void SentrySDK::remove_user() {
+	MutexLock lock(*user_mutex.ptr());
 	user.instantiate();
 	internal_sdk->remove_user();
 }
@@ -195,6 +204,8 @@ void SentrySDK::_bind_methods() {
 SentrySDK::SentrySDK() {
 	ERR_FAIL_NULL(OS::get_singleton());
 	ERR_FAIL_NULL(SentryOptions::get_singleton());
+
+	user_mutex.instantiate();
 
 	singleton = this;
 

--- a/src/sentry_sdk.h
+++ b/src/sentry_sdk.h
@@ -7,6 +7,7 @@
 #include "sentry_event.h"
 #include "sentry_options.h"
 
+#include <godot_cpp/classes/mutex.hpp>
 #include <godot_cpp/core/object.hpp>
 #include <memory>
 
@@ -29,6 +30,7 @@ private:
 	std::shared_ptr<sentry::InternalSDK> internal_sdk;
 	Ref<RuntimeConfig> runtime_config;
 	Ref<SentryUser> user;
+	Ref<Mutex> user_mutex;
 	bool enabled = false;
 	bool configuration_succeeded = false;
 
@@ -58,7 +60,7 @@ public:
 	void remove_tag(const String &p_key);
 
 	void set_user(const Ref<SentryUser> &p_user);
-	Ref<SentryUser> get_user() const { return user; }
+	Ref<SentryUser> get_user() const;
 	void remove_user();
 
 	String capture_message(const String &p_message, sentry::Level p_level = sentry::LEVEL_INFO);

--- a/src/sentry_user.cpp
+++ b/src/sentry_user.cpp
@@ -29,6 +29,16 @@ void SentryUser::generate_new_id() {
 	id = sentry::uuid::make_uuid();
 }
 
+Ref<SentryUser> SentryUser::duplicate() {
+	Ref<SentryUser> copy;
+	copy.instantiate();
+	copy->set_id(id);
+	copy->set_username(username);
+	copy->set_email(email);
+	copy->set_ip_address(ip_address);
+	return copy;
+}
+
 void SentryUser::_bind_methods() {
 	// Setters / getters
 	ClassDB::bind_method(D_METHOD("set_id", "id"), &SentryUser::set_id);
@@ -49,4 +59,5 @@ void SentryUser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("infer_ip_address"), &SentryUser::infer_ip_address);
 	ClassDB::bind_method(D_METHOD("is_empty"), &SentryUser::is_empty);
 	ClassDB::bind_method(D_METHOD("generate_new_id"), &SentryUser::generate_new_id);
+	ClassDB::bind_method(D_METHOD("duplicate"), &SentryUser::duplicate);
 }

--- a/src/sentry_user.h
+++ b/src/sentry_user.h
@@ -38,6 +38,8 @@ public:
 	bool is_empty() const;
 
 	void generate_new_id();
+
+	Ref<SentryUser> duplicate();
 };
 
 #endif // SENTRY_USER_H


### PR DESCRIPTION
* Store last_uuid as atomic
* Synchronize access to SentryUser
* Add test for threaded event capture
* Add `SentryUser.duplicate()`