### PR TITLE
fix: Fix crashing when SDK is disabled via options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Check options.enabled during SDK initialization ([#250](https://github.com/getsentry/sentry-godot/pull/250))
+- Fix crashing when SDK is disabled via options ([#253](https://github.com/getsentry/sentry-godot/pull/253))
 
 ## 1.0.0-alpha.0
 

--- a/src/sentry_sdk.cpp
+++ b/src/sentry_sdk.cpp
@@ -139,7 +139,7 @@ void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 
 Ref<SentryUser> SentrySDK::get_user() const {
 	MutexLock lock(*user_mutex.ptr());
-	return user->duplicate();
+	return user.is_valid() ? user->duplicate() : nullptr;
 }
 
 void SentrySDK::remove_user() {


### PR DESCRIPTION
- Fix null pointer dereference in SentrySDK::get_user