### PR TITLE
ci: Fix code signing for macOS

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,8 +20,7 @@ jobs:
     env:
       APPLE_CERT_PATH: /tmp/certs.p12
       APPLE_API_KEY_PATH: /tmp/apple_key.json
-      # DO_CODESIGN: ${{ startsWith(github.ref, 'refs/heads/release/') && '1' || '0' }}
-      DO_CODESIGN: 1
+      DO_CODESIGN: ${{ startsWith(github.ref, 'refs/heads/release/') && '1' || '0' }}
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
This PR addresses a problem with the notarized release on macOS. Previously we were only submitting the binary for code signing and notarization. However, after adding the Info.plist file, this approach caused issues. 

This PR includes the whole framework directory for code signing and notarization, making sure all needed files, like Info.plist, are taken into account.

### Problem
<img width="274" height="261" alt="Screenshot 2025-10-03 at 15 54 13" src="https://github.com/user-attachments/assets/31b0e4de-5bd9-44f8-a0a2-fbb7f9989401" />

In terminal:
ERROR: Can't open dynamic library: /Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework. Error: dlopen(/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug, 0x0002): tried: '/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug' (code signature in <38746A80-318E-3658-A703-77CF450D50C2> '/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug' not valid for use in process: library load disallowed by system policy), '/System/Volumes/Preboot/Cryptexes/OS/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug' (no such file), '/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug' (code signature in <38746A80-318E-3658-A703-77CF450D50C2> '/Users/limbonaut/Downloads/sentry-godot-gdextension-1.0.0+a903d46/addons/sentry/bin/macos/libsentry.macos.debug.framework/libsentry.macos.debug' not valid for use in process: library load disallowed by system policy).
