### PR TITLE
fix: Check options.enabled during SDK initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Check options.enabled during SDK initialization ([#250](https://github.com/getsentry/sentry-godot/pull/250))
+
 ## 1.0.0-alpha.0
 
 ### Breaking changes

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -204,6 +204,12 @@ PackedStringArray SentrySDK::_get_global_attachments() {
 void SentrySDK::_initialize() {
 	sentry::util::print_debug("starting Sentry SDK version " + String(SENTRY_GODOT_SDK_VERSION));
 
+	if (!SentryOptions::get_singleton()->is_enabled()) {
+		enabled = false;
+		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
+		return;
+	}
+
 #ifdef NATIVE_SDK
 	internal_sdk = std::make_shared<NativeSDK>();
 	enabled = true;


### PR DESCRIPTION
- Due to a bug, currently, it's not possible to disable SDK programmatically. 
- Fixes #249 