### PR TITLE
ref: Improve initialization flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Impove initialization flow ([#322](https://github.com/getsentry/sentry-godot/pull/322))
+
 ## 1.0.0-beta.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Impove initialization flow ([#322](https://github.com/getsentry/sentry-godot/pull/322))
+- Improve initialization flow ([#322](https://github.com/getsentry/sentry-godot/pull/322))
 
 ## 1.0.0-beta.0
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -73,7 +73,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 
 		SentryOptions::create_singleton();
 
-		SentrySDK *sentry_singleton = memnew(SentrySDK);
+		SentrySDK::create_singleton();
 		Engine::get_singleton()->register_singleton("SentrySDK", SentrySDK::get_singleton());
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 #ifdef TOOLS_ENABLED

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -39,49 +39,58 @@
 using namespace godot;
 using namespace sentry;
 
-void initialize_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
-	} else if (p_level == godot::MODULE_INITIALIZATION_LEVEL_SERVERS) {
-	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		GDREGISTER_CLASS(SentryLoggerLimits);
-		GDREGISTER_CLASS(SentryOptions);
-		GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
-		GDREGISTER_CLASS(SentryConfiguration);
-		GDREGISTER_CLASS(SentryUser);
-		GDREGISTER_CLASS(SentryTimestamp);
-		GDREGISTER_CLASS(SentrySDK);
-		GDREGISTER_ABSTRACT_CLASS(SentryAttachment);
-		GDREGISTER_ABSTRACT_CLASS(SentryEvent);
-		GDREGISTER_INTERNAL_CLASS(DisabledEvent);
-		GDREGISTER_INTERNAL_CLASS(SentryEventProcessor);
-		GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);
-		GDREGISTER_INTERNAL_CLASS(ViewHierarchyProcessor);
-		GDREGISTER_INTERNAL_CLASS(SentryLogger);
+void register_runtime_classes() {
+	GDREGISTER_CLASS(SentryLoggerLimits);
+	GDREGISTER_CLASS(SentryOptions);
+	GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
+	GDREGISTER_CLASS(SentryConfiguration);
+	GDREGISTER_CLASS(SentryUser);
+	GDREGISTER_CLASS(SentryTimestamp);
+	GDREGISTER_CLASS(SentrySDK);
+	GDREGISTER_ABSTRACT_CLASS(SentryAttachment);
+	GDREGISTER_ABSTRACT_CLASS(SentryEvent);
+	GDREGISTER_INTERNAL_CLASS(DisabledEvent);
+	GDREGISTER_INTERNAL_CLASS(SentryEventProcessor);
+	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);
+	GDREGISTER_INTERNAL_CLASS(ViewHierarchyProcessor);
+	GDREGISTER_INTERNAL_CLASS(SentryLogger);
 
 #ifdef SDK_NATIVE
-		GDREGISTER_INTERNAL_CLASS(NativeEvent);
+	GDREGISTER_INTERNAL_CLASS(NativeEvent);
 #endif
 
 #ifdef SDK_ANDROID
-		GDREGISTER_INTERNAL_CLASS(AndroidEvent);
-		GDREGISTER_INTERNAL_CLASS(SentryAndroidBeforeSendHandler);
+	GDREGISTER_INTERNAL_CLASS(AndroidEvent);
+	GDREGISTER_INTERNAL_CLASS(SentryAndroidBeforeSendHandler);
 #endif
 
 #ifdef SDK_COCOA
-		GDREGISTER_INTERNAL_CLASS(cocoa::CocoaEvent);
+	GDREGISTER_INTERNAL_CLASS(cocoa::CocoaEvent);
 #endif
+}
 
+void register_editor_classes() {
+#ifdef TOOLS_ENABLED
+	GDREGISTER_INTERNAL_CLASS(SentryEditorExportPluginAndroid);
+	GDREGISTER_INTERNAL_CLASS(SentryEditorPlugin);
+
+#ifndef WINDOWS_ENABLED
+	GDREGISTER_INTERNAL_CLASS(SentryEditorExportPluginUnix);
+#endif // !WINDOWS_ENABLED
+
+#endif // TOOLS_ENABLED
+}
+
+void initialize_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
+	} else if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		register_runtime_classes();
 		SentryOptions::create_singleton();
-
 		SentrySDK::create_singleton();
-		Engine::get_singleton()->register_singleton("SentrySDK", SentrySDK::get_singleton());
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 #ifdef TOOLS_ENABLED
-#ifndef WINDOWS_ENABLED
-		GDREGISTER_INTERNAL_CLASS(SentryEditorExportPluginUnix);
-#endif // !WINDOWS_ENABLED
-		GDREGISTER_INTERNAL_CLASS(SentryEditorExportPluginAndroid);
-		GDREGISTER_INTERNAL_CLASS(SentryEditorPlugin);
+		register_editor_classes();
 		EditorPlugins::add_by_type<SentryEditorPlugin>();
 #endif // TOOLS_ENABLED
 	}
