### PR TITLE
test: Add JSONAssert and SentryTestSuite

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -14,6 +14,7 @@ runs:
       run: |
         git submodule update --init --depth 1 modules/gdUnit4
         git submodule update --init --depth 1 modules/godot-cpp
+        git submodule update --init --depth 1 project/test/util/json_assert
 
     - name: Download artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -56,7 +56,7 @@ jobs:
               --script "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" \
               --ignoreHeadlessMode \
               --continue \
-              --add test/suites/
+              --add test/suites/ \
               --add test/util/json_assert/
 
       - name: Run isolated tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -52,7 +52,12 @@ jobs:
         timeout-minutes: 5
         run: |
           # Exit status codes: 0 - success, 100 - ends with test failures, 101 - ends with test warnings.
-          ${GODOT} --headless --path project/ -s -d "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" --ignoreHeadlessMode -c -a test/suites/
+          ${GODOT} --headless --debug --path project/ \
+              --script "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" \
+              --ignoreHeadlessMode \
+              --continue \
+              --add test/suites/
+              --add test/util/json_assert/
 
       - name: Run isolated tests
         if: success() || failure()

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -56,14 +56,24 @@ jobs:
               --script "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" \
               --ignoreHeadlessMode \
               --continue \
-              --add test/suites/ \
-              --add test/util/json_assert/
+              --add test/suites/
 
       - name: Run isolated tests
         if: success() || failure()
         shell: pwsh
         timeout-minutes: 5
         run: ./scripts/run-isolated-tests.ps1
+
+      - name: Run JSONAssert tests
+        if: success() || failure()
+        shell: bash
+        timeout-minutes: 2
+        run: |
+          ${GODOT} --headless --debug --path project/ \
+              --script "res://addons/gdUnit4/bin/GdUnitCmdTool.gd" \
+              --ignoreHeadlessMode \
+              --continue \
+              --add test/util/json_assert/
 
       - name: Upload results
         if: always() # do this step even if the tests fail

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "modules/godot-cpp"]
 	path = modules/godot-cpp
 	url = https://github.com/godotengine/godot-cpp
+[submodule "project/test/util/json_assert"]
+	path = project/test/util/json_assert
+	url = https://github.com/getsentry/gdunit-json-assert

--- a/project/project_main_loop.gd
+++ b/project/project_main_loop.gd
@@ -8,6 +8,9 @@ extends SceneTree
 
 
 func _initialize() -> void:
+	if _is_testing_environment():
+		return
+
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		print("INFO: [ProjectMainLoop] Initializing SDK from GDScript")
 
@@ -34,3 +37,7 @@ func _on_before_send_to_sentry(ev: SentryEvent) -> SentryEvent:
 		print("INFO: [ProjectMainLoop] Discarding event with message 'junk'")
 		return null
 	return ev
+
+
+func _is_testing_environment() -> bool:
+	return "res://addons/gdUnit4/src/core/runners/GdUnitTestRunner.tscn" in OS.get_cmdline_args()

--- a/project/project_main_loop.gd
+++ b/project/project_main_loop.gd
@@ -8,7 +8,7 @@ extends SceneTree
 
 
 func _initialize() -> void:
