### PR TITLE
fix: Class reference not being generated

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -83,7 +83,7 @@ elif platform == "android":
     sources += Glob("src/sentry/android/*.cpp")
 
 # Generate documentation data.
-if platform in ["editor", "template_debug"]:
+if env["target"] in ["editor", "template_debug"]:
     try:
         doc_data = env.GodotCPPDocData(
             "src/gen/doc_data.gen.cpp", source=Glob("doc_classes/*.xml"))


### PR DESCRIPTION
Address regression introduced by build system refactor, which prevents documentation generation during builds.

#skip-changelog since we didn't release the bug