### PR TITLE
chore: Fix flaky timestamp test case

### DIFF
--- a/project/test/suites/test_breadcrumb.gd
+++ b/project/test/suites/test_breadcrumb.gd
@@ -49,7 +49,7 @@ func test_breadcrumb_default_values() -> void:
 
 
 func test_breadcrumb_timestamp_is_set_automatically() -> void:
-	const time_tolerance: float = 0.05  # 50 ms
+	const time_tolerance: float = 0.001  # 1 ms
 
 	var time_before: float = Time.get_unix_time_from_system() - time_tolerance
 	await get_tree().process_frame  # small delay to ensure timestamp differs


### PR DESCRIPTION
Few times I hit this issue:
<img width="745" height="146" alt="Screenshot 2025-09-04 at 17 34 46" src="https://github.com/user-attachments/assets/1728e4f9-1c9f-4821-ab1e-137ca2b109b8" />

This PR should allow more tolerance for this test.

#skip-changelog