### PR TITLE
fix: Ensure crashpad_handler has executable permissions on Unix exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- Ensure crashpad_handler has executable permissions on Unix exports ([#207](https://github.com/getsentry/sentry-godot/pull/207))
+
 ### Dependencies
 
 - Bump gdUnit 4 from v5.0.0 to v5.0.4 ([#193](https://github.com/getsentry/sentry-godot/pull/193), [#197](https://github.com/getsentry/sentry-godot/pull/197))

--- a/SConstruct
+++ b/SConstruct
@@ -218,6 +218,7 @@ env.Append(CPPPATH=["src/"])
 
 # Source files to compile.
 sources = Glob("src/*.cpp")
+sources += Glob("src/editor/*.cpp")
 sources += Glob("src/sentry/*.cpp")
 sources += Glob("src/sentry/util/*.cpp")
 # Compile sentry-native code only on respective platforms.

--- a/src/editor/sentry_editor_export_plugin_unix.cpp
+++ b/src/editor/sentry_editor_export_plugin_unix.cpp
@@ -15,17 +15,12 @@ void _set_executable_permissions(const String &p_path) {
 	}
 
 	BitField<FileAccess::UnixPermissionFlags> perm = FileAccess::get_unix_permissions(p_path);
-	BitField<FileAccess::UnixPermissionFlags> new_perm = perm;
 
-	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_OWNER)) {
-		new_perm.set_flag(FileAccess::UNIX_EXECUTE_OWNER);
-	}
-	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_GROUP)) {
-		new_perm.set_flag(FileAccess::UNIX_EXECUTE_GROUP);
-	}
-	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_OTHER)) {
-		new_perm.set_flag(FileAccess::UNIX_EXECUTE_OTHER);
-	}
+	// Permissions for executable files should be set to 755.
+	BitField<FileAccess::UnixPermissionFlags> new_perm =
+			FileAccess::UNIX_READ_OWNER | FileAccess::UNIX_WRITE_OWNER | FileAccess::UNIX_EXECUTE_OWNER |
+			FileAccess::UNIX_READ_GROUP | FileAccess::UNIX_EXECUTE_GROUP |
+			FileAccess::UNIX_READ_OTHER | FileAccess::UNIX_EXECUTE_OTHER;
 
 	if (perm != new_perm) {
 		Error err = FileAccess::set_unix_permissions(p_path, new_perm);

--- a/src/editor/sentry_editor_export_plugin_unix.cpp
+++ b/src/editor/sentry_editor_export_plugin_unix.cpp
@@ -1,0 +1,89 @@
+#include "sentry_editor_export_plugin_unix.h"
+
+#if defined(TOOLS_ENABLED) && !defined(WINDOWS_ENABLED)
+
+#include "sentry/util/print.h"
+
+#include <godot_cpp/classes/dir_access.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+
+namespace {
+
+void _set_executable_permissions(const String &p_path) {
+	if (!FileAccess::file_exists(p_path)) {
+		return;
+	}
+
+	BitField<FileAccess::UnixPermissionFlags> perm = FileAccess::get_unix_permissions(p_path);
+	BitField<FileAccess::UnixPermissionFlags> new_perm = perm;
+
+	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_OWNER)) {
+		new_perm.set_flag(FileAccess::UNIX_EXECUTE_OWNER);
+	}
+	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_GROUP)) {
+		new_perm.set_flag(FileAccess::UNIX_EXECUTE_GROUP);
+	}
+	if (!perm.has_flag(FileAccess::UNIX_EXECUTE_OTHER)) {
+		new_perm.set_flag(FileAccess::UNIX_EXECUTE_OTHER);
+	}
+
+	if (perm != new_perm) {
+		Error err = FileAccess::set_unix_permissions(p_path, new_perm);
+		if (err != OK && err != ERR_UNAVAILABLE) {
+			sentry::util::print_warning("Failed to set executable permissions for: " + p_path);
+		}
+	}
+}
+
+void _find_and_fix_crashpad_handler(const String &p_path) {
+	List<String> dirs_to_process;
+	dirs_to_process.push_back(FileAccess::file_exists(p_path) ? p_path.get_base_dir() : p_path);
+
+	while (!dirs_to_process.is_empty()) {
+		String work_dir = dirs_to_process.back()->get();
+		dirs_to_process.pop_back();
+
+		Ref<DirAccess> da = DirAccess::open(work_dir);
+		if (da.is_null()) {
+			continue;
+		}
+
+		da->list_dir_begin();
+
+		String file = da->get_next();
+		while (!file.is_empty()) {
+			String full_path = work_dir.path_join(file);
+
+			if (da->current_is_dir() && file != "." && file != "..") {
+				// Add subdirectory to be processed
+				dirs_to_process.push_back(full_path);
+			} else if (file == "crashpad_handler") {
+				_set_executable_permissions(full_path);
+			}
+
+			file = da->get_next();
+		}
+		da->list_dir_end();
+	}
+}
+
+} // unnamed namespace
+
+String SentryEditorExportPluginUnix::_get_name() const {
+	return "SentryEditorExportPluginUnix";
+}
+
+bool SentryEditorExportPluginUnix::_supports_platform(const Ref<EditorExportPlatform> &p_platform) const {
+	return p_platform->get_os_name() != "Windows";
+}
+
+void SentryEditorExportPluginUnix::_export_begin(const PackedStringArray &p_features, bool p_is_debug, const String &p_path, uint32_t p_flags) {
+	export_path = p_path;
+}
+
+void SentryEditorExportPluginUnix::_export_end() {
+	// Fix crashpad handler executable permissions on Unix platforms.
+	_find_and_fix_crashpad_handler(export_path);
+}
+
+#endif // TOOLS_ENABLED && !WINDOWS_ENABLED

