### PR TITLE
ci: Fix update deps workflow permissions

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write # needed to add commits to branches
   pull-requests: write
   actions: write # needed for cancelling workflow runs
 


### PR DESCRIPTION
Update dependencies fails due to lacking permissions to push commits to branches it creates. This PR sets the needed `contents: write` permissions.