### PR TITLE
fix: Filter out expected missing attachment warnings

### DIFF
--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -17,6 +17,7 @@
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
+#include <regex>
 
 #ifdef DEBUG_ENABLED
 #include <godot_cpp/classes/time.hpp>
@@ -220,6 +221,14 @@ void _log_native_message(sentry_level_t level, const char *message, va_list args
 		}
 	}
 	va_end(args_copy);
+
+	// Filter out warnings about missing attachment files that may not exist in some scenarios.
+	static auto pattern = std::regex{
+		R"(^failed to read envelope item from \".*(screenshot\.jpg|view-hierarchy\.json)\")"
+	};
+	if (std::regex_search(std::string(buffer), pattern)) {
+		return;
+	}
 
 	sentry::util::print(sentry::native::native_to_level(level), String(buffer));
 


### PR DESCRIPTION
Remove messages from logging related to missing `screenshot.jpg` and `view-hierarchy.json` attachments. They are expected to be missing in some scenarios.