### PR TITLE
ref: Move native and android code into respective namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Potential crash in SentryLogger if removed early ([#323](https://github.com/getsentry/sentry-godot/pull/323))
 - Ensure compatibility with minSdk 24 on Android ([#324](https://github.com/getsentry/sentry-godot/pull/324))
 
+## Other changes
+
+- Move native and Android internal code into respective namespaces ([#333](https://github.com/getsentry/sentry-godot/pull/333))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.54.0 to v8.55.0 ([#318](https://github.com/getsentry/sentry-godot/pull/318))

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -56,12 +56,12 @@ void register_runtime_classes() {
 	GDREGISTER_INTERNAL_CLASS(SentryLogger);
 
 #ifdef SDK_NATIVE
-	GDREGISTER_INTERNAL_CLASS(NativeEvent);
+	GDREGISTER_INTERNAL_CLASS(native::NativeEvent);
 #endif
 
 #ifdef SDK_ANDROID
-	GDREGISTER_INTERNAL_CLASS(AndroidEvent);
-	GDREGISTER_INTERNAL_CLASS(SentryAndroidBeforeSendHandler);
+	GDREGISTER_INTERNAL_CLASS(android::AndroidEvent);
+	GDREGISTER_INTERNAL_CLASS(android::SentryAndroidBeforeSendHandler);
 #endif
 
 #ifdef SDK_COCOA

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -2,7 +2,7 @@
 
 #include "android_string_names.h"
 
-namespace sentry {
+namespace sentry::android {
 
 String AndroidEvent::get_id() const {
 	ERR_FAIL_NULL_V(android_plugin, String());
@@ -153,4 +153,4 @@ AndroidEvent::~AndroidEvent() {
 	}
 }
 
-} // namespace sentry
+} //namespace sentry::android

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -5,7 +5,7 @@
 
 using namespace godot;
 
-namespace sentry {
+namespace sentry::android {
 
 // Event class that is used with the AndroidSDK.
 class AndroidEvent : public SentryEvent {
@@ -66,6 +66,6 @@ public:
 	virtual ~AndroidEvent() override;
 };
 
-} // namespace sentry
+} //namespace sentry::android
 
 #endif // SENTRY_ANDROID_EVENT_H

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -13,7 +13,7 @@
 
 using namespace godot;
 
-namespace sentry {
+namespace sentry::android {
 
 void SentryAndroidBeforeSendHandler::_initialize(Object *p_android_plugin) {
 	android_plugin = p_android_plugin;
@@ -167,4 +167,4 @@ AndroidSDK::~AndroidSDK() {
 	}
 }
 
-} //namespace sentry
+} //namespace sentry::android

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -5,7 +5,7 @@
 
 using namespace godot;
 
-namespace sentry {
+namespace sentry::android {
 
 class SentryAndroidBeforeSendHandler : public Object {
 	GDCLASS(SentryAndroidBeforeSendHandler, Object);
@@ -57,6 +57,6 @@ public:
 	virtual ~AndroidSDK() override;
 };
 
-} //namespace sentry
+} //namespace sentry::android
 
 #endif // SENTRY_ANDROID_SDK_H

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -1,6 +1,6 @@
 #include "sentry/android/android_string_names.h"
 
-namespace sentry {
+namespace sentry::android {
 
 AndroidStringNames *AndroidStringNames::singleton = nullptr;
 
@@ -62,4 +62,4 @@ AndroidStringNames::AndroidStringNames() {
 	eventAddException = StringName("eventAddException");
 }
 
-} // namespace sentry
+} //namespace sentry::android

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -5,7 +5,7 @@
 
 using namespace godot;
 
-namespace sentry {
+namespace sentry::android {
 
 /**
  * Stores StringName constants for Android SDK implementation.
@@ -74,7 +74,7 @@ public:
 	StringName eventAddException;
 };
 
-} // namespace sentry
+} //namespace sentry::android
 
 #define ANDROID_SN(m_arg) sentry::AndroidStringNames::get_singleton()->m_arg
 

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -76,6 +76,6 @@ public:
 
 } //namespace sentry::android
 
-#define ANDROID_SN(m_arg) sentry::AndroidStringNames::get_singleton()->m_arg
+#define ANDROID_SN(m_arg) sentry::android::AndroidStringNames::get_singleton()->m_arg
 
 #endif // SENTRY_ANDROID_STRING_NAMES_H

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -47,7 +47,7 @@ void sentry_event_merge_context(sentry_value_t p_event, const char *p_context_na
 
 } // unnamed namespace
 
-namespace sentry {
+namespace sentry::native {
 
 String NativeEvent::get_id() const {
 	sentry_value_t id = sentry_value_get_by_key(native_event, "event_id");
@@ -242,4 +242,4 @@ NativeEvent::~NativeEvent() {
 	sentry_value_decref(native_event); // release ownership
 }
 
-} // namespace sentry
+} //namespace sentry::native

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -5,7 +5,7 @@
 
 #include <sentry.h>
 
-namespace sentry {
+namespace sentry::native {
 
 // Event class that is used with the NativeSDK.
 class NativeEvent : public SentryEvent {
@@ -63,6 +63,6 @@ public:
 	virtual ~NativeEvent() override;
 };
 
-} // namespace sentry
+} //namespace sentry::native
 
 #endif // NATIVE_EVENT_H

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -18,7 +18,7 @@
 
 namespace {
 
-using NativeEvent = sentry::NativeEvent;
+using NativeEvent = sentry::native::NativeEvent;
 
 sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closure) {
 	Ref<NativeEvent> event_obj = memnew(NativeEvent(event, false));
@@ -119,7 +119,7 @@ inline String _uuid_as_string(sentry_uuid_t p_uuid) {
 
 } // unnamed namespace
 
-namespace sentry {
+namespace sentry::native {
 
 void NativeSDK::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND(p_key.is_empty());
@@ -339,4 +339,4 @@ NativeSDK::~NativeSDK() {
 	sentry_close();
 }
 
-} //namespace sentry
+} //namespace sentry::native

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -6,7 +6,7 @@
 #include <sentry.h>
 #include <godot_cpp/classes/mutex.hpp>
 
-namespace sentry {
+namespace sentry::native {
 
 // Internal SDK utilizing sentry-native.
 class NativeSDK : public InternalSDK {
@@ -42,6 +42,6 @@ public:
 	virtual ~NativeSDK() override;
 };
 
-} //namespace sentry
+} //namespace sentry::native
 
 #endif // NATIVE_SDK_H

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -407,13 +407,13 @@ SentrySDK::SentrySDK() {
 	user_mutex.instantiate();
 
 #ifdef SDK_NATIVE
-	internal_sdk = std::make_shared<NativeSDK>();
+	internal_sdk = std::make_shared<sentry::native::NativeSDK>();
 #elif SDK_ANDROID
 	if (unlikely(OS::get_singleton()->has_feature("editor"))) {
 		sentry::util::print_debug("Sentry SDK is disabled in Android editor mode (only supported in exported Android projects)");
 		internal_sdk = std::make_shared<DisabledSDK>();
 	} else {
-		auto sdk = std::make_shared<AndroidSDK>();
+		auto sdk = std::make_shared<sentry::android::AndroidSDK>();
 		if (sdk->has_android_plugin()) {
 			internal_sdk = sdk;
 		} else {


### PR DESCRIPTION
Move Native and Android classes into their own namespace, similar to Cocoa internals.
