### PR TITLE
fix: Setting `throttle_window_ms` to 0 should disable it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Improve scene tree data capture performance ([#373](https://github.com/getsentry/sentry-godot/pull/373))
 
+### Fixes
+
+- Fixed setting `throttle_window_ms` to 0 should disable it ([#382](https://github.com/getsentry/sentry-godot/pull/382))
+
 ### Other changes
 
 - Demo: Add "Run tests" button instead of running tests on start on mobile platforms ([#379](https://github.com/getsentry/sentry-godot/pull/379))

--- a/doc_classes/SentryLoggerLimits.xml
+++ b/doc_classes/SentryLoggerLimits.xml
@@ -14,13 +14,13 @@
 			This serves as a safety measure to prevent the SDK from overloading a single frame.
 		</member>
 		<member name="repeated_error_window_ms" type="int" setter="set_repeated_error_window_ms" getter="get_repeated_error_window_ms" default="1000">
-			Specifies the minimum time interval in milliseconds between two identical errors. If exceeded, no further errors from the same line of code with the identical message will be captured until the next interval. Set to [code]0[/code] to disable this feature.
+			Specifies the minimum time interval in milliseconds between two identical errors. If exceeded, no further errors from the same line of code with the identical message will be captured until the next interval. Set to [code]0[/code] to disable this limit.
 		</member>
 		<member name="throttle_events" type="int" setter="set_throttle_events" getter="get_throttle_events" default="20">
 			Specifies the maximum number of events allowed within a sliding time window of [member throttle_window_ms] milliseconds. If exceeded, errors will be captured as breadcrumbs only until capacity is freed.
 		</member>
 		<member name="throttle_window_ms" type="int" setter="set_throttle_window_ms" getter="get_throttle_window_ms" default="10000">
-			Specifies the time window in milliseconds for [member throttle_events].
+			Specifies the time window in milliseconds for [member throttle_events]. Set to [code]0[/code] to disable this limit.
 		</member>
 	</members>
 </class>

--- a/doc_classes/SentryLoggerLimits.xml
+++ b/doc_classes/SentryLoggerLimits.xml
@@ -14,7 +14,7 @@
 			This serves as a safety measure to prevent the SDK from overloading a single frame.
 		</member>
 		<member name="repeated_error_window_ms" type="int" setter="set_repeated_error_window_ms" getter="get_repeated_error_window_ms" default="1000">
-			Specifies the minimum time interval in milliseconds between two identical errors. If exceeded, no further errors from the same line of code will be captured until the next interval.
+			Specifies the minimum time interval in milliseconds between two identical errors. If exceeded, no further errors from the same line of code with the identical message will be captured until the next interval. Set to [code]0[/code] to disable this feature.
 		</member>
 		<member name="throttle_events" type="int" setter="set_throttle_events" getter="get_throttle_events" default="20">
 			Specifies the maximum number of events allowed within a sliding time window of [member throttle_window_ms] milliseconds. If exceeded, errors will be captured as breadcrumbs only until capacity is freed.

--- a/project/test/isolated/test_limit_throttling_disabled.gd
+++ b/project/test/isolated/test_limit_throttling_disabled.gd
@@ -1,0 +1,35 @@
+extends GdUnitTestSuite
+## Test throttling should be disabled if the window is set to 0.
+
+
+signal callback_processed
+
+var _num_events: int = 0
+
+
+func before() -> void:
+	SentrySDK.init(func(options: SentryOptions) -> void:
+		# Setting throttle window to 0 should disable throttling.
+		options.logger_limits.throttle_window_ms = 0
+		# Make sure other limits are not interfering.
+		options.logger_limits.events_per_frame = 88
+		options.before_send = _before_send
+	)
+
+
+func _before_send(_ev: SentryEvent) -> SentryEvent:
+	_num_events += 1
+	callback_processed.emit()
+	return null
+
+
+## All errors should be logged.
+func test_throttling_window_set_to_zero() -> void:
+	monitor_signals(self, false)
+	push_error("dummy-error 1")
+	push_error("dummy-error 2")
+	push_error("dummy-error 3")
+	push_error("dummy-error 4")
+	await assert_signal(self).is_emitted("callback_processed")
+	await get_tree().create_timer(0.1).timeout
+	assert_int(_num_events).is_equal(4)

--- a/project/test/isolated/test_limit_throttling_disabled.gd
+++ b/project/test/isolated/test_limit_throttling_disabled.gd
@@ -11,6 +11,7 @@ func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Setting throttle window to 0 should disable throttling.
 		options.logger_limits.throttle_window_ms = 0
+		options.logger_limits.throttle_events = 1
 		# Make sure other limits are not interfering.
 		options.logger_limits.events_per_frame = 88
 		options.before_send = _before_send

--- a/project/test/isolated/test_limit_throttling_disabled.gd.uid
+++ b/project/test/isolated/test_limit_throttling_disabled.gd.uid
@@ -1,0 +1,1 @@
+uid://dnltebooqe1ue

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -300,7 +300,7 @@ void SentryLogger::_log_error(const String &p_function, const String &p_file, in
 		bool is_spammy_error = it != error_timepoints.end() && now - it->second < limits.repeated_error_window;
 
 		bool within_frame_limit = frame_events < limits.events_per_frame;
-		bool within_throttling_limit = event_times.size() < limits.throttle_events;
+		bool within_throttling_limit = event_times.size() < limits.throttle_events || limits.throttle_window.count() == 0;
 
 		as_event = SentryOptions::get_singleton()->should_capture_event((GodotErrorType)p_error_type) &&
 				within_frame_limit &&


### PR DESCRIPTION
Fix setting `throttle_window_ms` to 0 should disable throttling, and clarify this in the class docs.

- Closes #270 
