### PR TITLE
feat: Add support for script context and variables on Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for script context and variables on Apple platforms ([#306](https://github.com/getsentry/sentry-godot/pull/306))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.54.0 to v8.55.0 ([#318](https://github.com/getsentry/sentry-godot/pull/318))

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -223,8 +223,21 @@ void CocoaEvent::add_exception(const Exception &p_exception) {
 		cocoa_frame.inApp = bool_to_objc(frame.in_app);
 		cocoa_frame.platform = string_to_objc(frame.platform);
 
-		// TODO: unable to pass context_line, pre_context, post_context.
-		// TODO: unable to pass local/member vars.
+		if (!frame.context_line.is_empty()) {
+			cocoa_frame.contextLine = string_to_objc(frame.context_line);
+			cocoa_frame.preContext = string_array_to_objc(frame.pre_context);
+			cocoa_frame.postContext = string_array_to_objc(frame.post_context);
+		}
+
+		if (!frame.vars.is_empty()) {
+			NSMutableDictionary *objc_vars = [NSMutableDictionary dictionaryWithCapacity:frame.vars.size()];
+			for (const auto &var : frame.vars) {
+				NSString *key = string_to_objc(var.first);
+				id value = variant_to_objc(var.second);
+				objc_vars[key] = value;
+			}
+			cocoa_frame.vars = objc_vars;
+		}
 
 		[mut_frames addObject:cocoa_frame];
 	}

--- a/src/sentry/cocoa/cocoa_util.h
+++ b/src/sentry/cocoa/cocoa_util.h
@@ -72,6 +72,7 @@ _FORCE_INLINE_ NSNumber *double_to_objc(double p_num) {
 
 NSObject *variant_to_objc(const godot::Variant &p_value, int p_depth = 0);
 NSDictionary *dictionary_to_objc(const godot::Dictionary &p_dictionary);
+NSArray<NSString *> *string_array_to_objc(const godot::PackedStringArray &p_array);
 
 } //namespace sentry::cocoa
 

--- a/src/sentry/cocoa/cocoa_util.mm
+++ b/src/sentry/cocoa/cocoa_util.mm
@@ -79,4 +79,12 @@ NSDictionary *dictionary_to_objc(const godot::Dictionary &p_dictionary) {
 	return (NSDictionary *)variant_to_objc(p_dictionary);
 }
 
+NSArray<NSString *> *string_array_to_objc(const godot::PackedStringArray &p_array) {
+	NSMutableArray<NSString *> *objc_array = [[NSMutableArray alloc] init];
+	for (int i = 0; i < p_array.size(); i++) {
+		[objc_array addObject:string_to_objc(p_array[i])];
+	}
+	return objc_array;
+}
+
 } // namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_util.mm
+++ b/src/sentry/cocoa/cocoa_util.mm
@@ -80,7 +80,7 @@ NSDictionary *dictionary_to_objc(const godot::Dictionary &p_dictionary) {
 }
 
 NSArray<NSString *> *string_array_to_objc(const godot::PackedStringArray &p_array) {
-	NSMutableArray<NSString *> *objc_array = [[NSMutableArray alloc] init];
+	NSMutableArray<NSString *> *objc_array = [NSMutableArray arrayWithCapacity:p_array.size()];
 	for (int i = 0; i < p_array.size(); i++) {
 		[objc_array addObject:string_to_objc(p_array[i])];
 	}


### PR DESCRIPTION
This PR adds support for scripting source context and local variables on iOS and macOS.

- Note: Builds will fail to compile without Cocoa SDK changes.
- Waiting for changes in Cocoa SDK https://github.com/getsentry/sentry-cocoa/pull/5853

Before this PR: 
<img width="735" height="256" alt="Screenshot 2025-08-08 at 14 27 43" src="https://github.com/user-attachments/assets/f9a1406d-b454-4e60-89ef-cab4a6180082" />

After this PR:
<img width="1002" height="621" alt="Screenshot 2025-08-07 at 16 27 01" src="https://github.com/user-attachments/assets/a95b0534-e598-4d5e-87bf-453d41fb48af" />
