### PR TITLE
chore: Bump Godot compatibility to `4.5-beta4`

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -33,7 +33,7 @@ runs:
       env:
         # Set pre-release version status here (e.g. "beta1");
         # for release version, set to "stable".
-        RELEASE_STATUS: beta3
+        RELEASE_STATUS: beta4
         ARCH: ${{ inputs.arch }}
       run: |
         major_minor=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1/p' project/addons/sentry/sentry.gdextension)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 - Remove `disabled_in_editor` option in favor of disabling SDK in the Godot editor by default.([#277](https://github.com/getsentry/sentry-godot/pull/277))
+- Bump Godot to `4.5-beta4` ([#285](https://github.com/getsentry/sentry-godot/pull/285))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking changes
 
 - Remove `disabled_in_editor` option in favor of disabling SDK in the Godot editor by default.([#277](https://github.com/getsentry/sentry-godot/pull/277))
-- Bump Godot to `4.5-beta4` ([#285](https://github.com/getsentry/sentry-godot/pull/285))
+- Bump Godot minimum version to `4.5-beta4` ([#285](https://github.com/getsentry/sentry-godot/pull/285))
 
 ### Fixes
 


### PR DESCRIPTION
Bump minimum compatibility to `4.5-beta4`