### PR TITLE
fix: UTF-8 retention problems with native SentryEvent properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Potential crash in SentryLogger if removed early ([#323](https://github.com/getsentry/sentry-godot/pull/323))
 - Ensure compatibility with minSdk 24 on Android ([#324](https://github.com/getsentry/sentry-godot/pull/324))
+- Fixed UTF-8 retention problems with native SentryEvent properties ([#345](https://github.com/getsentry/sentry-godot/pull/345))
 
 ## Other changes
 

--- a/project/test/suites/test_event.gd
+++ b/project/test/suites/test_event.gd
@@ -2,18 +2,26 @@ extends GdUnitTestSuite
 ## Basic tests for the SentryEvent class.
 
 
+## Test string properties accessors and UTF-8 encoding preservation.
+@warning_ignore("unused_parameter")
+func test_string_properties_and_utf8(property: String, test_parameters := [
+		["message"],
+		["logger"],
+		["release"],
+		["dist"],
+		["environment"],
+]) -> void:
+	var event := SentrySDK.create_event()
+	event.set(property, "Hello, World!")
+	assert_str(event.get(property)).is_equal("Hello, World!")
+	event.set(property, "Hello 世界! 👋")
+	assert_str(event.get(property)).is_equal("Hello 世界! 👋")
+
+
 ## SentryEvent.id should not be empty on event creation.
-func test_event_id() -> void:
+func test_event_id_not_empty() -> void:
 	var event := SentrySDK.create_event()
 	assert_str(event.id).is_not_empty()
-
-
-## SentryEvent.message should be set to the specified value, and should be empty on event creation.
-func test_event_message() -> void:
-	var event := SentrySDK.create_event()
-	assert_str(event.message).is_empty()
-	event.message = "Hello, World!"
-	assert_str(event.message).is_equal("Hello, World!")
 
 
 ## SentryEvent.level should be set to the specified value.
@@ -51,41 +59,9 @@ func test_event_timestamp() -> void:
 
 
 ## SentryEvent.platform should not be empty.
-func test_event_platform() -> void:
+func test_event_platform_not_empty() -> void:
 	var event := SentrySDK.create_event()
 	assert_str(event.platform).is_not_empty()
-
-
-## SentryEvent.logger should be set to the specified value, and empty on event creation.
-func test_event_logger() -> void:
-	var event := SentrySDK.create_event()
-	assert_str(event.logger).is_empty()
-	event.logger = "custom-logger"
-	assert_str(event.logger).is_equal("custom-logger")
-
-
-## SentryEvent.release should be set to the specified value, and empty on event creation.
-func test_event_release() -> void:
-	var event := SentrySDK.create_event()
-	assert_str(event.release).is_empty()
-	event.release = "custom-release"
-	assert_str(event.release).is_equal("custom-release")
-
-
-## SentryEvent.dist should be set to the specified value, and empty on event creation.
-func test_event_dist() -> void:
-	var event := SentrySDK.create_event()
-	assert_str(event.dist).is_empty()
-	event.dist = "custom-dist"
-	assert_str(event.dist).is_equal("custom-dist")
-
-
-## SentryEvent.environment should be set to the specified value, and empty on event creation.
-func test_event_environment() -> void:
-	var event := SentrySDK.create_event()
-	assert_str(event.environment).is_empty()
-	event.environment = "custom-environment"
-	assert_str(event.environment).is_equal("custom-environment")
 
 
 ## SentryEvent.set_tag() should set tag to the specified value, remove_tag() should unset it.
@@ -96,6 +72,8 @@ func test_event_tags() -> void:
 	assert_str(event.get_tag("test_tag")).is_equal("test_value")
 	event.remove_tag("test_tag")
 	assert_str(event.get_tag("test_tag")).is_empty()
+	event.set_tag("test_utf8", "Hello 世界! 👋")
+	assert_str(event.get_tag("test_utf8")).is_equal("Hello 世界! 👋")
 
 
 ## SentryEvent.is_crash() should return false on a custom-created event.

--- a/project/test/suites/test_sdk.gd
+++ b/project/test/suites/test_sdk.gd
@@ -6,7 +6,7 @@ signal callback_processed
 
 
 ## SentrySDK.capture_message() should return a non-empty event ID, which must match the ID returned by the get_last_event_id() call.
-func test_capture_message() -> void:
+func test_capture_message_id() -> void:
 	var event_id := SentrySDK.capture_message("capture_message_test", SentrySDK.LEVEL_DEBUG)
 	assert_str(event_id).is_not_empty()
 	assert_str(SentrySDK.get_last_event_id()).is_not_empty()
@@ -18,10 +18,12 @@ func test_set_tag() -> void:
 	SentrySDK._set_before_send(
 		func(ev: SentryEvent):
 			assert_str(ev.get_tag("custom-tag")).is_equal("custom-tag-value")
+			assert_str(ev.get_tag("utf8-test")).is_equal("Hello 世界! 👋")
 			callback_processed.emit()
 			return null)
 
 	SentrySDK.set_tag("custom-tag", "custom-tag-value")
+	SentrySDK.set_tag("utf8-test", "Hello 世界! 👋")
 
 	var monitor := monitor_signals(self, false)
 	SentrySDK.capture_message("test-tags")

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -73,7 +73,7 @@ String NativeEvent::get_message() const {
 		return String();
 	}
 	sentry_value_t formatted = sentry_value_get_by_key(message, "formatted");
-	return sentry_value_as_string(formatted);
+	return String::utf8(sentry_value_as_string(formatted));
 }
 
 void NativeEvent::set_timestamp(const Ref<SentryTimestamp> &p_timestamp) {
@@ -91,7 +91,7 @@ Ref<SentryTimestamp> NativeEvent::get_timestamp() const {
 
 String NativeEvent::get_platform() const {
 	sentry_value_t platform = sentry_value_get_by_key(native_event, "platform");
-	return sentry_value_as_string(platform);
+	return String::utf8(sentry_value_as_string(platform));
 }
 
 void NativeEvent::set_level(sentry::Level p_level) {
@@ -116,7 +116,7 @@ void NativeEvent::set_logger(const String &p_logger) {
 
 String NativeEvent::get_logger() const {
 	sentry_value_t logger = sentry_value_get_by_key(native_event, "logger");
-	return sentry_value_as_string(logger);
+	return String::utf8(sentry_value_as_string(logger));
 }
 
 void NativeEvent::set_release(const String &p_release) {
@@ -125,7 +125,7 @@ void NativeEvent::set_release(const String &p_release) {
 
 String NativeEvent::get_release() const {
 	sentry_value_t release = sentry_value_get_by_key(native_event, "release");
-	return sentry_value_as_string(release);
+	return String::utf8(sentry_value_as_string(release));
 }
 
 void NativeEvent::set_dist(const String &p_dist) {
@@ -134,7 +134,7 @@ void NativeEvent::set_dist(const String &p_dist) {
 
 String NativeEvent::get_dist() const {
 	sentry_value_t dist = sentry_value_get_by_key(native_event, "dist");
-	return sentry_value_as_string(dist);
+	return String::utf8(sentry_value_as_string(dist));
 }
 
 void NativeEvent::set_environment(const String &p_environment) {
@@ -143,7 +143,7 @@ void NativeEvent::set_environment(const String &p_environment) {
 
 String NativeEvent::get_environment() const {
 	sentry_value_t environment = sentry_value_get_by_key(native_event, "environment");
-	return sentry_value_as_string(environment);
+	return String::utf8(sentry_value_as_string(environment));
 }
 
 void NativeEvent::set_tag(const String &p_key, const String &p_value) {
@@ -169,7 +169,7 @@ String NativeEvent::get_tag(const String &p_key) {
 	sentry_value_t tags = sentry_value_get_by_key(native_event, "tags");
 	if (!sentry_value_is_null(tags)) {
 		sentry_value_t value = sentry_value_get_by_key(tags, p_key.utf8());
-		return String(sentry_value_as_string(value));
+		return String::utf8(sentry_value_as_string(value));
 	}
 	return String();
 }


### PR DESCRIPTION
This PR fixes issues with retaining UTF-8 encoding in native SentryEvent implementation, discovered while working on tests in #326. The problem is that getters should be using String::utf8() where we reasonably expect UTF-8. Extracted from #326.

- Fixes #336
- Partially implements #337, more are coming in #326