### PR TITLE
feat: Add 32-bit targets for Windows and Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -118,55 +118,55 @@ env.Append(CPPPATH=["src/"])
 
 # Include sentry-native libs (static).
 if env["platform"] in ["linux", "macos", "windows"]:
-    env.Append(CPPDEFINES=["SENTRY_BUILD_STATIC", "NATIVE_SDK"])
-    env.Append(CPPPATH=["modules/sentry-native/include"])
-    env.Append(LIBPATH=["modules/sentry-native/install/lib/"])
+    # env.Append(CPPDEFINES=["SENTRY_BUILD_STATIC", "NATIVE_SDK"])
+    # env.Append(CPPPATH=["modules/sentry-native/include"])
+    # env.Append(LIBPATH=["modules/sentry-native/install/lib/"])
 
-    sn_targets = []
-    sn_sources = ["modules/sentry-native/src/"]
+    # sn_targets = []
+    # sn_sources = ["modules/sentry-native/src/"]
 
-    def add_target(lib_name):
-        env.Append(LIBS=[lib_name])
-        if env["platform"] == "windows":
-            sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".lib")
-            sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".pdb")
-        else:
-            sn_targets.append("modules/sentry-native/install/lib/lib" + lib_name + ".a")
+    # def add_target(lib_name):
+    #     env.Append(LIBS=[lib_name])
+    #     if env["platform"] == "windows":
+    #         sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".lib")
+    #         sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".pdb")
+    #     else:
+    #         sn_targets.append("modules/sentry-native/install/lib/lib" + lib_name + ".a")
 
-    add_target("sentry")
-    add_target("crashpad_client")
-    add_target("crashpad_handler_lib")
-    add_target("crashpad_minidump")
-    add_target("crashpad_snapshot")
-    add_target("crashpad_tools")
-    add_target("crashpad_util")
-    add_target("mini_chromium")
+    # add_target("sentry")
+    # add_target("crashpad_client")
+    # add_target("crashpad_handler_lib")
+    # add_target("crashpad_minidump")
+    # add_target("crashpad_snapshot")
+    # add_target("crashpad_tools")
+    # add_target("crashpad_util")
+    # add_target("mini_chromium")
 
-    # Include additional platform-specific libs.
-    if env["platform"] == "windows":
-        add_target("crashpad_compat")
-        env.Append(
-            LIBS=[
-                "winhttp",
-                "advapi32",
-                "DbgHelp",
-                "Version",
-            ]
-        )
-    elif env["platform"] == "linux":
-        add_target("crashpad_compat")
-        env.Append(
-            LIBS=[
-                "curl",
-                "atomic"
-            ]
-        )
-    elif env["platform"] == "macos":
-        env.Append(
-            LIBS=[
-                "curl",
-            ]
-        )
+    # # Include additional platform-specific libs.
+    # if env["platform"] == "windows":
+    #     add_target("crashpad_compat")
+    #     env.Append(
+    #         LIBS=[
+    #             "winhttp",
+    #             "advapi32",
+    #             "DbgHelp",
+    #             "Version",
+    #         ]
+    #     )
+    # elif env["platform"] == "linux":
+    #     add_target("crashpad_compat")
+    #     env.Append(
+    #         LIBS=[
+    #             "curl",
+    #             "atomic"
+    #         ]
+    #     )
+    # elif env["platform"] == "macos":
+    #     env.Append(
+    #         LIBS=[
+    #             "curl",
+    #         ]
+    #     )
 
     build_actions = []
     dest_dir = BIN_DIR + "/" + env["platform"]
@@ -177,18 +177,18 @@ if env["platform"] in ["linux", "macos", "windows"]:
         # ),
         build_actions.append(
             Copy(
-                dest_dir + "/crashpad_handler.exe",
-                "modules/sentry-native/install/bin/crashpad_handler.exe",
+                env.File(f"{dest_dir}/crashpad_handler.exe"),
+                env.File("modules/sentry-native/install/bin/crashpad_handler.exe"),
             )
         )
         build_actions.append(
             Copy(
-                dest_dir + "/crashpad_handler.pdb",
-                "modules/sentry-native/install/bin/crashpad_handler.pdb",
+                env.File(f"{dest_dir}/crashpad_handler.pdb"),
+                env.File("modules/sentry-native/install/bin/crashpad_handler.pdb"),
             )
         )
-        sn_targets.append(dest_dir + "/crashpad_handler.exe")
-        sn_targets.append(dest_dir + "/crashpad_handler.pdb")
+        # sn_targets.append(dest_dir + "/crashpad_handler.exe")
+        # sn_targets.append(dest_dir + "/crashpad_handler.pdb")
     else:
         # TODO: macOS needs to use a different SDK.
         # build_actions.append(
