### PR TITLE
fix: Logger connecting to signal runtime error with early initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Allow configuration script to run even if SDK is initially disabled in project settings ([#258](https://github.com/getsentry/sentry-godot/pull/258))
+- Logger connecting to signal runtime error with early initialization ([#265](https://github.com/getsentry/sentry-godot/pull/265))
 
 ## 1.0.0-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Allow configuration script to run even if SDK is initially disabled in project settings ([#258](https://github.com/getsentry/sentry-godot/pull/258))
-- Logger connecting to signal runtime error with early initialization ([#265](https://github.com/getsentry/sentry-godot/pull/265))
+- Fixed runtime errors with logger connecting to signal and early initialization ([#265](https://github.com/getsentry/sentry-godot/pull/265))
 
 ## 1.0.0-alpha.1
 

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -149,7 +149,10 @@ namespace sentry {
 void SentryLogger::_connect_process_frame() {
 	SceneTree *scene_tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
 	if (scene_tree) {
-		scene_tree->connect("process_frame", callable_mp(this, &SentryLogger::_process_frame));
+		Callable callable = callable_mp(this, &SentryLogger::_process_frame);
+		if (!scene_tree->is_connected("process_frame", callable)) {
+			scene_tree->connect("process_frame", callable);
+		}
 	} else {
 		ERR_PRINT("Sentry: Failed to connect `process_frame` signal – main loop is null");
 	}

--- a/src/sentry/sentry_logger.h
+++ b/src/sentry/sentry_logger.h
@@ -49,6 +49,7 @@ private:
 	// Filter: Remove messages from breadcrumbs which start with any of these prefixes.
 	std::vector<String> filter_by_prefix;
 
+	void _enable_process_frame();
 	void _process_frame();
 
 protected:

--- a/src/sentry/sentry_logger.h
+++ b/src/sentry/sentry_logger.h
@@ -49,7 +49,8 @@ private:
 	// Filter: Remove messages from breadcrumbs which start with any of these prefixes.
 	std::vector<String> filter_by_prefix;
 
-	void _enable_process_frame();
+	void _connect_process_frame();
+	void _disconnect_process_frame();
 	void _process_frame();
 
 protected:


### PR DESCRIPTION
This PR fixes a runtime error with Logger not being able to connect to a signal on the main loop during the early initialization path, because the main loop is not yet available.

Also, disconnect from the mentioned signal on free.