-	if _is_testing_environment():
+	if _is_running_tests():
 		return
 
 	SentrySDK.init(func(options: SentryOptions) -> void:
@@ -39,5 +39,5 @@ func _on_before_send_to_sentry(ev: SentryEvent) -> SentryEvent:
 	return ev
 
 
-func _is_testing_environment() -> bool:
+func _is_running_tests() -> bool:
 	return "res://addons/gdUnit4/src/core/runners/GdUnitTestRunner.tscn" in OS.get_cmdline_args()

--- a/project/test/suites/test_attachment.gd
+++ b/project/test/suites/test_attachment.gd
@@ -1,4 +1,4 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Basic tests for the SentryAttachment class.
 
 

--- a/project/test/suites/test_breadcrumb.gd
+++ b/project/test/suites/test_breadcrumb.gd
@@ -1,4 +1,4 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Test SentryBreadcrumb class properties and methods.
 
 

--- a/project/test/suites/test_event.gd
+++ b/project/test/suites/test_event.gd
@@ -1,10 +1,5 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Basic tests for the SentryEvent class.
-
-
-func before() -> void:
-	if not SentrySDK.is_enabled():
-		SentrySDK.init()
 
 
 ## Test string properties accessors and UTF-8 encoding preservation.
@@ -89,8 +84,12 @@ func test_event_is_crash() -> void:
 
 ## SentrySDK.capture_event() should return a non-empty event ID, which must match the ID returned by the get_last_event_id() call.
 func test_capture_event() -> void:
+	# Ensure events are not discarded.
+	SentrySDK._set_before_send(func(ev): return ev)
+
 	var event := SentrySDK.create_event()
 	var event_id := SentrySDK.capture_event(event)
+
 	assert_str(event_id).is_not_empty()
 	assert_str(event_id).is_equal(event.id)
 	assert_str(SentrySDK.get_last_event_id()).is_not_empty()

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -1,4 +1,4 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Basic tests for the SentryOptions class.
 
 
@@ -6,6 +6,7 @@ var options: SentryOptions
 
 
 func before_test() -> void:
+	super()
 	options = SentryOptions.new()
 
 
@@ -95,7 +96,7 @@ func test_callback_properties(property: String, test_parameters := [
 	["before_send"],
 	["before_capture_screenshot"]
 ]) -> void:
-	var callback := func(a1): pass
+	var callback := func(_a): pass
 	var prev: Callable = options.get(property)
 	options.set(property, callback)
 	assert_that(options.get(property)).is_equal(callback)

--- a/project/test/suites/test_sentry_user.gd
+++ b/project/test/suites/test_sentry_user.gd
@@ -1,4 +1,4 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Test SentryUser class.
 
 

--- a/project/test/suites/test_timestamp.gd
+++ b/project/test/suites/test_timestamp.gd
@@ -1,4 +1,4 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Tests for SentryTimestamp class.
 
 

--- a/project/test/util/sentry_test_suite.gd
+++ b/project/test/util/sentry_test_suite.gd
@@ -1,0 +1,59 @@
+class_name SentryTestSuite
+extends GdUnitTestSuite
+## Sentry test suite extensions for gdUnit4.
+
+## Emitted after event was processed by before_send callback, and its JSON content stored in captured_events.
+signal event_captured
+
+var captured_events: Array[String]
+
+var _saved_before_send: Callable
+
+
+## Perform queries and assertions on JSON content.
+func assert_json(json: Variant) -> JSONAssert:
+	return JSONAssert.new(json)
+
+
+## Capture event, expect it to be processed and return its JSON content.
+func capture_event_and_get_json(event: SentryEvent) -> String:
+	SentrySDK.capture_event(event)
+	await assert_signal(self).is_emitted("event_captured")
+	return captured_events[-1] if captured_events.size() > 0 else ""
+
+
+## Expect an event to be processed and return its serialized JSON content.
+func wait_for_captured_event_json() -> String:
+	await assert_signal(self).is_emitted("event_captured")
+	return captured_events[-1] if captured_events.size() > 0 else ""
+
+
+func before() -> void:
+	# NOTE: Make sure to call super() if overriding.
+	# Save before send
+	_saved_before_send = SentrySDK._get_before_send()
+
+
+func after() -> void:
+	# NOTE: Make sure to call super() if overriding.
+	# Restore before send
+	if _saved_before_send.is_valid():
+		SentrySDK._set_before_send(_saved_before_send)
+
+
+func before_test() -> void:
+	# NOTE: Make sure to call super() if overriding.
+	captured_events.clear()
+	SentrySDK._set_before_send(_before_send)
+	monitor_signals(self, false)
+
+
+func after_test() -> void:
+	# NOTE: Make sure to call super() if overriding.
+	SentrySDK._unset_before_send()
+
+
+func _before_send(event: SentryEvent) -> SentryEvent:
+	captured_events.append(event.to_json())
+	event_captured.emit()
+	return null

--- a/project/test/util/sentry_test_suite.gd
+++ b/project/test/util/sentry_test_suite.gd
@@ -2,11 +2,16 @@ class_name SentryTestSuite
 extends GdUnitTestSuite
 ## Sentry test suite extensions for gdUnit4.
 ##
-## The default `before_send` handler collects captured event json content in
-## `captured_events` array in the chronological order. The array is cleared
-## before each test.
-## The `before_send` handler is reassigned before each test, and unset after each test.
-## To override the default `before_send` handler, simply set a new one in a test body.
+## Base test suite class for Sentry SDK testing that automatically initializes the SDK
+## and provides utilities for capturing and analyzing event JSON content.
+##
+## The default "before_send" handler intercepts all events and stores their JSON
+## representations in the "captured_events" array in chronological order. This array
+## is automatically cleared before each test case runs.
+##
+## The "before_send" handler is reassigned before each test case and removed afterward
+## to ensure clean runs. To customize event handling, simply assign a new
+## "before_send" handler within your test method.
 
 
 ## Emitted after event was processed by before_send callback, and its JSON content stored in captured_events.

--- a/project/test/util/sentry_test_suite.gd.uid
+++ b/project/test/util/sentry_test_suite.gd.uid
@@ -1,0 +1,1 @@
+uid://nclyr5r4in0o


### PR DESCRIPTION
This PR adds tools to support testing in GDScript:
- Add [JSONAssert](https://github.com/getsentry/gdunit-json-assert) submodule – a tool that lets us query and assert on JSON content
  - The [tool](https://github.com/getsentry/gdunit-json-assert/blob/main/JSONAssertImpl.gd) was extracted into its own repository.
  - It comes with a [test suite](https://github.com/getsentry/gdunit-json-assert/blob/main/test_json_assert.gd) that is added to our CI runs in this PR.
  - See examples of usage in #326 (which this PR was extracted from).
- Add `SentryTestSuite` – supporting base class for our test suites that initializes the SDK for testing and integrates JSONAssert tool
- Update old tests to use the new `SentryTestSuite` as a base class
  - This is important because the regular test run needs to be predictable, and this class is responsible for initializing the SDK.
  - Before, when you ran tests from the editor, ProjectMainLoop would initialize the SDK, which doesn't execute in CI (testing framework CLI script replaces it). So, we ended up with different places initializing the SDK in CI and the editor, potentially with different options.
