### PR TITLE
ref: Implement Event.add_exception() to replace capture_error()

### DIFF
--- a/src/sentry/disabled_event.h
+++ b/src/sentry/disabled_event.h
@@ -49,6 +49,8 @@ public:
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
 
+	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) override {}
+
 	virtual bool is_crash() const override { return false; }
 };
 

--- a/src/sentry/disabled_event.h
+++ b/src/sentry/disabled_event.h
@@ -49,7 +49,7 @@ public:
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
 
-	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) override {}
+	virtual void add_exception(const Exception &p_exception) override {}
 
 	virtual bool is_crash() const override { return false; }
 };

--- a/src/sentry/disabled_sdk.h
+++ b/src/sentry/disabled_sdk.h
@@ -22,7 +22,6 @@ class DisabledSDK : public InternalSDK {
 
 	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override { return ""; }
 	virtual String get_last_event_id() override { return ""; }
-	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) override { return ""; }
 
 	virtual Ref<SentryEvent> create_event() override { return memnew(DisabledEvent); }
 	virtual String capture_event(const Ref<SentryEvent> &p_event) override { return ""; }

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -16,16 +16,6 @@ namespace sentry {
 // Interface for SDKs used internally.
 class InternalSDK {
 public:
-	// Represents a frame of a stack trace.
-	struct StackFrame {
-		String filename;
-		String function;
-		int lineno = -1;
-		String context_line;
-		PackedStringArray pre_context;
-		PackedStringArray post_context;
-	};
-
 	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void remove_context(const String &p_key) = 0;
 
@@ -37,12 +27,9 @@ public:
 
 	virtual void add_breadcrumb(const String &p_message, const String &p_category, Level p_level,
 			const String &p_type = "default", const Dictionary &p_data = Dictionary()) = 0;
-	// TODO: Consider adding the following function.
-	// virtual void clear_breadcrumbs() = 0;
 
 	virtual String capture_message(const String &p_message, Level p_level) = 0;
 	virtual String get_last_event_id() = 0;
-	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) = 0;
 
 	virtual Ref<SentryEvent> create_event() = 0;
 	virtual String capture_event(const Ref<SentryEvent> &p_event) = 0;

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -139,14 +139,14 @@ String NativeEvent::get_tag(const String &p_key) {
 	return String();
 }
 
-void NativeEvent::add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) {
-	sentry_value_t exception = sentry_value_new_exception(p_type.utf8(), p_value.utf8());
+void NativeEvent::add_exception(const Exception &p_exception) {
+	sentry_value_t native_exception = sentry_value_new_exception(p_exception.type.utf8(), p_exception.value.utf8());
 	sentry_value_t stack_trace = sentry_value_new_object();
-	sentry_value_set_by_key(exception, "stacktrace", stack_trace);
+	sentry_value_set_by_key(native_exception, "stacktrace", stack_trace);
 	sentry_value_t frames = sentry_value_new_list();
 	sentry_value_set_by_key(stack_trace, "frames", frames);
 
-	for (const StackFrame &frame : p_frames) {
+	for (const StackFrame &frame : p_exception.frames) {
 		sentry_value_t sentry_frame = sentry_value_new_object();
 		sentry_value_set_by_key(sentry_frame, "filename", sentry_value_new_string(frame.filename.utf8()));
 		sentry_value_set_by_key(sentry_frame, "function", sentry_value_new_string(frame.function.utf8()));
@@ -161,7 +161,7 @@ void NativeEvent::add_exception(const String &p_type, const String &p_value, con
 		sentry_value_append(frames, sentry_frame);
 	}
 
-	sentry_event_add_exception(native_event, exception);
+	sentry_event_add_exception(native_event, native_exception);
 }
 
 bool NativeEvent::is_crash() const {

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -48,7 +48,7 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
-	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) override;
+	virtual void add_exception(const Exception &p_exception) override;
 
 	virtual bool is_crash() const override;
 

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -48,6 +48,8 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) override;
+
 	virtual bool is_crash() const override;
 
 	NativeEvent(sentry_value_t p_event, bool p_is_crash);

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -308,35 +308,6 @@ String NativeSDK::get_last_event_id() {
 	return _uuid_as_string(last_uuid);
 }
 
-String NativeSDK::capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) {
-	sentry_value_t event = sentry_value_new_event();
-	sentry_value_set_by_key(event, "level",
-			sentry_value_new_string(sentry::level_as_cstring(p_level)));
-
-	sentry_value_t exception = sentry_value_new_exception(p_type.utf8(), p_value.utf8());
-	sentry_value_t stack_trace = sentry_value_new_object();
-
-	sentry_value_t frames = sentry_value_new_list();
-	for (const StackFrame &frame : p_frames) {
-		sentry_value_t sentry_frame = sentry_value_new_object();
-		sentry_value_set_by_key(sentry_frame, "filename", sentry_value_new_string(frame.filename.utf8()));
-		sentry_value_set_by_key(sentry_frame, "function", sentry_value_new_string(frame.function.utf8()));
-		sentry_value_set_by_key(sentry_frame, "lineno", sentry_value_new_int32(frame.lineno));
-		if (!frame.context_line.is_empty()) {
-			sentry_value_set_by_key(sentry_frame, "context_line", sentry_value_new_string(frame.context_line.utf8()));
-			sentry_value_set_by_key(sentry_frame, "pre_context", sentry::native::strings_to_sentry_list(frame.pre_context));
-			sentry_value_set_by_key(sentry_frame, "post_context", sentry::native::strings_to_sentry_list(frame.post_context));
-		}
-		sentry_value_append(frames, sentry_frame);
-	}
-
-	sentry_value_set_by_key(stack_trace, "frames", frames);
-	sentry_value_set_by_key(exception, "stacktrace", stack_trace);
-	sentry_event_add_exception(event, exception);
-	last_uuid = sentry_capture_event(event);
-	return _uuid_as_string(last_uuid);
-}
-
 Ref<SentryEvent> NativeSDK::create_event() {
 	sentry_value_t event_value = sentry_value_new_event();
 	Ref<SentryEvent> event = memnew(NativeEvent(event_value, false));

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -28,7 +28,6 @@ public:
 
 	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
-	virtual String capture_error(const String &p_type, const String &p_value, Level p_level, const Vector<StackFrame> &p_frames) override;
 
 	virtual Ref<SentryEvent> create_event() override;
 	virtual String capture_event(const Ref<SentryEvent> &p_event) override;

--- a/src/sentry_event.h
+++ b/src/sentry_event.h
@@ -26,6 +26,12 @@ public:
 		PackedStringArray post_context;
 	};
 
+	struct Exception {
+		String type;
+		String value;
+		Vector<StackFrame> frames;
+	};
+
 protected:
 	static void _bind_methods();
 
@@ -59,7 +65,7 @@ public:
 	virtual void remove_tag(const String &p_key) = 0;
 	virtual String get_tag(const String &p_key) = 0;
 
-	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) = 0;
+	virtual void add_exception(const Exception &p_exception) = 0;
 
 	virtual bool is_crash() const = 0;
 

