### PR TITLE
feat: Add option to disable logging messages as breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Intoduce `SentryTimestamp` class to improve timestamp handling ([#286](https://github.com/getsentry/sentry-godot/pull/286))
 - Support for iOS & macOS using Sentry Cocoa SDK integration ([#266](https://github.com/getsentry/sentry-godot/pull/266))
+- Add option to disable logging messages as breadcrumbs ([#305](https://github.com/getsentry/sentry-godot/pull/305))
 
 ### Improvements
 

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -84,6 +84,9 @@
 		<member name="logger_limits" type="SentryLoggerLimits" setter="set_logger_limits" getter="get_logger_limits">
 			Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending too many non-critical and repeating error events. See [SentryLoggerLimits].
 		</member>
+		<member name="logger_messages_as_breadcrumbs" type="bool" setter="set_logger_messages_as_breadcrumbs" getter="is_logger_messages_as_breadcrumbs_enabled" default="true">
+			If [code]true[/code], the SDK will capture log messages (such as [code]print()[/code] statements) as breadcrumbs along with events.
+		</member>
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">
 			Maximum number of breadcrumbs to send with an event. You should be aware that Sentry has a maximum payload size and any events exceeding that payload size will be dropped.
 		</member>

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -338,6 +338,10 @@ void SentryLogger::_log_error(const String &p_function, const String &p_file, in
 }
 
 void SentryLogger::_log_message(const String &p_message, bool p_error) {
+	if (!SentryOptions::get_singleton()->is_logger_messages_as_breadcrumbs_enabled()) {
+		return;
+	}
+
 	static thread_local uint32_t num_entries = 0;
 	constexpr uint32_t MAX_ENTRIES = 5;
 	RecursionGuard feedback_loop_guard{ &num_entries, MAX_ENTRIES };

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -78,6 +78,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);
 	_define_setting("sentry/logger/include_variables", p_options->logger_include_variables, false);
 	_requires_restart("sentry/logger/include_variables");
+	_define_setting("sentry/logger/messages_as_breadcrumbs", p_options->logger_messages_as_breadcrumbs);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_event_mask, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_breadcrumb_mask, false);
 
@@ -116,6 +117,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	p_options->logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", p_options->logger_include_source);
 	p_options->logger_include_variables = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_variables", p_options->logger_include_variables);
+	p_options->logger_messages_as_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/logger/messages_as_breadcrumbs", p_options->logger_messages_as_breadcrumbs);
 	p_options->logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", p_options->logger_event_mask);
 	p_options->logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", p_options->logger_breadcrumb_mask);
 
@@ -195,6 +197,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_variables"), set_logger_include_variables, is_logger_include_variables_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), set_logger_messages_as_breadcrumbs, is_logger_messages_as_breadcrumbs_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_event_mask"), set_logger_event_mask, get_logger_event_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), set_logger_breadcrumb_mask, get_logger_breadcrumb_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_logger_limits, get_logger_limits);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -68,6 +68,7 @@ private:
 	bool logger_enabled = true;
 	bool logger_include_source = true;
 	bool logger_include_variables = false;
+	bool logger_messages_as_breadcrumbs = true;
 	BitField<GodotErrorMask> logger_event_mask = int(GodotErrorMask::MASK_ALL_EXCEPT_WARNING);
 	BitField<GodotErrorMask> logger_breadcrumb_mask = int(GodotErrorMask::MASK_ALL);
 	Ref<SentryLoggerLimits> logger_limits;
@@ -144,6 +145,9 @@ public:
 
 	_FORCE_INLINE_ bool is_logger_include_variables_enabled() const { return logger_include_variables; }
 	_FORCE_INLINE_ void set_logger_include_variables(bool p_logger_include_variables) { logger_include_variables = p_logger_include_variables; }
+
+	_FORCE_INLINE_ bool is_logger_messages_as_breadcrumbs_enabled() const { return logger_messages_as_breadcrumbs; }
+	_FORCE_INLINE_ void set_logger_messages_as_breadcrumbs(bool p_enabled) { logger_messages_as_breadcrumbs = p_enabled; }
 
 	_FORCE_INLINE_ BitField<GodotErrorMask> get_logger_event_mask() const { return logger_event_mask; }
 	_FORCE_INLINE_ void set_logger_event_mask(BitField<GodotErrorMask> p_mask) { logger_event_mask = p_mask; }


### PR DESCRIPTION
This PR adds option `logger/messages_as_breadcrumbs` which is enabled by default. This allows disabling messages as breadcrumbs by a simple toggle. Since some projects `print()` heavily into console, this option should be quite useful.

- Resolves #293 

<img width="607" height="337" alt="Screenshot 2025-08-07 at 19 15 49" src="https://github.com/user-attachments/assets/00106666-8c1e-4044-b9e4-6d7fa21c8825" />

