### PR TITLE
build: Generate Info.plist for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Prevent usage of Godot logger during crash handling on Windows/Linux ([#398](https://github.com/getsentry/sentry-godot/pull/398))
 - Add missing Cocoa SDK symbols to builds ([#401](https://github.com/getsentry/sentry-godot/pull/401))
 - Add build option to separate debug symbols for GDExtension and crashpad_handler, and do it in the official builds ([#399](https://github.com/getsentry/sentry-godot/pull/399))
+- Generate Info.plist for macOS during build ([#403](https://github.com/getsentry/sentry-godot/pull/403))
 
 ### Fixes
 

--- a/SConstruct
+++ b/SConstruct
@@ -80,6 +80,7 @@ arch = env["arch"]
 # Register tools
 env.Tool("copy")
 env.Tool("separate_debug_symbols")
+env.Tool("plist")
 
 # Restore original ARGUMENTS and add custom options to environment
 ARGUMENTS.clear()
@@ -226,6 +227,17 @@ elif platform == "macos":
 
     library = env.SharedLibrary(lib_path, source=sources)
     Default(library)
+
+    # Create Info.plist
+    plist_path = f"{out_dir}/{lib_name}.framework/Resources/Info.plist"
+    plist = env.FrameworkPlist(File(plist_path), File("SConstruct"),
+        bundle_executable=lib_name,
+        bundle_identifier=f"io.sentry.{lib_name}.framework",
+        bundle_version=VERSION,
+        bundle_platforms=["MacOSX"]
+    )
+    Depends(plist, library)
+    Default(plist)
 
 else:
     # *** Build shared library on other platforms.

--- a/SConstruct
+++ b/SConstruct
@@ -232,7 +232,7 @@ elif platform == "macos":
     plist_path = f"{out_dir}/{lib_name}.framework/Resources/Info.plist"
     plist = env.FrameworkPlist(File(plist_path), File("SConstruct"),
         bundle_executable=lib_name,
-        bundle_identifier=f"io.sentry.libsentry.{build_type}",
+        bundle_identifier=f"io.sentry.SentryForGodot.{build_type}",
         bundle_version=VERSION,
         bundle_platforms=["MacOSX"]
     )

--- a/SConstruct
+++ b/SConstruct
@@ -232,7 +232,7 @@ elif platform == "macos":
     plist_path = f"{out_dir}/{lib_name}.framework/Resources/Info.plist"
     plist = env.FrameworkPlist(File(plist_path), File("SConstruct"),
         bundle_executable=lib_name,
-        bundle_identifier=f"io.sentry.{lib_name}.framework",
+        bundle_identifier=f"io.sentry.libsentry.{build_type}",
         bundle_version=VERSION,
         bundle_platforms=["MacOSX"]
     )

--- a/site_scons/site_tools/plist.py
+++ b/site_scons/site_tools/plist.py
@@ -16,7 +16,7 @@ def generate_framework_plist(target, source, env):
     bundle_package_type = env.get("bundle_package_type", "FMWK")  # FMWK or BNDL
     bundle_min_system = env.get("bundle_min_system", env.get("macos_deployment_target", "10.13"))
 
-    # Split numeric version for CFBundleVersion
+    platforms_content = "\n".join(f"        <string>{p}</string>" for p in bundle_platforms)
 
     content = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -36,7 +36,7 @@ def generate_framework_plist(target, source, env):
     <string>{bundle_version_string}</string>
     <key>CFBundleSupportedPlatforms</key>
     <array>
-{"\n".join(f"        <string>{p}</string>" for p in bundle_platforms)}
+{platforms_content}
     </array>
     <key>CFBundleVersion</key>
     <string>{bundle_version}</string>

--- a/site_scons/site_tools/plist.py
+++ b/site_scons/site_tools/plist.py
@@ -1,0 +1,60 @@
+"""
+Tool to generate Info.plist.
+"""
+
+import os
+from SCons.Script import Builder, Action
+
+
+def generate_framework_plist(target, source, env):
+    bundle_executable = env.get("bundle_executable", "MyFramework")
+    bundle_identifier = env.get("bundle_identifier", "com.example.MyFramework")
+    bundle_name = env.get("bundle_name", bundle_executable)
+    bundle_version_string = env.get("bundle_version", "1.0")
+    bundle_version = bundle_version_string.split("-", 1)[0]
+    bundle_platforms = env.get("bundle_platforms", ["MacOSX"])
+    bundle_package_type = env.get("bundle_package_type", "FMWK")  # FMWK or BNDL
+    bundle_min_system = env.get("bundle_min_system", env.get("macos_deployment_target", "10.13"))
+
+    # Split numeric version for CFBundleVersion
+
+    content = f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>{bundle_executable}</string>
+    <key>CFBundleIdentifier</key>
+    <string>{bundle_identifier}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>{bundle_name}</string>
+    <key>CFBundlePackageType</key>
+    <string>{bundle_package_type}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>{bundle_version_string}</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+{"\n".join(f"        <string>{p}</string>" for p in bundle_platforms)}
+    </array>
+    <key>CFBundleVersion</key>
+    <string>{bundle_version}</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>{bundle_min_system}</string>
+</dict>
+</plist>"""
+
+    with open(str(target[0]), "w") as f:
+        f.write(content)
+
+    return None
+
+
+def generate(env):
+    plist_builder = Builder(action=Action(generate_framework_plist, cmdstr="Generating Info.plist for $TARGET"))
+    env.Append(BUILDERS={"FrameworkPlist": plist_builder})
+
+
+def exists(env):
+    return True


### PR DESCRIPTION
Generate Info.plist for GDExtension library on macOS. This fixes the warning during Godot export, and generic Info.plist added.

- Depends on #399 
- Resolves #112 
