### PR TITLE
chore: Prevent usage of Godot logger during crash handling on Windows/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Improve scene tree data capture performance ([#373](https://github.com/getsentry/sentry-godot/pull/373))
 - Set device.name to OS hostname on Windows/Linux dedicated servers ([#391](https://github.com/getsentry/sentry-godot/pull/391))
-- Disable logger when crashing on Native ([#398](https://github.com/getsentry/sentry-godot/pull/398))
+- Prevent usage of Godot logger during crash handling on Windows/Linux ([#398](https://github.com/getsentry/sentry-godot/pull/398))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Improve scene tree data capture performance ([#373](https://github.com/getsentry/sentry-godot/pull/373))
 - Set device.name to OS hostname on Windows/Linux dedicated servers ([#391](https://github.com/getsentry/sentry-godot/pull/391))
+- Disable logger when crashing on Native ([#398](https://github.com/getsentry/sentry-godot/pull/398))
 
 ### Fixes
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -288,6 +288,7 @@ void NativeSDK::init(const PackedStringArray &p_global_attachments, const Callab
 	sentry_options_set_sample_rate(options, SentryOptions::get_singleton()->get_sample_rate());
 	sentry_options_set_max_breadcrumbs(options, SentryOptions::get_singleton()->get_max_breadcrumbs());
 	sentry_options_set_sdk_name(options, "sentry.native.godot");
+	sentry_options_set_logger_enabled_when_crashed(options, false);
 
 	// Establish handler path.
 	String handler_fn;


### PR DESCRIPTION
Prevent usage of Godot logger during crash handling on Windows/Linux. And this also disables console output when crashing. This should improve crash reporting in some cases, such as memory corruption.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable native logger when crashed and document it in the changelog.
> 
> - **Native SDK initialization (`src/sentry/native/native_sdk.cpp`)**:
>   - Set `sentry_options_set_logger_enabled_when_crashed(options, false)` to disable logging during crash handling.
> - **Changelog**:
>   - Add entry noting logger is disabled when crashing on Native.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a5c637a303ba8878fe5c3a49e33efc8d76fc4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->