### PR TITLE
fix: Don't add device and app contexts on Android

### DIFF
--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -113,6 +113,7 @@ Dictionary make_device_context_update() {
 
 	const Dictionary &meminfo = OS::get_singleton()->get_memory_info();
 	// NOTE: Using double since int32 can't handle size in bytes.
+	//       On some platforms, memory info may not be available (-1).
 	int64_t free_memory = meminfo["free"];
 	if (free_memory >= 0) {
 		device_context["free_memory"] = double(free_memory);

--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -112,9 +112,15 @@ Dictionary make_device_context_update() {
 	device_context["orientation"] = _screen_orientation_as_string(primary_screen);
 
 	const Dictionary &meminfo = OS::get_singleton()->get_memory_info();
-	// Note: Using double since int32 can't handle size in bytes.
-	device_context["free_memory"] = double(meminfo["free"]);
-	device_context["usable_memory"] = double(meminfo["available"]);
+	// NOTE: Using double since int32 can't handle size in bytes.
+	int64_t free_memory = meminfo["free"];
+	if (free_memory >= 0) {
+		device_context["free_memory"] = double(free_memory);
+	}
+	int64_t available_memory = meminfo["available"];
+	if (available_memory >= 0) {
+		device_context["usable_memory"] = double(available_memory);
+	}
 
 	auto dir = DirAccess::open("user://");
 	if (dir.is_valid()) {
@@ -342,7 +348,11 @@ Dictionary make_performance_context() {
 HashMap<String, Dictionary> make_event_contexts() {
 	HashMap<String, Dictionary> event_contexts;
 	event_contexts["godot_performance"] = make_performance_context();
+
+#ifdef NATIVE_SDK
 	event_contexts["device"] = make_device_context_update();
+#endif
+
 	return event_contexts;
 }
 

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -121,10 +121,14 @@ void SentrySDK::set_context(const godot::String &p_key, const godot::Dictionary 
 
 void SentrySDK::_init_contexts() {
 	sentry::util::print_debug("initializing contexts");
+
+#ifdef NATIVE_SDK
 	internal_sdk->set_context("device", sentry::contexts::make_device_context(runtime_config));
 	internal_sdk->set_context("app", sentry::contexts::make_app_context());
-	internal_sdk->set_context("gpu", sentry::contexts::make_gpu_context());
+#endif
+
 	internal_sdk->set_context("culture", sentry::contexts::make_culture_context());
+	internal_sdk->set_context("gpu", sentry::contexts::make_gpu_context());
 
 	// Custom contexts.
 	internal_sdk->set_context("display", sentry::contexts::make_display_context());


### PR DESCRIPTION
* Don't add device and app contexts on Android since those are handled by the Android SDK.
* Fix device memory info can contain invalid values on some platforms.

#skip-changelog since we didn't release with this issue

