### PR TITLE
ci: Fix isolated tests routine executed for .uid files

### DIFF
--- a/scripts/run-isolated-tests.ps1
+++ b/scripts/run-isolated-tests.ps1
@@ -30,7 +30,7 @@ $exitCode = 0
 $numFailed = 0
 $numPassed = 0
 
-Get-ChildItem -Path "test/isolated" -Filter "test_*" | ForEach-Object {
+Get-ChildItem -Path "test/isolated" -Filter "test_*.gd" | ForEach-Object {
     $file = $_.FullName
     Highlight "Running isolated test: $file"
 
@@ -38,7 +38,7 @@ Get-ChildItem -Path "test/isolated" -Filter "test_*" | ForEach-Object {
     $process = Start-Process $godot -ArgumentList $args -PassThru -Wait -NoNewWindow
     $err = $process.ExitCode
 
-    Highlight "Finished with exit code: $err" 
+    Highlight "Finished with exit code: $err"
 
     if ($err -ne 0) {
         $exitCode = $err


### PR DESCRIPTION
Starting with Godot 4.4, additional files are created for each script, and it happens that our routine executes for those files as well.

#skip-changelog

<img width="299" alt="Screenshot 2025-06-27 at 16 24 16" src="https://github.com/user-attachments/assets/b66ff795-78cc-48b9-8760-d36066f9ebf1" />

