### PR TITLE
feat: Add SentryEvent.to_json()

### DIFF
--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import io.sentry.Attachment
 import io.sentry.Breadcrumb
 import io.sentry.Hint
+import io.sentry.ISerializer
 import io.sentry.Sentry
 import io.sentry.SentryEvent
 import io.sentry.SentryLevel
@@ -20,6 +21,7 @@ import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.plugin.UsedByGodot
 import org.godotengine.godot.variant.Callable
 import java.io.File
+import java.io.StringWriter
 import kotlin.random.Random
 
 
@@ -379,6 +381,15 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     @UsedByGodot
     fun eventIsCrash(eventHandle: Int): Boolean {
         return getEvent(eventHandle)?.isCrashed == true
+    }
+
+    @UsedByGodot
+    fun eventToJson(eventHandle: Int): String {
+        val event = getEvent(eventHandle) ?: return ""
+        val serializer: ISerializer = Sentry.getCurrentScopes().options.serializer
+        val writer = StringWriter()
+        serializer.serialize(event, writer)
+        return writer.toString()
     }
 
     @UsedByGodot

--- a/doc_classes/SentryEvent.xml
+++ b/doc_classes/SentryEvent.xml
@@ -38,6 +38,12 @@
 				Sets a tag with the specified [param key] to the given [param value].
 			</description>
 		</method>
+		<method name="to_json" qualifiers="const">
+			<return type="String" />
+			<description>
+				Serializes the event to JSON string.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="dist" type="String" setter="set_dist" getter="get_dist">

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -136,6 +136,11 @@ bool AndroidEvent::is_crash() const {
 	return android_plugin->call(ANDROID_SN(eventIsCrash), event_handle);
 }
 
+String AndroidEvent::to_json() const {
+	ERR_FAIL_NULL_V(android_plugin, String());
+	return android_plugin->call(ANDROID_SN(eventToJson), event_handle);
+}
+
 AndroidEvent::AndroidEvent(Object *p_android_plugin, int32_t p_event_handle) {
 	android_plugin = p_android_plugin;
 	event_handle = p_event_handle;

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -57,6 +57,8 @@ public:
 
 	virtual bool is_crash() const override;
 
+	virtual String to_json() const override;
+
 	void set_as_borrowed() { is_borrowed = true; }
 
 	AndroidEvent() {}

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -53,6 +53,7 @@ AndroidStringNames::AndroidStringNames() {
 	eventGetTag = StringName("eventGetTag");
 	eventMergeContext = StringName("eventMergeContext");
 	eventIsCrash = StringName("eventIsCrash");
+	eventToJson = StringName("eventToJson");
 
 	// Exceptions.
 	createException = StringName("createException");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -65,6 +65,7 @@ public:
 	StringName eventGetTag;
 	StringName eventMergeContext;
 	StringName eventIsCrash;
+	StringName eventToJson;
 
 	// Exceptions.
 	StringName createException;

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -53,6 +53,8 @@ public:
 
 	virtual bool is_crash() const override;
 
+	virtual String to_json() const override;
+
 	CocoaEvent(objc::SentryEvent *p_cocoa_event);
 	CocoaEvent();
 	virtual ~CocoaEvent() override;

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -270,6 +270,20 @@ bool CocoaEvent::is_crash() const {
 	return cocoa_event.error != nil;
 }
 
+String CocoaEvent::to_json() const {
+	ERR_FAIL_NULL_V(cocoa_event, String());
+
+	NSDictionary *event_dict = [cocoa_event serialize];
+
+	NSError *error = nil;
+	NSData *json_data = [NSJSONSerialization dataWithJSONObject:event_dict
+														options:0
+														  error:&error];
+	ERR_FAIL_COND_V(error != nil, "Sentry: Failed to serialize event to JSON: " + string_from_objc(error.localizedDescription));
+
+	return String::utf8((const char *)json_data.bytes, json_data.length);
+}
+
 CocoaEvent::CocoaEvent() :
 		cocoa_event([[objc::SentryEvent alloc] init]) {
 }

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -56,6 +56,8 @@ public:
 	virtual void add_exception(const Exception &p_exception) override {}
 
 	virtual bool is_crash() const override { return false; }
+
+	virtual String to_json() const override { return ""; }
 };
 
 } // namespace sentry

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -215,6 +215,10 @@ bool NativeEvent::is_crash() const {
 	return _is_crash;
 }
 
+String NativeEvent::to_json() const {
+	return String::utf8(sentry_value_to_json(native_event));
+}
+
 NativeEvent::NativeEvent(sentry_value_t p_native_event, bool p_is_crash) :
 		_is_crash(p_is_crash) {
 	if (sentry_value_refcount(p_native_event) > 0) {

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -56,6 +56,8 @@ public:
 
 	virtual bool is_crash() const override;
 
+	virtual String to_json() const override;
+
 	NativeEvent(sentry_value_t p_event, bool p_is_crash);
 	NativeEvent();
 	virtual ~NativeEvent() override;

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -27,6 +27,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentryEvent::remove_tag);
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
+	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "id"), "", "get_id");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "message"), "set_message", "get_message");

--- a/src/sentry/sentry_event.h
+++ b/src/sentry/sentry_event.h
@@ -76,6 +76,8 @@ public:
 
 	virtual bool is_crash() const = 0;
 
+	virtual String to_json() const = 0;
+
 	virtual ~SentryEvent() = default;
 };
 


### PR DESCRIPTION
Add `SentryEvent.to_json()` in public API just like in other SDKs. Extracted from #326. 
Tests are in #326.