--- a/src/editor/sentry_editor_export_plugin_unix.h
+++ b/src/editor/sentry_editor_export_plugin_unix.h
@@ -1,0 +1,29 @@
+#ifndef SENTRY_EDITOR_EXPORT_PLUGIN_UNIX_H
+#define SENTRY_EDITOR_EXPORT_PLUGIN_UNIX_H
+
+#if defined(TOOLS_ENABLED) && !defined(WINDOWS_ENABLED)
+
+#include <godot_cpp/classes/editor_export_platform.hpp>
+#include <godot_cpp/classes/editor_export_plugin.hpp>
+
+using namespace godot;
+
+class SentryEditorExportPluginUnix : public EditorExportPlugin {
+	GDCLASS(SentryEditorExportPluginUnix, EditorExportPlugin);
+
+private:
+	String export_path;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual String _get_name() const override;
+	virtual bool _supports_platform(const Ref<EditorExportPlatform> &p_platform) const override;
+	virtual void _export_begin(const PackedStringArray &p_features, bool p_is_debug, const String &p_path, uint32_t p_flags) override;
+	virtual void _export_end() override;
+};
+
+#endif // # TOOLS_ENABLED && !WINDOWS_ENABLED
+
+#endif // SENTRY_EDITOR_EXPORT_PLUGIN_UNIX_H

--- a/src/editor/sentry_editor_plugin.cpp
+++ b/src/editor/sentry_editor_plugin.cpp
@@ -1,0 +1,31 @@
+#include "sentry_editor_plugin.h"
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/sentry_editor_export_plugin_unix.h"
+
+#include "sentry/util/print.h"
+
+void SentryEditorPlugin::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+#ifndef WINDOWS_ENABLED
+			if (unix_export_plugin.is_null()) {
+				unix_export_plugin = Ref(memnew(SentryEditorExportPluginUnix));
+			}
+			sentry::util::print_debug("adding export plugin");
+			add_export_plugin(unix_export_plugin);
+#endif
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+#ifndef WINDOWS_ENABLED
+			if (unix_export_plugin.is_valid()) {
+				remove_export_plugin(unix_export_plugin);
+				unix_export_plugin.unref();
+			}
+#endif
+		} break;
+	}
+}
+
+#endif // TOOLS_ENABLED

--- a/src/editor/sentry_editor_plugin.h
+++ b/src/editor/sentry_editor_plugin.h
@@ -1,0 +1,26 @@
+#ifndef SENTRY_EDITOR_PLUGIN_H
+#define SENTRY_EDITOR_PLUGIN_H
+
+#ifdef TOOLS_ENABLED
+
+#include <godot_cpp/classes/editor_export_plugin.hpp>
+#include <godot_cpp/classes/editor_plugin.hpp>
+
+using namespace godot;
+
+class SentryEditorPlugin : public EditorPlugin {
+	GDCLASS(SentryEditorPlugin, EditorPlugin);
+
+private:
+	Ref<EditorExportPlugin> unix_export_plugin;
+
+protected:
+	static void _bind_methods() {}
+	void _notification(int p_what);
+
+public:
+};
+
+#endif // TOOLS_ENABLED
+
+#endif // SENTRY_EDITOR_PLUGIN_H

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,3 +1,5 @@
+#include "editor/sentry_editor_export_plugin_unix.h"
+#include "editor/sentry_editor_plugin.h"
 #include "runtime_config.h"
 #include "sentry/disabled_event.h"
 #include "sentry/util/print.h"
@@ -65,6 +67,14 @@ void initialize_module(ModuleInitializationLevel p_level) {
 		Engine::get_singleton()->register_singleton("SentrySDK", SentrySDK::get_singleton());
 
 		callable_mp_static(_init_logger).call_deferred();
+	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+#ifdef TOOLS_ENABLED
+#ifndef WINDOWS_ENABLED
+		GDREGISTER_INTERNAL_CLASS(SentryEditorExportPluginUnix);
+#endif // !WINDOWS_ENABLED
+		GDREGISTER_INTERNAL_CLASS(SentryEditorPlugin);
+		EditorPlugins::add_by_type<SentryEditorPlugin>();
+#endif // TOOLS_ENABLED
 	}
 }
 


### PR DESCRIPTION
Add editor export plugin to automatically set executable permissions for crashpad_handler binary on Unix platforms after project export. This prevents runtime failure to launch handler on Unix platforms.

- The problem manifests mainly on macOS and Linux, where crashpad_handler loses executable permissions on exporting Linux builds.
- The fix is not needed on Windows as in my tests exporting to a ZIP archive works just fine, preserving the necessary executable permissions.
- Plugin now autofixes permissions automatically on project export on Unix platforms.
- Exporting ZIP files for Linux also preserves permissions (tested on macOS).
- The fix is also applied to APP bundles, and zipped APP bundles, just in case. It may not be necessary, but we have a previous report that suggests maybe leaving it in place for the time being.

Issues:
- Resolves #206  
- Resolves #110