### PR TITLE
ci: Build iOS artifacts

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -172,33 +172,33 @@ jobs:
             arch: x86_64
             scons-flags: debug_symbols=yes
 
-          - name: 🍏 iOS (noop, arm64, release)
+          - name: 🍏 iOS (arm64, release)
             runner: macos-15
             platform: ios
             target: template_release
             arch: arm64
-            scons-flags: debug_symbols=no
+            scons-flags: debug_symbols=yes
 
-          - name: 🍏 iOS (noop, arm64, debug)
+          - name: 🍏 iOS (arm64, debug)
             runner: macos-15
             platform: ios
             target: editor
             arch: arm64
-            scons-flags: debug_symbols=no
+            scons-flags: debug_symbols=yes
 
-          - name: 🍏 iOS (noop, simulator, release)
+          - name: 🍏 iOS (simulator, release)
             runner: macos-15
             platform: ios
             target: template_release
             arch: universal
-            scons-flags: debug_symbols=no ios_simulator=yes
+            scons-flags: debug_symbols=yes ios_simulator=yes
 
-          - name: 🍏 iOS (noop, simulator, debug)
+          - name: 🍏 iOS (simulator, debug)
             runner: macos-15
             platform: ios
             target: editor
             arch: universal
-            scons-flags: debug_symbols=no ios_simulator=yes
+            scons-flags: debug_symbols=yes ios_simulator=yes
 
           - name: 🌐 Web (noop, threads, release)
             runner: ubuntu-latest

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -347,7 +347,7 @@ jobs:
   ios-framework:
     name: 🍏 Make iOS XCFramework
     needs: [build]
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -373,6 +373,10 @@ jobs:
           xcodebuild -version
           clang --version
 
+      - name: Diagnostics
+        run: |
+          ls -laR .
+
       - name: Create iOS XCFramework
         run: |
           scons platform=ios target=editor ios_framework

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -387,8 +387,8 @@ jobs:
           name: sentry.ios-framework
           # NOTE: Include-exclude pattern forces archive to start with project/ as root directory.
           path: |
-            project
-            !project
+            project/
+            !project/
             project/addons/sentry/bin/ios/
 
       - name: Delete downloaded iOS artifacts

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -387,10 +387,10 @@ jobs:
             !project
             project/addons/sentry/bin/ios/
 
-      - name: Delete other iOS artifacts
-        uses: actions/delete-artifact@v4
+      - name: Delete downloaded iOS artifacts
+        uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
         with:
-          pattern: sentry.ios.*
+          name: sentry.ios.*
 
   package:
     name: 📦 Package GDExtension

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -358,6 +358,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: sentry.ios.*
+          path: project/
 
       - name: Build iOS XCFramework
         run: |

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -344,10 +344,45 @@ jobs:
             project/addons/sentry/bin/android/sentry_android_godot_plugin.debug.aar
             project/addons/sentry/bin/android/sentry_android_godot_plugin.release.aar
 
+  ios-framework:
+    name: 🍏 Make iOS XCFramework
+    needs: [build]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.ref}}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sentry.ios.*
+
+      - name: Build iOS XCFramework
+        run: |
+          scons platform=ios target=editor ios_framework
+          scons platform=ios target=template_release ios_framework
+          rm -rf project/addons/sentry/bin/ios/temp/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sentry.ios-framework
+          path: |
+            project
+            !project
+            project/addons/sentry/bin/ios/
+
+      - name: Delete other iOS artifacts
+        uses: actions/delete-artifact@v4
+        with:
+          pattern: sentry.ios.*
+
   package:
     name: 📦 Package GDExtension
     runs-on: ubuntu-latest
-    needs: [build, android-plugin]
+    needs: [build, android-plugin, ios-framework]
     steps:
       - name: Merge artifacts
         uses: actions/upload-artifact/merge@v4

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -338,6 +338,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sentry.android.godot_plugin
+          # NOTE: Include-exclude pattern forces archive to start with project/ as root directory.
           path: |
             project/
             !project/
@@ -384,6 +385,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sentry.ios-framework
+          # NOTE: Include-exclude pattern forces archive to start with project/ as root directory.
           path: |
             project
             !project

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -360,6 +360,7 @@ jobs:
         with:
           pattern: sentry.ios.*
           path: project/
+          merge-multiple: true
 
       - name: Install SCons
         run: |

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -360,6 +360,18 @@ jobs:
           pattern: sentry.ios.*
           path: project/
 
+      - name: Install SCons
+        run: |
+          python -m pip install scons
+          python --version
+          scons --version
+
+      - name: Select Xcode version
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{env.XCODE_VERSION}}.app/Contents/Developer
+          xcodebuild -version
+          clang --version
+
       - name: Build iOS XCFramework
         run: |
           scons platform=ios target=editor ios_framework

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -353,6 +353,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{inputs.ref}}
+          submodules: recursive
 
       - name: Download iOS artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -374,10 +374,6 @@ jobs:
           xcodebuild -version
           clang --version
 
-      - name: Diagnostics
-        run: |
-          ls -laR .
-
       - name: Create iOS XCFramework
         run: |
           scons platform=ios target=editor ios_framework

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -354,7 +354,7 @@ jobs:
         with:
           ref: ${{inputs.ref}}
 
-      - name: Download artifacts
+      - name: Download iOS artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: sentry.ios.*
@@ -372,7 +372,7 @@ jobs:
           xcodebuild -version
           clang --version
 
-      - name: Build iOS XCFramework
+      - name: Create iOS XCFramework
         run: |
           scons platform=ios target=editor ios_framework
           scons platform=ios target=template_release ios_framework


### PR DESCRIPTION
Make usable iOS builds in CI. This PR adds a job to combine GDExtension iOS artifacts into XCFramework.

#skip-changelog