### PR TITLE
fix: Enable ARC when compiling with Cocoa SDK

### DIFF
--- a/modules/sentry-cocoa.SConscript
+++ b/modules/sentry-cocoa.SConscript
@@ -215,7 +215,9 @@ if platform in ["macos", "ios"]:
     env.Append(
         LINKFLAGS=[
             "-framework", "Foundation",
-        ]
+        ],
+        # Enable ARC for Objective-C files
+        CCFLAGS=["-fobjc-arc"]
     )
 
     # Add Sentry Cocoa framework to compilation.

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -10,7 +10,7 @@ class CocoaEvent : public sentry::SentryEvent {
 	GDCLASS(CocoaEvent, sentry::SentryEvent);
 
 private:
-	__strong objc::SentryEvent *cocoa_event = nullptr;
+	objc::SentryEvent *cocoa_event = nullptr;
 
 protected:
 	static void _bind_methods() {}


### PR DESCRIPTION
Enable ARC (automatic reference counting) in Objective C/C++ files when compiling with Cocoa SDK.

So, it turns out that ARC wasn’t turned on in the builds, which caused some memory leaks and other problems. Since we don’t manually release objects, this was a bit of a surprise.

I used this code to test ARC:
```cpp
void test_arc_behavior() {
	print_line("--- STARTING ARC TEST");

	@autoreleasepool {
		objc::SentryEvent *event = [[objc::SentryEvent alloc] init];
		print_line("--- NEW EVENT CREATED");

		__weak objc::SentryEvent *weak_ref = event;
		print_line("--- WEAK REF SET - IS NIL: ", (weak_ref == nil));

		// Clear the strong reference
		event = nil;
		print_line("--- AFTER CLEARING STRONG REF - WEAK IS NIL: ", (weak_ref == nil));
	}
}
```

Before this PR (compilation error):
```
src/sentry/cocoa/cocoa_event.mm:267:3: error: cannot create __weak reference in file using manual reference counting
  267 |                 __weak objc::SentryEvent *weak_ref = event;
      |                 ^
1 error generated.
scons: *** [src/sentry/cocoa/cocoa_event.os] Error 1
scons: building terminated because of errors.
```

After this PR:
```
--- STARTING ARC TEST
--- NEW EVENT CREATED
--- WEAK REF SET - IS NIL: false
--- AFTER CLEARING STRONG REF - WEAK IS NIL: true
```

#skip-changelog because we didn't ship the bug
