### PR TITLE
fix: Ensure compatibility with minSdk 24 on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Ensure compatibility with minSdk 24 on Android ([#324](https://github.com/getsentry/sentry-godot/pull/324))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.54.0 to v8.55.0 ([#318](https://github.com/getsentry/sentry-godot/pull/318))

--- a/android_lib/build.gradle.kts
+++ b/android_lib/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
 
         consumerProguardFiles("consumer-rules.pro")
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -277,7 +277,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     @UsedByGodot
     fun eventGetTimestamp(eventHandle: Int): Long {
         val event: SentryEvent = getEvent(eventHandle) ?: return 0
-        return event.timestamp?.toInstant()?.toMicros() ?: 0
+        return event.timestamp?.toMicros() ?: 0
     }
 
     @UsedByGodot

--- a/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
@@ -24,16 +24,12 @@ fun SentryLevel.toInt(): Int =
     }
 
 fun Long.microsecondsToTimestamp(): Date {
-    val micros: Long = this@microsecondsToTimestamp
-    val seconds = micros / 1_000_000
-    val nanos = (micros % 1_000_000) * 1000
-
-    val instant = Instant.ofEpochSecond(seconds, nanos.toLong())
-    return Date.from(instant)
+    val millis = this / 1_000
+    return Date(millis)
 }
 
 
-fun Instant.toMicros(): Long {
-    val instant: Instant = this@toMicros
-    return instant.epochSecond * 1_000_000 + instant.nano / 1_000
+fun Date.toMicros(): Long {
+    val date: Date = this@toMicros
+    return date.time * 1000
 }


### PR DESCRIPTION
This PR sets minimum Android SDK compatibility to 24 as in the upcoming Godot 4.5, and replaces API 26-only calls to ensure such compatibility.