### PR TITLE
fix: Allow configuration script to run even if SDK is initially disabled in project settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Allow configuration script to run even if SDK is initially disabled in project settings ([#258](https://github.com/getsentry/sentry-godot/pull/258))
+
 ## 1.0.0-alpha.1
 
 ### Fixes

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -207,40 +207,6 @@ PackedStringArray SentrySDK::_get_global_attachments() {
 void SentrySDK::_initialize() {
 	sentry::util::print_debug("starting Sentry SDK version " + String(SENTRY_GODOT_SDK_VERSION));
 
-	if (!SentryOptions::get_singleton()->is_enabled()) {
-		enabled = false;
-		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
-		return;
-	}
-
-#ifdef NATIVE_SDK
-	internal_sdk = std::make_shared<NativeSDK>();
-	enabled = true;
-#elif ANDROID_ENABLED
-	if (unlikely(OS::get_singleton()->has_feature("editor"))) {
-		sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
-		enabled = false;
-	} else {
-		auto sdk = std::make_shared<AndroidSDK>();
-		if (sdk->has_android_plugin()) {
-			internal_sdk = sdk;
-			enabled = true;
-		} else {
-			sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
-			enabled = false;
-		}
-	}
-#else
-	// Unsupported platform
-	sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
-	enabled = false;
-#endif
-
-	if (!enabled) {
-		sentry::util::print_debug("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
-		return;
-	}
-
 	// Initialize user if it wasn't set explicitly in the configuration script.
 	if (user.is_null()) {
 		user.instantiate();
@@ -250,6 +216,48 @@ void SentrySDK::_initialize() {
 		}
 	}
 	set_user(user);
+
+	bool should_enable = true;
+
+	if (!SentryOptions::get_singleton()->is_enabled()) {
+		should_enable = false;
+		sentry::util::print_debug("Sentry SDK is disabled in options.");
+	}
+
+	if (Engine::get_singleton()->is_editor_hint() && SentryOptions::get_singleton()->is_disabled_in_editor()) {
+		should_enable = false;
+		sentry::util::print_debug("Sentry SDK is disabled in the editor. Tip: This can be changed in the project settings.");
+	}
+
+	if (should_enable) {
+#ifdef NATIVE_SDK
+		internal_sdk = std::make_shared<NativeSDK>();
+#elif ANDROID_ENABLED
+		if (unlikely(OS::get_singleton()->has_feature("editor"))) {
+			sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
+			should_enable = false;
+		} else {
+			auto sdk = std::make_shared<AndroidSDK>();
+			if (sdk->has_android_plugin()) {
+				internal_sdk = sdk;
+			} else {
+				sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
+				should_enable = false;
+			}
+		}
+#else
+		// Unsupported platform
+		sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
+		should_enable = false;
+#endif
+	}
+
+	enabled = should_enable;
+
+	if (!enabled) {
+		sentry::util::print_info("Sentry SDK is DISABLED! Operations with Sentry SDK will result in no-ops.");
+		return;
+	}
 
 	// Add event processors
 	if (SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
@@ -358,38 +366,25 @@ SentrySDK::SentrySDK() {
 	}
 #endif
 
-	bool should_enable = SentryOptions::get_singleton()->is_enabled();
-
-	if (!should_enable) {
-		sentry::util::print_debug("Sentry SDK is disabled in the project settings.");
-	}
-
-	if (should_enable && Engine::get_singleton()->is_editor_hint() && SentryOptions::get_singleton()->is_disabled_in_editor()) {
-		sentry::util::print_debug("Sentry SDK is disabled in the editor. Tip: This can be changed in the project settings.");
-		should_enable = false;
-	}
-
-	if (should_enable) {
-		if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
-			_initialize();
-			// Delay contexts initialization until the engine singletons are ready.
-			callable_mp(this, &SentrySDK::_init_contexts).call_deferred();
-		} else {
-			// Register an autoload singleton, which is a user script extending the
-			// `SentryConfiguration` class. It will be instantiated and added to the
-			// scene tree by the engine shortly after ScriptServer is initialized.
-			// When this happens, the `SentryConfiguration` instance receives
-			// `NOTIFICATION_READY`, triggering our notification processing code in
-			// C++, which calls `_configure()` on the user script and then invokes
-			// `notify_options_configured()` in `SentrySDK`. This, in turn, initializes
-			// the internal SDK.
-			sentry::util::print_debug("waiting for user configuration autoload");
-			ERR_FAIL_NULL(ProjectSettings::get_singleton());
-			ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",
-					SentryOptions::get_singleton()->get_configuration_script());
-			// Ensure issues with the configuration script are detected.
-			callable_mp(this, &SentrySDK::_check_if_configuration_succeeded).call_deferred();
-		}
+	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
+		_initialize();
+		// Delay contexts initialization until the engine singletons are ready.
+		callable_mp(this, &SentrySDK::_init_contexts).call_deferred();
+	} else {
+		// Register an autoload singleton, which is a user script extending the
+		// `SentryConfiguration` class. It will be instantiated and added to the
+		// scene tree by the engine shortly after ScriptServer is initialized.
+		// When this happens, the `SentryConfiguration` instance receives
+		// `NOTIFICATION_READY`, triggering our notification processing code in
+		// C++, which calls `_configure()` on the user script and then invokes
+		// `notify_options_configured()` in `SentrySDK`. This, in turn, initializes
+		// the internal SDK.
+		sentry::util::print_debug("waiting for user configuration autoload");
+		ERR_FAIL_NULL(ProjectSettings::get_singleton());
+		ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",
+				SentryOptions::get_singleton()->get_configuration_script());
+		// Ensure issues with the configuration script are detected.
+		callable_mp(this, &SentrySDK::_check_if_configuration_succeeded).call_deferred();
 	}
 }
 


### PR DESCRIPTION
- Fixes #255
