### PR TITLE
fix: Failing to set initial user on Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 
 - Fixed setting `throttle_window_ms` to 0 should disable it ([#382](https://github.com/getsentry/sentry-godot/pull/382))
+- Fixed failing to set initial user on Apple platforms ([#390](https://github.com/getsentry/sentry-godot/pull/390))
 
 ### Other changes
 

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -150,8 +150,6 @@ void AndroidSDK::init(const PackedStringArray &p_global_attachments, const Calla
 				is_view_hierarchy ? "event.view_hierarchy" : String());
 	}
 
-	set_user(p_user);
-
 	android_plugin->call(ANDROID_SN(init),
 			before_send_handler->get_instance_id(),
 			SentryOptions::get_singleton()->get_dsn(),
@@ -161,6 +159,12 @@ void AndroidSDK::init(const PackedStringArray &p_global_attachments, const Calla
 			SentryOptions::get_singleton()->get_environment(),
 			SentryOptions::get_singleton()->get_sample_rate(),
 			SentryOptions::get_singleton()->get_max_breadcrumbs());
+
+	if (is_enabled()) {
+		set_user(p_user);
+	} else {
+		ERR_PRINT("Sentry: Failed to initialize Android SDK.");
+	}
 }
 
 void AndroidSDK::close() {

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -134,7 +134,7 @@ void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}
 }
 
-void AndroidSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) {
+void AndroidSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) {
 	ERR_FAIL_NULL(android_plugin);
 
 	if (p_configuration_callback.is_valid()) {
@@ -149,6 +149,8 @@ void AndroidSDK::init(const PackedStringArray &p_global_attachments, const Calla
 				is_view_hierarchy ? "application/json" : String(),
 				is_view_hierarchy ? "event.view_hierarchy" : String());
 	}
+
+	set_user(p_user);
 
 	android_plugin->call(ANDROID_SN(init),
 			before_send_handler->get_instance_id(),

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -60,11 +60,16 @@ void AndroidSDK::remove_tag(const String &p_key) {
 
 void AndroidSDK::set_user(const Ref<SentryUser> &p_user) {
 	ERR_FAIL_NULL(android_plugin);
-	android_plugin->call(ANDROID_SN(setUser),
-			p_user->get_id(),
-			p_user->get_username(),
-			p_user->get_email(),
-			p_user->get_ip_address());
+
+	if (p_user.is_valid()) {
+		android_plugin->call(ANDROID_SN(setUser),
+				p_user->get_id(),
+				p_user->get_username(),
+				p_user->get_email(),
+				p_user->get_ip_address());
+	} else {
+		remove_user();
+	}
 }
 
 void AndroidSDK::remove_user() {

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -49,7 +49,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) override;
+	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;
 

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) override;
+	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -141,7 +141,7 @@ void CocoaSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}];
 }
 
-void CocoaSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) {
+void CocoaSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) {
 	[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.godot"];
 
 	[objc::SentrySDK startWithConfigureOptions:^(objc::SentryOptions *options) {
@@ -182,6 +182,21 @@ void CocoaSDK::init(const PackedStringArray &p_global_attachments, const Callabl
 				ERR_CONTINUE(att == nil);
 				[scope addAttachment:att];
 			}
+
+			// Initialize user.
+			if (p_user.is_valid()) {
+				objc::SentryUser *user = [[objc::SentryUser alloc] init];
+
+				user.userId = string_to_objc_or_nil_if_empty(p_user->get_id());
+				user.username = string_to_objc_or_nil_if_empty(p_user->get_username());
+				user.email = string_to_objc_or_nil_if_empty(p_user->get_email());
+				user.ipAddress = string_to_objc_or_nil_if_empty(p_user->get_ip_address());
+
+				[scope setUser:user];
+			} else {
+				[scope setUser:nil];
+			}
+
 			return scope;
 		};
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -214,6 +214,10 @@ void CocoaSDK::init(const PackedStringArray &p_global_attachments, const Callabl
 			}
 		};
 	}];
+
+	if (!is_enabled()) {
+		ERR_PRINT("Sentry: Failed to initialize Cocoa SDK.");
+	}
 }
 
 void CocoaSDK::close() {

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -29,7 +29,7 @@ class DisabledSDK : public InternalSDK {
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override {}
 
-	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) override {}
+	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) override {}
 	virtual void close() override {}
 	virtual bool is_enabled() const override { return false; }
 };

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -39,7 +39,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) = 0;
 