@@ -203,7 +203,7 @@ if env["platform"] in ["linux", "macos", "windows"]:
                 "modules/sentry-native/install/bin/crashpad_handler",
             )
         )
-        sn_targets.append(dest_dir + "/crashpad_handler")
+        # sn_targets.append(dest_dir + "/crashpad_handler")
 
     # sentry_native = env.Command(sn_targets, sn_sources, build_actions)
 
@@ -214,7 +214,7 @@ if env["platform"] in ["linux", "macos", "windows"]:
     # Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
 
 # Build sentry-native
-SConscript("modules/SConstruct", exports=["env"])
+env = SConscript("modules/SConstruct", exports=["env"])
 
 
 # *** Build GDExtension library.

--- a/SConstruct
+++ b/SConstruct
@@ -53,168 +53,45 @@ with open("src/gen/sdk_version.gen.h", "w") as f:
 print("Reading godot-cpp build configuration...")
 env = SConscript("modules/godot-cpp/SConstruct")
 
+platform = env["platform"] 
 
 # *** Build sentry-native.
 
-# Sentry-native is now built via modules/SConstruct
-# TODO: macOS needs to use a different SDK.
-# if env["platform"] in ["linux", "macos"]:
-
-#     def build_sentry_native(target, source, env):
-#         result = subprocess.run(
-#             ["sh", "scripts/build-sentry-native.sh"],
-#             check=True,
-#         )
-#         return result.returncode
-
-#     crashpad_handler_target = "{bin}/{platform}/crashpad_handler".format(
-#         bin=BIN_DIR,
-#         platform=env["platform"]
-#     )
-#     sentry_native = env.Command(
-#         [
-#             "modules/sentry-native/install/lib/libsentry.a",
-#             crashpad_handler_target,
-#         ],
-#         ["modules/sentry-native/src"],
-#         [
-#             build_sentry_native,
-#             Copy(
-#                 crashpad_handler_target,
-#                 "modules/sentry-native/install/bin/crashpad_handler",
-#             ),
-#         ],
-#     )
-# elif env["platform"] == "windows":
-
-#     def build_sentry_native(target, source, env):
-#         result = subprocess.run(
-#             ["powershell", "scripts/build-sentry-native.ps1"],
-#             check=True,
-#         )
-#         return result.returncode
-
-#     sentry_native = env.Command(
-#         ["modules/sentry-native/install/lib/sentry.lib",
-#             BIN_DIR + "/windows/crashpad_handler.exe"],
-#         ["modules/sentry-native/src/"],
-#         [
-#             build_sentry_native,
-#             Copy(
-#                 BIN_DIR + "/windows/crashpad_handler.exe",
-#                 "modules/sentry-native/install/bin/crashpad_handler.exe",
-#             ),
-#         ],
-#     )
-
-# if env["platform"] in ["linux", "macos", "windows"]:
-#     # Force sentry-native to be built sequential to godot-cpp (not in parallel)
-#     Depends(sentry_native, "modules/godot-cpp")
-#     Default(sentry_native)
-#     Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
-
-# Include relative to project source root.
-env.Append(CPPPATH=["src/"])
-
 # Include sentry-native libs (static).
-if env["platform"] in ["linux", "macos", "windows"]:
-    # env.Append(CPPDEFINES=["SENTRY_BUILD_STATIC", "NATIVE_SDK"])
-    # env.Append(CPPPATH=["modules/sentry-native/include"])
-    # env.Append(LIBPATH=["modules/sentry-native/install/lib/"])
+if platform in ["linux", "macos", "windows"]:
+    # Build sentry-native.
+    env = SConscript("modules/SConstruct", exports=["env"])
 
-    # sn_targets = []
-    # sn_sources = ["modules/sentry-native/src/"]
+    # Copy crashpad handler to project directory.
+    sn_actions = []
+    sn_targets = []
+    sn_sources = []
 
-    # def add_target(lib_name):
-    #     env.Append(LIBS=[lib_name])
-    #     if env["platform"] == "windows":
-    #         sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".lib")
-    #         sn_targets.append("modules/sentry-native/install/lib/" + lib_name + ".pdb")
-    #     else:
-    #         sn_targets.append("modules/sentry-native/install/lib/lib" + lib_name + ".a")
+    def copy_file_action(target_file, source_file):
+        sn_actions.append(Copy(target_file, source_file))
+        sn_targets.append(target_file)
+        sn_sources.append(source_file)
 