@@ -89,9 +98,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 
 void uninitialize_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		if (SentrySDK::get_singleton()) {
-			memdelete(SentrySDK::get_singleton());
-		}
+		SentrySDK::destroy_singleton();
 		SentryOptions::destroy_singleton();
 	}
 }

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -88,6 +88,7 @@ void initialize_module(ModuleInitializationLevel p_level) {
 		register_runtime_classes();
 		SentryOptions::create_singleton();
 		SentrySDK::create_singleton();
+		SentrySDK::get_singleton()->prepare_and_auto_initialize();
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 #ifdef TOOLS_ENABLED
 		register_editor_classes();

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -125,7 +125,7 @@ void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}
 }
 
-void AndroidSDK::initialize(const PackedStringArray &p_global_attachments) {
+void AndroidSDK::init(const PackedStringArray &p_global_attachments) {
 	ERR_FAIL_NULL(android_plugin);
 
 	sentry::util::print_debug("Initializing Sentry Android SDK");

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -49,7 +49,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void initialize(const PackedStringArray &p_global_attachments) override;
+	virtual void init(const PackedStringArray &p_global_attachments) override;
 
 	bool has_android_plugin() const { return android_plugin != nullptr; }
 

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -36,8 +36,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void initialize(const PackedStringArray &p_global_attachments) override;
-
+	virtual void init(const PackedStringArray &p_global_attachments) override;
 	bool is_enabled() const;
 
 	CocoaSDK();

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -144,7 +144,7 @@ void CocoaSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}];
 }
 
-void CocoaSDK::initialize(const PackedStringArray &p_global_attachments) {
+void CocoaSDK::init(const PackedStringArray &p_global_attachments) {
 	[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.godot"];
 
 	[objc::SentrySDK startWithConfigureOptions:^(objc::SentryOptions *options) {

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -28,7 +28,7 @@ class DisabledSDK : public InternalSDK {
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override {}
 
-	virtual void initialize(const PackedStringArray &p_global_attachments) override {}
+	virtual void init(const PackedStringArray &p_global_attachments) override {}
 };
 
 } // namespace sentry

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) = 0;
 
-	virtual void initialize(const PackedStringArray &p_global_attachments) = 0;
+	virtual void init(const PackedStringArray &p_global_attachments) = 0;
 
 	virtual ~InternalSDK() = default;
 };

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -261,7 +261,7 @@ void NativeSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}
 }
 