-	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) = 0;
+	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) = 0;
 	virtual void close() = 0;
 	virtual bool is_enabled() const = 0;
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -332,12 +332,12 @@ void NativeSDK::init(const PackedStringArray &p_global_attachments, const Callab
 	sentry_options_set_on_crash(options, _handle_on_crash, NULL);
 	sentry_options_set_logger(options, _log_native_message, NULL);
 
-	set_user(p_user);
-
 	int err = sentry_init(options);
 	initialized = (err == 0);
 
-	if (err != 0) {
+	if (is_enabled()) {
+		set_user(p_user);
+	} else {
 		ERR_PRINT("Sentry: Failed to initialize native SDK. Error code: " + itos(err));
 	}
 }

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -267,7 +267,7 @@ void NativeSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}
 }
 
-void NativeSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) {
+void NativeSDK::init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) {
 	ERR_FAIL_NULL(OS::get_singleton());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
@@ -331,6 +331,8 @@ void NativeSDK::init(const PackedStringArray &p_global_attachments, const Callab
 	sentry_options_set_before_send(options, _handle_before_send, NULL);
 	sentry_options_set_on_crash(options, _handle_on_crash, NULL);
 	sentry_options_set_logger(options, _log_native_message, NULL);
+
+	set_user(p_user);
 
 	int err = sentry_init(options);
 	initialized = (err == 0);

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -144,27 +144,29 @@ void NativeSDK::remove_tag(const String &p_key) {
 }
 
 void NativeSDK::set_user(const Ref<SentryUser> &p_user) {
-	ERR_FAIL_NULL(p_user);
+	if (p_user.is_valid()) {
+		sentry_value_t user_data = sentry_value_new_object();
 
-	sentry_value_t user_data = sentry_value_new_object();
-
-	if (!p_user->get_id().is_empty()) {
-		sentry_value_set_by_key(user_data, "id",
-				sentry_value_new_string(p_user->get_id().utf8()));
+		if (!p_user->get_id().is_empty()) {
+			sentry_value_set_by_key(user_data, "id",
+					sentry_value_new_string(p_user->get_id().utf8()));
+		}
+		if (!p_user->get_username().is_empty()) {
+			sentry_value_set_by_key(user_data, "username",
+					sentry_value_new_string(p_user->get_username().utf8()));
+		}
+		if (!p_user->get_email().is_empty()) {
+			sentry_value_set_by_key(user_data, "email",
+					sentry_value_new_string(p_user->get_email().utf8()));
+		}
+		if (!p_user->get_ip_address().is_empty()) {
+			sentry_value_set_by_key(user_data, "ip_address",
+					sentry_value_new_string(p_user->get_ip_address().utf8()));
+		}
+		sentry_set_user(user_data);
+	} else {
+		remove_user();
 	}
-	if (!p_user->get_username().is_empty()) {
-		sentry_value_set_by_key(user_data, "username",
-				sentry_value_new_string(p_user->get_username().utf8()));
-	}
-	if (!p_user->get_email().is_empty()) {
-		sentry_value_set_by_key(user_data, "email",
-				sentry_value_new_string(p_user->get_email().utf8()));
-	}
-	if (!p_user->get_ip_address().is_empty()) {
-		sentry_value_set_by_key(user_data, "ip_address",
-				sentry_value_new_string(p_user->get_ip_address().utf8()));
-	}
-	sentry_set_user(user_data);
 }
 
 void NativeSDK::remove_user() {

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 
-	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback) override;
+	virtual void init(const PackedStringArray &p_global_attachments, const Callable &p_configuration_callback, const Ref<SentryUser> &p_user) override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -129,7 +129,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 #endif
 
 	sentry::util::print_debug("Initializing Sentry SDK");
-	internal_sdk->init(_get_global_attachments(), p_configuration_callback);
+	internal_sdk->init(_get_global_attachments(), p_configuration_callback, user);
 
 	if (internal_sdk->is_enabled()) {
 		if (is_auto_initializing) {
@@ -332,7 +332,6 @@ void SentrySDK::prepare_and_auto_initialize() {
 			user->infer_ip_address();
 		}
 	}
-	set_user(user);
 
 	// Verify project settings and notify user via errors if there are any issues (deferred).
 	callable_mp_static(_verify_project_settings).call_deferred();


### PR DESCRIPTION
This PR fixes `The SDK is disabled, so setUser doesn't work`  error on Apple platforms. Initial user is now set in the initialScope on Apple, and after init() on other platforms that don't support initial scope. This also adds null user handling directly to internal SDK implementations to prevent crashing.
- Resolves #388