### PR TITLE
chore: Bump Godot compatibility to 4.5-beta5

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -33,7 +33,7 @@ runs:
       env:
         # Set pre-release version status here (e.g. "beta1");
         # for release version, set to "stable".
-        RELEASE_STATUS: beta4
+        RELEASE_STATUS: beta5
         ARCH: ${{ inputs.arch }}
       run: |
         major_minor=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1/p' project/addons/sentry/sentry.gdextension)

--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -283,7 +283,7 @@ jobs:
         if: matrix.platform == 'android'
         uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # v1.5.0
         with:
-          ndk-version: r23c
+          ndk-version: r28b
           link-to-sdk: true
 
       - name: Compile GDExtension library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Bump Godot compatibility to 4.5-beta5 ([#307](https://github.com/getsentry/sentry-godot/pull/307))
+
 ### Features
 
 - Intoduce `SentryTimestamp` class to improve timestamp handling ([#286](https://github.com/getsentry/sentry-godot/pull/286))


### PR DESCRIPTION
BREAKING: Compatible Godot version is `4.5-beta5`.