--- a/src/sentry_event.h
+++ b/src/sentry_event.h
@@ -4,6 +4,7 @@
 #include "sentry/level.h"
 
 #include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/templates/pair.hpp>
 #include <godot_cpp/variant/string.hpp>
 
 using namespace godot;
@@ -11,6 +12,19 @@ using namespace godot;
 // Base class for event objects in the public API.
 class SentryEvent : public RefCounted {
 	GDCLASS(SentryEvent, RefCounted);
+
+public:
+	// Represents a frame of a stack trace.
+	struct StackFrame {
+		String filename;
+		String function;
+		int lineno = -1;
+		bool in_app = true;
+		String platform;
+		String context_line;
+		PackedStringArray pre_context;
+		PackedStringArray post_context;
+	};
 
 protected:
 	static void _bind_methods();
@@ -44,6 +58,8 @@ public:
 	virtual void set_tag(const String &p_key, const String &p_value) = 0;
 	virtual void remove_tag(const String &p_key) = 0;
 	virtual String get_tag(const String &p_key) = 0;
+
+	virtual void add_exception(const String &p_type, const String &p_value, const Vector<StackFrame> &p_frames) = 0;
 
 	virtual bool is_crash() const = 0;
 

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -183,7 +183,7 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 
 		Ref<SentryEvent> ev = SentrySDK::get_singleton()->create_event();
 		ev->set_level(sentry::get_sentry_level_for_godot_error_type(p_error_type));
-		ev->add_exception(error_types[int(p_error_type)], p_rationale, { stack_frame });
+		ev->add_exception({ error_types[int(p_error_type)], p_rationale, { stack_frame } });
 		SentrySDK::get_singleton()->capture_event(ev);
 
 		// For throttling

--- a/src/sentry_logger.cpp
+++ b/src/sentry_logger.cpp
@@ -159,7 +159,13 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 
 	// Capture error as event.
 	if (as_event) {
-		sentry::InternalSDK::StackFrame stack_frame{ p_file, p_func, p_line };
+		SentryEvent::StackFrame stack_frame{
+			p_file,
+			p_func,
+			p_line,
+			true, // in_app
+			"godot" // platform
+		};
 
 		// Provide script source code context for script errors if available.
 		if (p_error_type == GodotErrorType::ERROR_TYPE_SCRIPT && SentryOptions::get_singleton()->is_logger_include_source_enabled()) {
@@ -175,11 +181,10 @@ void SentryLogger::_log_error(const char *p_func, const char *p_file, int p_line
 			}
 		}
 
-		SentrySDK::get_singleton()->get_internal_sdk()->capture_error(
-				error_types[int(p_error_type)],
-				p_rationale,
-				sentry::get_sentry_level_for_godot_error_type(p_error_type),
-				{ stack_frame });
+		Ref<SentryEvent> ev = SentrySDK::get_singleton()->create_event();
+		ev->set_level(sentry::get_sentry_level_for_godot_error_type(p_error_type));
+		ev->add_exception(error_types[int(p_error_type)], p_rationale, { stack_frame });
+		SentrySDK::get_singleton()->capture_event(ev);
 
 		// For throttling
 		frame_events++;


### PR DESCRIPTION
This is needed for both godot-4.5 branch and android.

#skip-changelog since it's a pure refactor