### PR TITLE
fix: Context-related errors generated at runtime with early intialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Allow configuration script to run even if SDK is initially disabled in project settings ([#258](https://github.com/getsentry/sentry-godot/pull/258))
-- Context-related errors generated at runtime with early intialization ([#264](https://github.com/getsentry/sentry-godot/pull/264))
+- Fixed context-related errors generated at runtime with early intialization ([#264](https://github.com/getsentry/sentry-godot/pull/264))
 
 ## 1.0.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Allow configuration script to run even if SDK is initially disabled in project settings ([#258](https://github.com/getsentry/sentry-godot/pull/258))
+- Context-related errors generated at runtime with early intialization ([#264](https://github.com/getsentry/sentry-godot/pull/264))
 
 ## 1.0.0-alpha.1
 

--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -108,6 +108,9 @@ Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config) {
 
 Dictionary make_device_context_update() {
 	Dictionary device_context = Dictionary();
+	ERR_FAIL_NULL_V(DisplayServer::get_singleton(), device_context);
+	ERR_FAIL_NULL_V(OS::get_singleton(), device_context);
+
 	int primary_screen = DisplayServer::get_singleton()->get_primary_screen();
 	device_context["orientation"] = _screen_orientation_as_string(primary_screen);
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -281,7 +281,6 @@ void SentrySDK::_initialize() {
 	}
 
 	internal_sdk->initialize(_get_global_attachments());
-	_init_contexts();
 
 	if (SentryOptions::get_singleton()->is_logger_enabled()) {
 		logger.instantiate();
@@ -380,6 +379,7 @@ SentrySDK::SentrySDK() {
 #endif
 
 	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
+		// Early initialization path.
 		_initialize();
 		// Delay contexts initialization until the engine singletons are ready.
 		callable_mp(this, &SentrySDK::_init_contexts).call_deferred();


### PR DESCRIPTION
Remove redundant context initialization that was resulting in errors at runtime in early initialization path (no configuration script used). For information, we initialize context [here](https://github.com/getsentry/sentry-godot/blob/main/src/sentry/sentry_sdk.cpp#L385) and [here](https://github.com/getsentry/sentry-godot/blob/main/src/sentry/sentry_sdk.cpp#L310), depending if configuration script is used (early vs delayed init).
- Also add additional null checks.
- Fixes #263 
