### PR TITLE
ci: Update Cocoa SDK dependency automatically

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,6 +21,8 @@ jobs:
         include:
           - name: Native SDK
             path: modules/sentry-native
+          - name: Cocoa SDK
+            path: modules/sentry-cocoa.properties
           - name: gdUnit 4
             path: modules/gdUnit4
     uses: getsentry/github-workflows/.github/workflows/updater.yml@v2


### PR DESCRIPTION
Add Cocoa SDK to dependency update workflow.

- Resolves #294