### PR TITLE
build: Support separating debug symbols of Android targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Prevent usage of Godot logger during crash handling on Windows/Linux ([#398](https://github.com/getsentry/sentry-godot/pull/398))
 - Add missing Cocoa SDK symbols to builds ([#401](https://github.com/getsentry/sentry-godot/pull/401))
 - Add build option to separate debug symbols for GDExtension and crashpad_handler, and do it in the official builds ([#399](https://github.com/getsentry/sentry-godot/pull/399))
+- Support separating debug symbols of Android targets ([#404](https://github.com/getsentry/sentry-godot/pull/404))
 - Generate Info.plist for macOS during build ([#403](https://github.com/getsentry/sentry-godot/pull/403))
 
 ### Fixes

--- a/SConstruct
+++ b/SConstruct
@@ -59,7 +59,7 @@ def add_custom_bool_option(name, description, default=False):
 # Define our custom options
 add_custom_bool_option("generate_ios_framework", "Generate iOS xcframework from static libraries", False)
 add_custom_bool_option("build_android_lib", "Build Android bridge library", False)
-add_custom_bool_option("separate_debug_symbols", "Separate debug symbols (supported on macOS, iOS, Linux)", True)
+add_custom_bool_option("separate_debug_symbols", "Separate debug symbols (supported on macOS, iOS, Linux, Android)", True)
 
 # Workaround: Remove custom options from ARGUMENTS to avoid warnings from godot-cpp.
 # Godot complains about variables it does not recognize. See: https://github.com/godotengine/godot-cpp/issues/1334
@@ -171,6 +171,7 @@ if internal_sdk == SDK.NATIVE:
 elif internal_sdk == SDK.ANDROID:
     sources += Glob("src/sentry/android/*.cpp")
     env.Append(CPPDEFINES=["SDK_ANDROID"])
+    env.Append(LINKFLAGS="-Wl,--build-id=sha1")  # Add Build ID to binaries.
 elif internal_sdk == SDK.COCOA:
     sources += Glob("src/sentry/cocoa/*.cpp")
     sources += Glob("src/sentry/cocoa/*.mm")
@@ -249,7 +250,7 @@ if env["debug_symbols"] and env["separate_debug_symbols"]:
         dsym_path = f"{out_dir}/dSYMs/{lib_name}.framework.dSYM"
         separate_symbols = env.SeparateDebugSymbols(Dir(dsym_path), File(lib_path))
         Default(separate_symbols)
-    elif platform == "linux":
+    elif platform in ["linux", "android"]:
         symbols_path = f"{lib_path}.debug"
         separate_symbols = env.SeparateDebugSymbols(File(symbols_path), File(lib_path))
         Default(separate_symbols)

--- a/SConstruct
+++ b/SConstruct
@@ -248,12 +248,10 @@ if env["debug_symbols"] and env["separate_debug_symbols"]:
     # Note: Windows/MSVC separates by default.
     if platform in ["macos", "ios"]:
         dsym_path = f"{out_dir}/dSYMs/{lib_name}.framework.dSYM"
-        separate_symbols = env.SeparateDebugSymbols(Dir(dsym_path), File(lib_path))
-        Default(separate_symbols)
+        env.SeparateDebugSymbols(Dir(dsym_path), library)
     elif platform in ["linux", "android"]:
         symbols_path = f"{lib_path}.debug"
-        separate_symbols = env.SeparateDebugSymbols(File(symbols_path), File(lib_path))
-        Default(separate_symbols)
+        env.SeparateDebugSymbols(File(symbols_path), library)
 
 
 # *** Build Android lib

--- a/site_scons/site_tools/separate_debug_symbols.py
+++ b/site_scons/site_tools/separate_debug_symbols.py
@@ -8,10 +8,11 @@ symbols, with a cleanup.
 from SCons.Script import Clean, Exit, Action
 import os
 
-def separate_debug_symbols(target, source, env, symbols_path):
+def separate_debug_symbols(target, source, env, p_symbols_path):
     platform = env["platform"]
 
     binary_path = str(target[0])
+    symbols_path = str(p_symbols_path)
 
     if platform in ["macos", "ios"]:
         err = env.Execute(f'dsymutil "{binary_path}" -o "{symbols_path}"')
@@ -46,7 +47,7 @@ def separate_debug_symbols(target, source, env, symbols_path):
             print(f"ERROR: Failed to split debug symbols (exit code {err})")
             Exit(1)
 
-        err = env.Execute(f'llvm-strip --strip-unneeded "{binary_path}"')
+        err = env.Execute(f'llvm-strip --strip-debug --strip-unneeded "{binary_path}"')
         if err != 0:
             print(f"ERROR: Failed to strip debug symbols (exit code {err})")
             Exit(1)

--- a/site_scons/site_tools/separate_debug_symbols.py
+++ b/site_scons/site_tools/separate_debug_symbols.py
@@ -3,7 +3,6 @@ Tool to separate debug symbols.
 """
 
 from SCons.Script import Clean, Exit, Action
-import os
 
 
 def separate_debug_symbols(target, source, env):
@@ -12,35 +11,49 @@ def separate_debug_symbols(target, source, env):
     target_path = str(target[0])
     source_path = str(source[0])
 
-    def run(cmd):
-        err = os.system(cmd)
-        return os.WEXITSTATUS(err)
-
     if platform in ["macos", "ios"]:
-        err = run(f'dsymutil "{source_path}" -o "{target_path}"')
+        err = env.Execute(f'dsymutil "{source_path}" -o "{target_path}"')
         if err != 0:
             print(f"ERROR: Failed to split debug symbols (exit code {err})")
             Exit(1)
 
-        err = run(f'strip -u -r "{source_path}"')
+        err = env.Execute(f'strip -u -r "{source_path}"')
         if err != 0:
             print(f"ERROR: Failed to strip debug symbols (exit code {err})")
             Exit(1)
+
     elif platform == "linux":
-        err = run(f'objcopy --only-keep-debug --compress-debug-sections=zlib "{source_path}" "{target_path}"')
+        err = env.Execute(f'objcopy --only-keep-debug --compress-debug-sections=zlib "{source_path}" "{target_path}"')
         if err != 0:
             print(f"ERROR: Failed to split debug symbols (exit code {err})")
             Exit(1)
 
-        err = run(f'strip --strip-debug --strip-unneeded "{source_path}"')
+        err = env.Execute(f'strip --strip-debug --strip-unneeded "{source_path}"')
         if err != 0:
             print(f"ERROR: Failed to strip debug symbols (exit code {err})")
             Exit(1)
 
-        err = run(f'objcopy --add-gnu-debuglink="{target_path}" "{source_path}"')
+        err = env.Execute(f'objcopy --add-gnu-debuglink="{target_path}" "{source_path}"')
         if err != 0:
             print(f"ERROR: Failed to add debug link (exit code {err})")
             Exit(1)
+
+    elif platform == "android":
+        err = env.Execute(f'llvm-objcopy --only-keep-debug --compress-debug-sections=zlib "{source_path}" "{target_path}"')
+        if err != 0:
+            print(f"ERROR: Failed to split debug symbols (exit code {err})")
+            Exit(1)
+
+        err = env.Execute(f'llvm-strip --strip-unneeded "{source_path}"')
+        if err != 0:
+            print(f"ERROR: Failed to strip debug symbols (exit code {err})")
+            Exit(1)
+
+        err = env.Execute(f'llvm-objcopy --add-gnu-debuglink="{target_path}" "{source_path}"')
+        if err != 0:
+            print(f"ERROR: Failed to add debug link (exit code {err})")
+            Exit(1)
+
     else:
         print("ERROR: Can't separate debug symbols on this platform")
         Exit(1)


### PR DESCRIPTION
Introduce support for separating debug symbols of Android targets using the `separate_debug_symbols` option.

Additionally, refactor the separation process to function as a post-action rather than a builder, addressing an issue where subsequent runs produced empty symbol files.