### PR TITLE
chore: Filter SDK messages in logger

### DIFF
--- a/src/sentry_logger.h
+++ b/src/sentry_logger.h
@@ -8,6 +8,7 @@
 #include <godot_cpp/classes/logger.hpp>
 #include <godot_cpp/classes/script_backtrace.hpp>
 #include <mutex>
+#include <regex>
 #include <unordered_map>
 
 using namespace godot;
@@ -43,6 +44,10 @@ private:
 
 	// Number of events captured during this frame.
 	int frame_events = 0;
+
+	// Patterns that are checked against each message.
+	// If matching, the message is not added as breadcrumb.
+	std::vector<std::regex> filter_patterns;
 
 	void _process_frame();
 


### PR DESCRIPTION
With new logger implementation, Sentry SDK messages end up as breadcrumbs in Sentry. This PR adds filtering to exclude such messages.

Resolves #231.

<img width="726" alt="Screenshot 2025-07-04 at 13 16 00" src="https://github.com/user-attachments/assets/c5505fae-4d16-4825-88d6-e10c2651ea72" />
