### PR TITLE
feat: Add `max_attachment_size` to `SentryOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Initial Android support ([#169](https://github.com/getsentry/sentry-godot/pull/169))
 - Refine demo for mobile screens ([#196](https://github.com/getsentry/sentry-godot/pull/196))
 - Add user attachments support ([#205](https://github.com/getsentry/sentry-godot/pull/205))
+- Add `max_attachment_size` to `SentryOptions` ([#219](https://github.com/getsentry/sentry-godot/pull/219))
 
-## Fixes
+### Fixes
 
 - Fixed Godot 4.5 complaining that "usage" is not supported ([#214](https://github.com/getsentry/sentry-godot/pull/214))
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -101,6 +101,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         environment: String,
         sampleRate: Float,
         maxBreadcrumbs: Int,
+        maxAttachmentSize: Long
     ) {
         Log.v(TAG, "Initializing Sentry Android")
         SentryAndroid.init(godot.getActivity()!!.applicationContext) { options ->
@@ -111,6 +112,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             options.environment = environment.ifEmpty { null }
             options.sampleRate = sampleRate.toDouble()
             options.maxBreadcrumbs = maxBreadcrumbs
+            options.maxAttachmentSize = maxAttachmentSize
             options.sdkVersion?.name = "sentry.java.android.godot"
             options.nativeSdkName = "sentry.native.android.godot"
             options.beforeSend =

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -80,6 +80,10 @@
 		<member name="logger_limits" type="SentryLoggerLimits" setter="set_logger_limits" getter="get_logger_limits">
 			Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending too many non-critical and repeating error events. See [SentryLoggerLimits].
 		</member>
+		<member name="max_attachment_size" type="int" setter="set_max_attachment_size" getter="get_max_attachment_size" default="20971520">
+			Defines the maximum size of each attachment in bytes that can be sent with an event. If an attachment exceeds this size, it will be dropped. The default is 20MiB. Please also check the [url=https://docs.sentry.io/product/relay/options/]maximum attachment size of Relay[/url] to make sure your attachments don't get discarded there.
+			[b]Note:[/b] This option is currently only effective on Android.
+		</member>
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">
 			Maximum number of breadcrumbs to send with an event. You should be aware that Sentry has a maximum payload size and any events exceeding that payload size will be dropped.
 		</member>

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -147,7 +147,8 @@ void AndroidSDK::initialize(const PackedStringArray &p_global_attachments) {
 			SentryOptions::get_singleton()->get_dist(),
 			SentryOptions::get_singleton()->get_environment(),
 			SentryOptions::get_singleton()->get_sample_rate(),
-			SentryOptions::get_singleton()->get_max_breadcrumbs());
+			SentryOptions::get_singleton()->get_max_breadcrumbs(),
+			SentryOptions::get_singleton()->get_max_attachment_size());
 }
 
 AndroidSDK::AndroidSDK() {

--- a/src/sentry_options.cpp
+++ b/src/sentry_options.cpp
@@ -68,6 +68,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
 	_define_setting(sentry::make_level_enum_property("sentry/options/screenshot_level"), p_options->screenshot_level, false);
+	_define_setting("sentry/options/max_attachment_size", p_options->max_attachment_size, false);
 
 	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);
@@ -113,6 +114,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/screenshot_level", p_options->screenshot_level);
 	p_options->attach_scene_tree = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
+	p_options->max_attachment_size = ProjectSettings::get_singleton()->get_setting("sentry/options/max_attachment_size", p_options->max_attachment_size);
 
 	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	p_options->logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", p_options->logger_include_source);
@@ -182,6 +184,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_screenshot"), set_attach_screenshot, is_attach_screenshot_enabled);
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree"), set_attach_scene_tree, is_attach_scene_tree_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_attachment_size"), set_max_attachment_size, get_max_attachment_size);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);

--- a/src/sentry_options.h
+++ b/src/sentry_options.h
@@ -65,6 +65,7 @@ private:
 	bool attach_screenshot = false;
 	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
 	bool attach_scene_tree = false;
+	int64_t max_attachment_size = 20 * 1024 * 1024; // 20 MiB
 
 	bool logger_enabled = true;
 	bool logger_include_source = true;
@@ -135,6 +136,9 @@ public:
 
 	_FORCE_INLINE_ void set_attach_scene_tree(bool p_enable) { attach_scene_tree = p_enable; }
 	_FORCE_INLINE_ bool is_attach_scene_tree_enabled() const { return attach_scene_tree; }
+
+	_FORCE_INLINE_ int64_t get_max_attachment_size() const { return max_attachment_size; }
+	_FORCE_INLINE_ void set_max_attachment_size(int64_t p_size) { max_attachment_size = p_size; }
 
 	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
 	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }


### PR DESCRIPTION
* Add `max_attachment_size` to SentryOptions
* Only effective on Android
* Documentation https://github.com/getsentry/sentry-docs/pull/14210
* Related issue #120 