-    # add_target("sentry")
-    # add_target("crashpad_client")
-    # add_target("crashpad_handler_lib")
-    # add_target("crashpad_minidump")
-    # add_target("crashpad_snapshot")
-    # add_target("crashpad_tools")
-    # add_target("crashpad_util")
-    # add_target("mini_chromium")
+    target_dir = BIN_DIR + "/" + env["platform"]
+    source_dir = "modules/sentry-native/install/bin"
 
-    # # Include additional platform-specific libs.
-    # if env["platform"] == "windows":
-    #     add_target("crashpad_compat")
-    #     env.Append(
-    #         LIBS=[
-    #             "winhttp",
-    #             "advapi32",
-    #             "DbgHelp",
-    #             "Version",
-    #         ]
-    #     )
-    # elif env["platform"] == "linux":
-    #     add_target("crashpad_compat")
-    #     env.Append(
-    #         LIBS=[
-    #             "curl",
-    #             "atomic"
-    #         ]
-    #     )
-    # elif env["platform"] == "macos":
-    #     env.Append(
-    #         LIBS=[
-    #             "curl",
-    #         ]
-    #     )
-
-    build_actions = []
-    dest_dir = BIN_DIR + "/" + env["platform"]
-
-    if env["platform"] == "windows":
-        # build_actions.append(
-        #     partial(run_cmd, args=["powershell", "scripts/build-sentry-native.ps1"])
-        # ),
-        build_actions.append(
-            Copy(
-                env.File(f"{dest_dir}/crashpad_handler.exe"),
-                env.File("modules/sentry-native/install/bin/crashpad_handler.exe"),
-            )
+    if platform == "windows":
+        copy_file_action(
+            File(f"{target_dir}/crashpad_handler.exe"),
+            File(f"{source_dir}/crashpad_handler.exe")
         )
-        build_actions.append(
-            Copy(
-                env.File(f"{dest_dir}/crashpad_handler.pdb"),
-                env.File("modules/sentry-native/install/bin/crashpad_handler.pdb"),
-            )
+        copy_file_action(
+            File(f"{target_dir}/crashpad_handler.pdb"),
+            File(f"{source_dir}/crashpad_handler.pdb")
         )
-        # sn_targets.append(dest_dir + "/crashpad_handler.exe")
-        # sn_targets.append(dest_dir + "/crashpad_handler.pdb")
     else:
-        # TODO: macOS needs to use a different SDK.
-        # build_actions.append(
-        #     partial(run_cmd, args=[
-        #         "sh", "scripts/build-sentry-native.sh",
-        #         "--macos-deployment-target", env["macos_deployment_target"]
-        #     ])
-        # ),
-        build_actions.append(
-            Copy(
-                dest_dir + "/crashpad_handler",
-                "modules/sentry-native/install/bin/crashpad_handler",
-            )
+        copy_file_action(
+            File(f"{target_dir}/crashpad_handler"),
+            File(f"{source_dir}/crashpad_handler")
         )
-        # sn_targets.append(dest_dir + "/crashpad_handler")
 
-    # sentry_native = env.Command(sn_targets, sn_sources, build_actions)
-
-    # Force sentry-native to be built sequential to godot-cpp (not in parallel).
-    # Depends(sentry_native, "modules/godot-cpp")
-
-    # Default(sentry_native)
-    # Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
-
-# Build sentry-native
-env = SConscript("modules/SConstruct", exports=["env"])
+    deploy_crashpad_handler = env.Command(sn_targets, sn_sources, sn_actions)
+    Default(deploy_crashpad_handler)
 
 
 # *** Build GDExtension library.

--- a/SConstruct
+++ b/SConstruct
@@ -62,35 +62,9 @@ if platform in ["linux", "macos", "windows"]:
     # Build sentry-native.
     env = SConscript("modules/SConstruct", exports=["env"])
 
-    # Copy crashpad handler to project directory.
-    sn_actions = []
-    sn_targets = []
-    sn_sources = []
-
-    def copy_file_action(target_file, source_file):
-        sn_actions.append(Copy(target_file, source_file))
-        sn_targets.append(target_file)
-        sn_sources.append(source_file)
-
-    target_dir = BIN_DIR + "/" + env["platform"]
-    source_dir = "modules/sentry-native/install/bin"
-
-    if platform == "windows":
-        copy_file_action(
-            File(f"{target_dir}/crashpad_handler.exe"),
-            File(f"{source_dir}/crashpad_handler.exe")
-        )
-        copy_file_action(
-            File(f"{target_dir}/crashpad_handler.pdb"),
-            File(f"{source_dir}/crashpad_handler.pdb")
-        )
-    else:
-        copy_file_action(
-            File(f"{target_dir}/crashpad_handler"),
-            File(f"{source_dir}/crashpad_handler")
-        )
-
-    deploy_crashpad_handler = env.Command(sn_targets, sn_sources, sn_actions)
+    # Deploy crashpad handler to project directory.
+    target_dir = Dir(BIN_DIR + "/" + platform)
+    deploy_crashpad_handler = env.CopyCrashpadHandler(target_dir)
     Default(deploy_crashpad_handler)
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -56,61 +56,62 @@ env = SConscript("modules/godot-cpp/SConstruct")
 
 # *** Build sentry-native.
 
+# Sentry-native is now built via modules/SConstruct
 # TODO: macOS needs to use a different SDK.
-if env["platform"] in ["linux", "macos"]:
+# if env["platform"] in ["linux", "macos"]:
 
-    def build_sentry_native(target, source, env):
-        result = subprocess.run(
-            ["sh", "scripts/build-sentry-native.sh"],
-            check=True,
-        )
-        return result.returncode
+#     def build_sentry_native(target, source, env):
+#         result = subprocess.run(
+#             ["sh", "scripts/build-sentry-native.sh"],
+#             check=True,
+#         )
+#         return result.returncode
 
-    crashpad_handler_target = "{bin}/{platform}/crashpad_handler".format(
-        bin=BIN_DIR,
-        platform=env["platform"]
-    )
-    sentry_native = env.Command(
-        [
-            "modules/sentry-native/install/lib/libsentry.a",
-            crashpad_handler_target,
-        ],
-        ["modules/sentry-native/src"],
-        [
-            build_sentry_native,
-            Copy(
-                crashpad_handler_target,
-                "modules/sentry-native/install/bin/crashpad_handler",
-            ),
-        ],
-    )
-elif env["platform"] == "windows":
+#     crashpad_handler_target = "{bin}/{platform}/crashpad_handler".format(
+#         bin=BIN_DIR,
+#         platform=env["platform"]
+#     )
+#     sentry_native = env.Command(
+#         [
+#             "modules/sentry-native/install/lib/libsentry.a",
+#             crashpad_handler_target,
+#         ],
+#         ["modules/sentry-native/src"],
+#         [
+#             build_sentry_native,
+#             Copy(
+#                 crashpad_handler_target,
+#                 "modules/sentry-native/install/bin/crashpad_handler",
+#             ),
+#         ],
+#     )
+# elif env["platform"] == "windows":
 
-    def build_sentry_native(target, source, env):
-        result = subprocess.run(
-            ["powershell", "scripts/build-sentry-native.ps1"],
-            check=True,
-        )
-        return result.returncode
+#     def build_sentry_native(target, source, env):
+#         result = subprocess.run(
+#             ["powershell", "scripts/build-sentry-native.ps1"],
+#             check=True,
+#         )
+#         return result.returncode
 
-    sentry_native = env.Command(
-        ["modules/sentry-native/install/lib/sentry.lib",
-            BIN_DIR + "/windows/crashpad_handler.exe"],
-        ["modules/sentry-native/src/"],
-        [
-            build_sentry_native,
-            Copy(
-                BIN_DIR + "/windows/crashpad_handler.exe",
-                "modules/sentry-native/install/bin/crashpad_handler.exe",
-            ),
-        ],
-    )
+#     sentry_native = env.Command(
+#         ["modules/sentry-native/install/lib/sentry.lib",
+#             BIN_DIR + "/windows/crashpad_handler.exe"],
+#         ["modules/sentry-native/src/"],
+#         [
+#             build_sentry_native,
+#             Copy(
+#                 BIN_DIR + "/windows/crashpad_handler.exe",
+#                 "modules/sentry-native/install/bin/crashpad_handler.exe",
+#             ),
+#         ],
+#     )
 
-if env["platform"] in ["linux", "macos", "windows"]:
-    # Force sentry-native to be built sequential to godot-cpp (not in parallel)
-    Depends(sentry_native, "modules/godot-cpp")
-    Default(sentry_native)
-    Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
+# if env["platform"] in ["linux", "macos", "windows"]:
+#     # Force sentry-native to be built sequential to godot-cpp (not in parallel)
+#     Depends(sentry_native, "modules/godot-cpp")
+#     Default(sentry_native)
+#     Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
 
 # Include relative to project source root.
 env.Append(CPPPATH=["src/"])
@@ -171,9 +172,9 @@ if env["platform"] in ["linux", "macos", "windows"]:
     dest_dir = BIN_DIR + "/" + env["platform"]
 
     if env["platform"] == "windows":
-        build_actions.append(
-            partial(run_cmd, args=["powershell", "scripts/build-sentry-native.ps1"])
-        ),
+        # build_actions.append(
+        #     partial(run_cmd, args=["powershell", "scripts/build-sentry-native.ps1"])
+        # ),
         build_actions.append(
             Copy(
                 dest_dir + "/crashpad_handler.exe",
@@ -190,12 +191,12 @@ if env["platform"] in ["linux", "macos", "windows"]:
         sn_targets.append(dest_dir + "/crashpad_handler.pdb")
     else:
         # TODO: macOS needs to use a different SDK.
-        build_actions.append(
-            partial(run_cmd, args=[
-                "sh", "scripts/build-sentry-native.sh",
-                "--macos-deployment-target", env["macos_deployment_target"]
-            ])
-        ),
+        # build_actions.append(
+        #     partial(run_cmd, args=[
+        #         "sh", "scripts/build-sentry-native.sh",
+        #         "--macos-deployment-target", env["macos_deployment_target"]
+        #     ])
+        # ),
         build_actions.append(
             Copy(
                 dest_dir + "/crashpad_handler",
@@ -204,13 +205,16 @@ if env["platform"] in ["linux", "macos", "windows"]:
         )
         sn_targets.append(dest_dir + "/crashpad_handler")
 
-    sentry_native = env.Command(sn_targets, sn_sources, build_actions)
+    # sentry_native = env.Command(sn_targets, sn_sources, build_actions)
 
     # Force sentry-native to be built sequential to godot-cpp (not in parallel).
-    Depends(sentry_native, "modules/godot-cpp")
+    # Depends(sentry_native, "modules/godot-cpp")
 
-    Default(sentry_native)
-    Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
+    # Default(sentry_native)
+    # Clean(sentry_native, ["modules/sentry-native/build", "modules/sentry-native/install"])
+
+# Build sentry-native
+SConscript("modules/SConstruct", exports=["env"])
 
 
 # *** Build GDExtension library.

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+## Purpose: Build sentry-native static library.
+
+import os
+
+try:
+    Import("env")
+    env = env.Clone()
+except:
+    env = Environment(ENV = os.environ)
+
+# Get platform and architecture from environment or command line arguments
+platform = env.get("platform", ARGUMENTS.get("platform", ""))
+arch = env.get("arch", ARGUMENTS.get("arch", ""))
+
+if not platform:
+    print("ERROR: Platform not specified. Use platform=<platform> argument.")
+    Exit(1)
+
+if not arch:
+    print("ERROR: Architecture not specified. Use arch=<arch> argument.")
+    Exit(1)
+
+if platform not in ["windows", "linux", "macos"]:
+    Return()
+
+if env.get("use_mingw") == True:
+    print("ERROR: Compiling with MinGW is not supported yet.")
+    Exit(1)
+
+if env.get("use_llvm") == True:
+    print("ERROR: Compiling with LLVM is not supported yet.")
+    Exit(1)
+
+cmake_gen = "cmake -B build"
+cmake_gen += " -DSENTRY_BUILD_SHARED_LIBS=OFF"
+cmake_gen += " -DSENTRY_BACKEND=crashpad"
+cmake_gen += " -DSENTRY_SDK_NAME=\"sentry.native.godot\""
+cmake_gen += " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+
+build_targets = []
+
+# Define our build targets for the command
+if platform == "windows":
+    build_targets.append(File("sentry-native/install/lib/sentry.lib"))
+    build_targets.append(File("sentry-native/install/bin/crashpad_handler.exe"))
+else:
+    build_targets.append(File("sentry-native/install/lib/libsentry.a"))
+    build_targets.append(File("sentry-native/install/bin/crashpad_handler"))
+
+# Platform-specific options
+if platform == "windows":
+    if arch == "x86_32":
+        cmake_arch = "-A Win32"
+    elif arch == "x86_64":
+        cmake_arch = "-A x64"
+    else:
+        print(f"ERROR: Unsupported architecture '{arch}' for platform '{platform}'")
+        Exit(1)
+    cmake_gen += f' -G "Visual Studio 17 2022" {cmake_arch}'
+elif platform == "linux":
+    if arch == "x86_32":
+        cmake_gen += ' -DCMAKE_C_FLAGS="-m32" -DCMAKE_CXX_FLAGS="-m32"'
+    elif arch == "x86_64":
+        cmake_gen += ' -DCMAKE_C_FLAGS="-m64" -DCMAKE_CXX_FLAGS="-m64"'
+    else:
+        print(f"ERROR: Unsupported architecture '{arch}' for platform '{platform}'")
+        Exit(1)
+elif platform == "macos":
+    cmake_arch = "arm64;x86_64" if arch == "universal" else arch
+    cmake_gen += f' -DCMAKE_OSX_ARCHITECTURES="{cmake_arch}"'
+    macos_deployment_target = env.get("macos_deployment_target", "default")
+    if macos_deployment_target != "default":
+        cmake_gen += f' -DCMAKE_OSX_DEPLOYMENT_TARGET=\"{macos_deployment_target}\"'
+
+cmake_sentry = "cmake --build build --target sentry --parallel --config RelWithDebInfo"
+cmake_crashpad = "cmake --build build --target crashpad_handler --parallel --config RelWithDebInfo"
+cmake_install = "cmake --install build --prefix install --config RelWithDebInfo"
+
+sentry_native_dir = Dir('sentry-native').abspath
+
+sentry_native = env.Command(
+    target=build_targets,
+    source=[Dir("sentry-native/src")],
+    action=[
+        f"cd {sentry_native_dir} && {cmake_gen}",
+        f"cd {sentry_native_dir} && {cmake_sentry}",
+        f"cd {sentry_native_dir} && {cmake_crashpad}",
+        f"cd {sentry_native_dir} && {cmake_install}",
+    ]
+)
+
+# Force sentry-native to be built sequential to godot-cpp (not in parallel)
+Depends(sentry_native, "godot-cpp")
+Default(sentry_native)
+
+Clean(sentry_native, [Dir("modules/sentry-native/build"), Dir("modules/sentry-native/install")])

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -3,13 +3,14 @@
 
 import os
 
+
+# *** Prologue: Initialization 
+
 try:
     Import("env")
     env = env.Clone()
 except:
     env = Environment(ENV = os.environ)
-
-env_cmake = Environment(ENV = os.environ)
 
 # Get platform and architecture from environment or command line arguments
 platform = env.get("platform", ARGUMENTS.get("platform", ""))
@@ -24,7 +25,7 @@ if not arch:
     Exit(1)
 
 if platform not in ["windows", "linux", "macos"]:
-    Return()
+    Return("env")
 
 if env.get("use_mingw") == True:
     print("ERROR: Compiling with MinGW is not supported yet.")
@@ -34,23 +35,75 @@ if env.get("use_llvm") == True:
     print("ERROR: Compiling with LLVM is not supported yet.")
     Exit(1)
 
+
+# *** Chapter 1: Targets and variables
+
+build_targets = []
+
+def add_lib_target(lib_name):
+    if platform == "windows":
+        build_targets.append(File(f"sentry-native/install/lib/{lib_name}.lib"))
+        build_targets.append(File(f"sentry-native/install/lib/{lib_name}.pdb"))
+    else:
+        build_targets.append(File(f"sentry-native/install/lib/lib{lib_name}.a"))
+    env.Append(LIBS=[lib_name])
+
+# Common libs
+add_lib_target("sentry")
+add_lib_target("crashpad_client")
+add_lib_target("crashpad_handler_lib")
+add_lib_target("crashpad_minidump")
+add_lib_target("crashpad_snapshot")
+add_lib_target("crashpad_tools")
+add_lib_target("crashpad_util")
+add_lib_target("mini_chromium")
+
+# Platform-specific libs
+if platform == "windows":
+    add_lib_target("crashpad_compat")
+    env.Append(
+        LIBS=[
+            "winhttp",
+            "advapi32",
+            "DbgHelp",
+            "Version",
+        ]
+    )
+elif platform == "linux":
+    add_lib_target("crashpad_compat")
+    env.Append(
+        LIBS=[
+            "curl",
+            "atomic"
+        ]
+    )
+elif platform == "macos":
+    env.Append(
+        LIBS=[
+            "curl",
+        ]
+    )
+
+# Crashpad handler
+if platform == "windows":
+    build_targets.append(File(f"sentry-native/install/bin/crashpad_handler.exe"))
+else:
+    build_targets.append(File(f"sentry-native/install/bin/crashpad_handler"))
+
+# Other defines
+env.Append(CPPDEFINES=["SENTRY_BUILD_STATIC", "NATIVE_SDK"])
+env.Append(CPPPATH=[Dir("sentry-native/include/")])
+env.Append(LIBPATH=[Dir("sentry-native/install/lib/")])
+
+
+# *** Chapter 2: CMake
+
 cmake_gen = "cmake -B build"
 cmake_gen += " -DSENTRY_BUILD_SHARED_LIBS=OFF"
 cmake_gen += " -DSENTRY_BACKEND=crashpad"
 cmake_gen += " -DSENTRY_SDK_NAME=\"sentry.native.godot\""
 cmake_gen += " -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
-build_targets = []
-
-# Define our build targets for the command
-if platform == "windows":
-    build_targets.append(File("sentry-native/install/lib/sentry.lib"))
-    build_targets.append(File("sentry-native/install/bin/crashpad_handler.exe"))
-else:
-    build_targets.append(File("sentry-native/install/lib/libsentry.a"))
-    build_targets.append(File("sentry-native/install/bin/crashpad_handler"))
-
-# Platform-specific options
 if platform == "windows":
     cmake_gen += " -DSENTRY_BUILD_RUNTIMESTATIC=ON"
     cmake_gen += ' -DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY="pdb"'
@@ -81,21 +134,28 @@ cmake_sentry = "cmake --build build --target sentry --parallel --config RelWithD
 cmake_crashpad = "cmake --build build --target crashpad_handler --parallel --config RelWithDebInfo"
 cmake_install = "cmake --install build --prefix install --config RelWithDebInfo"
 
-sentry_native_dir = Dir('sentry-native').abspath
+
+## *** Chapter 3: Build Commands
+
+env_cmake = Environment(ENV = os.environ)
+sentry_native_path = Dir('sentry-native').abspath
 
 sentry_native = env_cmake.Command(
     target=build_targets,
     source=[Dir("sentry-native/src")],
     action=[
-        f"cd {sentry_native_dir} && {cmake_gen}",
-        f"cd {sentry_native_dir} && {cmake_sentry}",
-        f"cd {sentry_native_dir} && {cmake_crashpad}",
-        f"cd {sentry_native_dir} && {cmake_install}",
+        f"cd {sentry_native_path} && {cmake_gen}",
+        f"cd {sentry_native_path} && {cmake_sentry}",
+        f"cd {sentry_native_path} && {cmake_crashpad}",
+        f"cd {sentry_native_path} && {cmake_install}",
     ]
 )
 
 # Force sentry-native to be built sequential to godot-cpp (not in parallel)
 Depends(sentry_native, "godot-cpp")
+
 Default(sentry_native)
 
 Clean(sentry_native, [Dir("sentry-native/build"), Dir("sentry-native/install")])
+
+Return("env")

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -173,4 +173,39 @@ Default(sentry_native)
 
 Clean(sentry_native, [Dir("sentry-native/build"), Dir("sentry-native/install")])
 
+
+## *** Chapter 4: Export action to copy crashpad handler
+
+def CopyCrashpadHandler(self, target_dir):
+    actions = []
+    targets = []
+    sources = []
+
+    def copy_file_action(target_file, source_file):
+        actions.append(Copy(target_file, source_file))
+        targets.append(target_file)
+        sources.append(source_file)
+
+    source_dir = Dir("modules/sentry-native/install/bin")
+
+    if platform == "windows":
+        copy_file_action(
+            target_dir.File("crashpad_handler.exe"),
+            source_dir.File("crashpad_handler.exe")
+        )
+        copy_file_action(
+            target_dir.File("crashpad_handler.pdb"),
+            source_dir.File("crashpad_handler.pdb")
+        )
+    else:
+        copy_file_action(
+            target_dir.File("crashpad_handler"),
+            source_dir.File("crashpad_handler")
+        )
+
+    return env.Command(targets, sources, actions)
+
+# Register action
+env.__class__.CopyCrashpadHandler = CopyCrashpadHandler
+
 Return("env")

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -60,9 +60,9 @@ if platform == "windows":
     cmake_gen += f' -G "Visual Studio 17 2022" {cmake_arch}'
 elif platform == "linux":
     if arch == "x86_32":
-        cmake_gen += ' -DCMAKE_C_FLAGS="-m32" -DCMAKE_CXX_FLAGS="-m32"'
+        cmake_gen += ' -DCMAKE_C_FLAGS="-m32" -DCMAKE_CXX_FLAGS="-m32" -DLINK_OPTIONS="-m32"'
     elif arch == "x86_64":
-        cmake_gen += ' -DCMAKE_C_FLAGS="-m64" -DCMAKE_CXX_FLAGS="-m64"'
+        cmake_gen += ' -DCMAKE_C_FLAGS="-m64" -DCMAKE_CXX_FLAGS="-m64" -DLINK_OPTIONS="-m64"'
     else:
         print(f"ERROR: Unsupported architecture '{arch}' for platform '{platform}'")
         Exit(1)
@@ -94,4 +94,4 @@ sentry_native = env.Command(
 Depends(sentry_native, "godot-cpp")
 Default(sentry_native)
 
-Clean(sentry_native, [Dir("modules/sentry-native/build"), Dir("modules/sentry-native/install")])
+Clean(sentry_native, [Dir("sentry-native/build"), Dir("sentry-native/install")])

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -137,18 +137,33 @@ cmake_install = "cmake --install build --prefix install --config RelWithDebInfo"
 
 ## *** Chapter 3: Build Commands
 
-env_cmake = Environment(ENV = os.environ)
 sentry_native_path = Dir('sentry-native').abspath
 
-sentry_native = env_cmake.Command(
-    target=build_targets,
-    source=[Dir("sentry-native/src")],
-    action=[
+actions = [
         f"cd {sentry_native_path} && {cmake_gen}",
         f"cd {sentry_native_path} && {cmake_sentry}",
         f"cd {sentry_native_path} && {cmake_crashpad}",
         f"cd {sentry_native_path} && {cmake_install}",
     ]
+
+# Copy crashpad handler PDB
+if platform == "windows":
+    target_file = File("sentry-native/install/bin/crashpad_handler.pdb")
+    actions.append(
+        Copy(
+            target_file,
+            File("sentry-native/build/crashpad_build/handler/RelWithDebInfo/crashpad_handler.pdb")
+        )
+    )
+    build_targets.append(target_file)
+
+# Use new environment importing current shell's env for greater compatibility.
+env_cmake = Environment(ENV = os.environ)
+
+sentry_native = env_cmake.Command(
+    target=build_targets,
+    source=[Dir("sentry-native/src")],
+    action=actions
 )
 
 # Force sentry-native to be built sequential to godot-cpp (not in parallel)

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -174,7 +174,7 @@ Default(sentry_native)
 Clean(sentry_native, [Dir("sentry-native/build"), Dir("sentry-native/install")])
 
 
-## *** Chapter 4: Export action to copy crashpad handler
+## *** Chapter 4: Export pseudo-builder to copy crashpad handler
 
 def CopyCrashpadHandler(self, target_dir):
     actions = []
@@ -205,7 +205,7 @@ def CopyCrashpadHandler(self, target_dir):
 
     return env.Command(targets, sources, actions)
 
-# Register action
-env.__class__.CopyCrashpadHandler = CopyCrashpadHandler
+env.AddMethod(CopyCrashpadHandler, "CopyCrashpadHandler")
+
 
 Return("env")

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -9,6 +9,8 @@ try:
 except:
     env = Environment(ENV = os.environ)
 
+env_cmake = Environment(ENV = os.environ)
+
 # Get platform and architecture from environment or command line arguments
 platform = env.get("platform", ARGUMENTS.get("platform", ""))
 arch = env.get("arch", ARGUMENTS.get("arch", ""))
@@ -50,6 +52,8 @@ else:
 
 # Platform-specific options
 if platform == "windows":
+    cmake_gen += " -DSENTRY_BUILD_RUNTIMESTATIC=ON"
+    cmake_gen += ' -DCMAKE_COMPILE_PDB_OUTPUT_DIRECTORY="pdb"'
     if arch == "x86_32":
         cmake_arch = "-A Win32"
     elif arch == "x86_64":
@@ -79,7 +83,7 @@ cmake_install = "cmake --install build --prefix install --config RelWithDebInfo"
 
 sentry_native_dir = Dir('sentry-native').abspath
 
-sentry_native = env.Command(
+sentry_native = env_cmake.Command(
     target=build_targets,
     source=[Dir("sentry-native/src")],
     action=[

--- a/modules/SConstruct
+++ b/modules/SConstruct
@@ -4,7 +4,7 @@
 import os
 
 
-# *** Prologue: Initialization 
+# *** Prologue: Initialization
 
 try:
     Import("env")
@@ -20,12 +20,12 @@ if not platform:
     print("ERROR: Platform not specified. Use platform=<platform> argument.")
     Exit(1)
 
+if platform not in ["windows", "linux", "macos"]:
+    Return("env")
+
 if not arch:
     print("ERROR: Architecture not specified. Use arch=<arch> argument.")
     Exit(1)
-
-if platform not in ["windows", "linux", "macos"]:
-    Return("env")
 
 if env.get("use_mingw") == True:
     print("ERROR: Compiling with MinGW is not supported yet.")


### PR DESCRIPTION
This PR adds 32 bit targets for Windows and Linux. To allow different architectures, the sentry-native compilation step needed to be reworked. It's a cleaner, separate, and more flexible routine now.
