### PR TITLE
feat: Strip invisible characters from logger breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Strip invisible characters from logger breadcrumbs ([#359](https://github.com/getsentry/sentry-godot/pull/359))
+
 ## 1.0.0-beta.2
 
 ### Breaking changes

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -387,14 +387,19 @@ void SentryLogger::_log_message(const String &p_message, bool p_error) {
 		return;
 	}
 
+	String processed_message = _strip_invisible(p_message);
+
+	if (processed_message.is_empty()) {
+		// Don't add empty breadcrumb.
+		return;
+	}
+
 	// Filtering: Check message prefixes to skip certain messages (e.g., Sentry's own debug output).
 	for (const String &prefix : filter_by_prefix) {
-		if (p_message.begins_with(prefix)) {
+		if (processed_message.begins_with(prefix)) {
 			return;
 		}
 	}
-
-	String processed_message = _strip_invisible(p_message);
 
 	Ref<SentryBreadcrumb> crumb = SentryBreadcrumb::create(processed_message);
 	crumb->set_category("log");

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -185,10 +185,10 @@ String _strip_invisible(const String &p_text) {
 		// Detect ANSI escape sequences: ESC (0x1B) + '['
 		if (c == 0x1B && i + 1 < length && p_text[i + 1] == '[') {
 			i += 2;
-			// Skip until we reach an ASCII letter (terminator)
+			// Skip until we reach a final byte (0x40-0x7E) aka [A-Za-z0-9].
 			while (i < length) {
 				char32_t cc = p_text[i];
-				if ((cc >= 'A' && cc <= 'Z') || (cc >= 'a' && cc <= 'z')) {
+				if (cc >= 0x40 && cc <= 0x7E) {
 					i++;
 					break;
 				}


### PR DESCRIPTION
Strip ASCII escape sequences and control characters from logger breadcrumbs. We're capturing Godot logger messages as breadcrumbs, and sometimes those messages contain unprintable control characters intended for terminal. Godot doesn't filter those sequences, hence this PR. 

- This affects any colorized output such as with `print_rich()`.
- Cocoa is particularly noisy, when such characters are added as breadcrumbs, making understanding unit test results very hard, as it produces a ton of errors.
- Closes #351 
