### PR TITLE
build: Add missing `crashpad_wer.dll` to Windows build and export

### DIFF
--- a/modules/sentry-native.SConscript
+++ b/modules/sentry-native.SConscript
@@ -199,6 +199,14 @@ def CopyCrashpadHandler(self, target_dir):
             target_dir.File("crashpad_handler.pdb"),
             source_dir.File("crashpad_handler.pdb")
         )
+        copy_file_action(
+            target_dir.File("crashpad_wer.dll"),
+            source_dir.File("crashpad_wer.dll")
+        )
+        copy_file_action(
+            target_dir.File("crashpad_wer.pdb"),
+            source_dir.File("crashpad_wer.pdb")
+        )
     else:
         copy_file_action(
             target_dir.File("crashpad_handler"),

--- a/src/manifest.gdextension
+++ b/src/manifest.gdextension
@@ -51,11 +51,13 @@ linux.x86_32 = {
 }
 
 windows.x86_64 = {
-	"res://addons/sentry/bin/windows/x86_64/crashpad_handler.exe" : ""
+	"res://addons/sentry/bin/windows/x86_64/crashpad_handler.exe" : "",
+	"res://addons/sentry/bin/windows/x86_64/crashpad_wer.dll": ""
 }
 
 windows.x86_32 = {
-	"res://addons/sentry/bin/windows/x86_32/crashpad_handler.exe" : ""
+	"res://addons/sentry/bin/windows/x86_32/crashpad_handler.exe" : "",
+	"res://addons/sentry/bin/windows/x86_32/crashpad_wer.dll": ""
 }
 
 macos.debug = {


### PR DESCRIPTION
Copy `crashpad_wer.dll` to the Windows build output directory after the build completes, and also add it to export dependencies so it's also copied during Godot export process.
- Resolves #394 