-void NativeSDK::initialize(const PackedStringArray &p_global_attachments) {
+void NativeSDK::init(const PackedStringArray &p_global_attachments) {
 	ERR_FAIL_NULL(OS::get_singleton());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void initialize(const PackedStringArray &p_global_attachments) override;
+	virtual void init(const PackedStringArray &p_global_attachments) override;
 
 	NativeSDK();
 	virtual ~NativeSDK() override;

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -267,14 +267,8 @@ void SentrySDK::_auto_initialize() {
 
 #if SDK_ANDROID
 	if (should_enable) {
-		if (unlikely(OS::get_singleton()->has_feature("editor"))) {
+		if (OS::get_singleton()->has_feature("editor")) {
 			should_enable = false;
-		} else {
-			std::shared_ptr<AndroidSDK> android_sdk = std::make_shared<AndroidSDK>();
-			if (!android_sdk->has_android_plugin()) {
-				sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
-				should_enable = false;
-			}
 		}
 	}
 #endif

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -280,7 +280,7 @@ void SentrySDK::_auto_initialize() {
 		return;
 	}
 
-	internal_sdk->initialize(_get_global_attachments());
+	internal_sdk->init(_get_global_attachments());
 
 	if (SentryOptions::get_singleton()->is_logger_enabled()) {
 		logger.instantiate();

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -270,7 +270,8 @@ void SentrySDK::_auto_initialize() {
 		if (unlikely(OS::get_singleton()->has_feature("editor"))) {
 			should_enable = false;
 		} else {
-			if (!sdk->has_android_plugin()) {
+			std::shared_ptr<AndroidSDK> android_sdk = std::make_shared<AndroidSDK>();
+			if (!android_sdk->has_android_plugin()) {
 				sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
 				should_enable = false;
 			}

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -285,14 +285,6 @@ void SentrySDK::_auto_initialize() {
 		return;
 	}
 
-	// Add event processors
-	if (SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
-		SentryOptions::get_singleton()->add_event_processor(memnew(ScreenshotProcessor));
-	}
-	if (SentryOptions::get_singleton()->is_attach_scene_tree_enabled()) {
-		SentryOptions::get_singleton()->add_event_processor(memnew(ViewHierarchyProcessor));
-	}
-
 	internal_sdk->initialize(_get_global_attachments());
 
 	if (SentryOptions::get_singleton()->is_logger_enabled()) {
@@ -341,6 +333,14 @@ void SentrySDK::prepare_and_auto_initialize() {
 		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/arm32/crashpad_handler");
 	}
 #endif
+
+	// Add event processors.
+	if (SentryOptions::get_singleton()->is_attach_screenshot_enabled()) {
+		SentryOptions::get_singleton()->add_event_processor(memnew(ScreenshotProcessor));
+	}
+	if (SentryOptions::get_singleton()->is_attach_scene_tree_enabled()) {
+		SentryOptions::get_singleton()->add_event_processor(memnew(ViewHierarchyProcessor));
+	}
 
 	// Auto-initialize SDK.
 	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -102,6 +102,22 @@ namespace sentry {
 
 SentrySDK *SentrySDK::singleton = nullptr;
 
+void SentrySDK::create_singleton() {
+	ERR_FAIL_NULL(Engine::get_singleton());
+	singleton = memnew(SentrySDK);
+	Engine::get_singleton()->register_singleton("SentrySDK", SentrySDK::get_singleton());
+}
+
+void SentrySDK::destroy_singleton() {
+	ERR_FAIL_NULL(Engine::get_singleton());
+	if (!singleton) {
+		return;
+	}
+	Engine::get_singleton()->unregister_singleton("SentrySDK");
+	memdelete(singleton);
+	singleton = nullptr;
+}
+
 String SentrySDK::capture_message(const String &p_message, Level p_level) {
 	return internal_sdk->capture_message(p_message, p_level);
 }

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -265,30 +265,18 @@ void SentrySDK::_initialize() {
 		sentry::util::print_debug("Sentry SDK is disabled when project is played from the editor. Tip: This can be changed in the project settings.");
 	}
 
+#if SDK_ANDROID
 	if (should_enable) {
-#ifdef SDK_NATIVE
-		internal_sdk = std::make_shared<NativeSDK>();
-#elif SDK_ANDROID
 		if (unlikely(OS::get_singleton()->has_feature("editor"))) {
-			sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
 			should_enable = false;
 		} else {
-			auto sdk = std::make_shared<AndroidSDK>();
-			if (sdk->has_android_plugin()) {
-				internal_sdk = sdk;
-			} else {
+			if (!sdk->has_android_plugin()) {
 				sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
 				should_enable = false;
 			}
 		}
-#elif SDK_COCOA
-		internal_sdk = std::make_shared<sentry::cocoa::CocoaSDK>();
-#else
-		// Unsupported platform
-		sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
-		should_enable = false;
-#endif
 	}
+#endif
 
 	enabled = should_enable;
 
@@ -332,6 +320,50 @@ void SentrySDK::notify_options_configured() {
 	configuration_succeeded = true;
 	_initialize();
 	_init_contexts();
+}
+
+void SentrySDK::prepare_and_auto_initialize() {
+	// Load the runtime configuration from the user's data directory.
+	runtime_config.instantiate();
+	runtime_config->load_file(OS::get_singleton()->get_user_data_dir() + "/sentry.dat");
+
+	// Verify project settings and notify user via errors if there are any issues (deferred).
+	callable_mp_static(_verify_project_settings).call_deferred();
+
+#if defined(LINUX_ENABLED) || defined(MACOS_ENABLED)
+	// Fix crashpad handler executable bit permissions on Unix platforms if the
+	// user extracts the distribution archive without preserving such permissions.
+	if (OS::get_singleton()->is_debug_build()) {
+		_fix_unix_executable_permissions("res://addons/sentry/bin/macos/crashpad_handler");
+		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/x86_64/crashpad_handler");
+		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/x86_32/crashpad_handler");
+		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/arm64/crashpad_handler");
+		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/arm32/crashpad_handler");
+	}
+#endif
+
+	// Auto-initialize SDK.
+	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
+		// Early initialization path.
+		_initialize();
+		// Delay contexts initialization until the engine singletons are ready.
+		callable_mp(this, &SentrySDK::_init_contexts).call_deferred();
+	} else {
+		// Register an autoload singleton, which is a user script extending the
+		// `SentryConfiguration` class. It will be instantiated and added to the
+		// scene tree by the engine shortly after ScriptServer is initialized.
+		// When this happens, the `SentryConfiguration` instance receives
+		// `NOTIFICATION_READY`, triggering our notification processing code in
+		// C++, which calls `_configure()` on the user script and then invokes
+		// `notify_options_configured()` in `SentrySDK`. This, in turn, initializes
+		// the internal SDK.
+		sentry::util::print_debug("waiting for user configuration autoload");
+		ERR_FAIL_NULL(ProjectSettings::get_singleton());
+		ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",
+				SentryOptions::get_singleton()->get_configuration_script());
+		// Ensure issues with the configuration script are detected.
+		callable_mp(this, &SentrySDK::_check_if_configuration_succeeded).call_deferred();
+	}
 }
 
 void SentrySDK::_notification(int p_what) {
@@ -379,51 +411,22 @@ SentrySDK::SentrySDK() {
 
 	user_mutex.instantiate();
 
-	// Prevent potential crashes if initialization is skipped (unsupported platform, script failure, etc.)
-	internal_sdk = std::make_shared<DisabledSDK>();
-
-	singleton = this;
-
-	// Load the runtime configuration from the user's data directory.
-	runtime_config.instantiate();
-	runtime_config->load_file(OS::get_singleton()->get_user_data_dir() + "/sentry.dat");
-
-	// Verify project settings and notify user via errors if there are any issues (deferred).
-	callable_mp_static(_verify_project_settings).call_deferred();
-
-#if defined(LINUX_ENABLED) || defined(MACOS_ENABLED)
-	// Fix crashpad handler executable bit permissions on Unix platforms if the
-	// user extracts the distribution archive without preserving such permissions.
-	if (OS::get_singleton()->is_debug_build()) {
-		_fix_unix_executable_permissions("res://addons/sentry/bin/macos/crashpad_handler");
-		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/x86_64/crashpad_handler");
-		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/x86_32/crashpad_handler");
-		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/arm64/crashpad_handler");
-		_fix_unix_executable_permissions("res://addons/sentry/bin/linux/arm32/crashpad_handler");
-	}
-#endif
-
-	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
-		// Early initialization path.
-		_initialize();
-		// Delay contexts initialization until the engine singletons are ready.
-		callable_mp(this, &SentrySDK::_init_contexts).call_deferred();
+#ifdef SDK_NATIVE
+	internal_sdk = std::make_shared<NativeSDK>();
+#elif SDK_ANDROID
+	if (unlikely(OS::get_singleton()->has_feature("editor"))) {
+		sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
+		internal_sdk = std::make_shared<DisabledSDK>();
 	} else {
-		// Register an autoload singleton, which is a user script extending the
-		// `SentryConfiguration` class. It will be instantiated and added to the
-		// scene tree by the engine shortly after ScriptServer is initialized.
-		// When this happens, the `SentryConfiguration` instance receives
-		// `NOTIFICATION_READY`, triggering our notification processing code in
-		// C++, which calls `_configure()` on the user script and then invokes
-		// `notify_options_configured()` in `SentrySDK`. This, in turn, initializes
-		// the internal SDK.
-		sentry::util::print_debug("waiting for user configuration autoload");
-		ERR_FAIL_NULL(ProjectSettings::get_singleton());
-		ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",
-				SentryOptions::get_singleton()->get_configuration_script());
-		// Ensure issues with the configuration script are detected.
-		callable_mp(this, &SentrySDK::_check_if_configuration_succeeded).call_deferred();
+		internal_sdk = std::make_shared<AndroidSDK>();
 	}
+#elif SDK_COCOA
+	internal_sdk = std::make_shared<sentry::cocoa::CocoaSDK>();
+#else
+	// Unsupported platform
+	sentry::util::print_debug("This is an unsupported platform. Disabling Sentry SDK...");
+	internal_sdk = std::make_shared<DisabledSDK>();
+#endif
 }
 
 SentrySDK::~SentrySDK() {

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -235,7 +235,7 @@ PackedStringArray SentrySDK::_get_global_attachments() {
 	return attachments;
 }
 
-void SentrySDK::_initialize() {
+void SentrySDK::_auto_initialize() {
 	sentry::util::print_debug("starting Sentry SDK version " + String(SENTRY_GODOT_SDK_VERSION));
 
 	// Initialize user if it wasn't set explicitly in the configuration script.
@@ -306,7 +306,7 @@ void SentrySDK::_check_if_configuration_succeeded() {
 		// Push error and initialize anyway.
 		ERR_PRINT("Sentry: Configuration via user script failed. Will try to initialize SDK anyway.");
 		sentry::util::print_error("initializing late because configuration via user script failed");
-		_initialize();
+		_auto_initialize();
 	}
 }
 
@@ -318,7 +318,7 @@ void SentrySDK::_demo_helper_crash_app() {
 void SentrySDK::notify_options_configured() {
 	sentry::util::print_debug("finished configuring options via user script");
 	configuration_succeeded = true;
-	_initialize();
+	_auto_initialize();
 	_init_contexts();
 }
 
@@ -345,7 +345,7 @@ void SentrySDK::prepare_and_auto_initialize() {
 	// Auto-initialize SDK.
 	if (SentryOptions::get_singleton()->get_configuration_script().is_empty() || Engine::get_singleton()->is_editor_hint()) {
 		// Early initialization path.
-		_initialize();
+		_auto_initialize();
 		// Delay contexts initialization until the engine singletons are ready.
 		callable_mp(this, &SentrySDK::_init_contexts).call_deferred();
 	} else {
@@ -355,8 +355,8 @@ void SentrySDK::prepare_and_auto_initialize() {
 		// When this happens, the `SentryConfiguration` instance receives
 		// `NOTIFICATION_READY`, triggering our notification processing code in
 		// C++, which calls `_configure()` on the user script and then invokes
-		// `notify_options_configured()` in `SentrySDK`. This, in turn, initializes
-		// the internal SDK.
+		// `notify_options_configured()` in `SentrySDK`. This, in turn,
+		// auto-initializes the internal SDK.
 		sentry::util::print_debug("waiting for user configuration autoload");
 		ERR_FAIL_NULL(ProjectSettings::get_singleton());
 		ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -356,7 +356,7 @@ void SentrySDK::prepare_and_auto_initialize() {
 		// `NOTIFICATION_READY`, triggering our notification processing code in
 		// C++, which calls `_configure()` on the user script and then invokes
 		// `notify_options_configured()` in `SentrySDK`. This, in turn,
-		// auto-initializes the internal SDK.
+		// auto-initializes the SDK.
 		sentry::util::print_debug("waiting for user configuration autoload");
 		ERR_FAIL_NULL(ProjectSettings::get_singleton());
 		ProjectSettings::get_singleton()->set_setting("autoload/SentryConfigurationScript",

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -413,7 +413,13 @@ SentrySDK::SentrySDK() {
 		sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
 		internal_sdk = std::make_shared<DisabledSDK>();
 	} else {
-		internal_sdk = std::make_shared<AndroidSDK>();
+		auto sdk = std::make_shared<AndroidSDK>();
+		if (sdk->has_android_plugin()) {
+			internal_sdk = sdk;
+		} else {
+			sentry::util::print_error("Failed to initialize on Android. Disabling Sentry SDK...");
+			internal_sdk = std::make_shared<DisabledSDK>();
+		}
 	}
 #elif SDK_COCOA
 	internal_sdk = std::make_shared<sentry::cocoa::CocoaSDK>();

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -51,6 +51,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static void create_singleton();
+	static void destroy_singleton();
 	static SentrySDK *get_singleton() { return singleton; }
 
 	_FORCE_INLINE_ std::shared_ptr<sentry::InternalSDK> get_internal_sdk() const { return internal_sdk; }

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -88,6 +88,8 @@ public:
 	void unset_before_send() { SentryOptions::get_singleton()->set_before_send(Callable()); }
 	Callable get_before_send() { return SentryOptions::get_singleton()->get_before_send(); }
 
+	void prepare_and_auto_initialize();
+
 	SentrySDK();
 	~SentrySDK();
 };

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -41,7 +41,7 @@ private:
 
 	void _init_contexts();
 	PackedStringArray _get_global_attachments();
-	void _initialize();
+	void _auto_initialize();
 	void _check_if_configuration_succeeded();
 	void _demo_helper_crash_app();
 


### PR DESCRIPTION
This PR cleans up and restructures initialization flow in preparation for lifecycle methods, extracted from #321.

- Clean up module initialization and class registration.
- Add SentrySDK create_singleton()/destroy_singleton() functions for cleaner code.
- Separate SentrySDK construction from SDK auto initialization.
   - Ensure InternalSDK interface is created early (in constructor).
   - Move startup and initialization logic from constructor into `prepare_and_auto_initialize()` method.
- Rename InternalSDK initialize() => init() to better align with Sentry terminology.
- Better function names.

These changes make it easier to follow the initialization flow and reduce the risk of errors.
