### PR TITLE
chore: Fix flaky throttling test

### DIFF
--- a/project/test/isolated/test_limit_throttling.gd
+++ b/project/test/isolated/test_limit_throttling.gd
@@ -38,7 +38,7 @@ func test_throttling_limits() -> void:
 	assert_int(_num_events).is_equal(2)
 
 	# Wait for throttling window to expire.
-	await get_tree().create_timer(1.0).timeout
+	await get_tree().create_timer(1.1).timeout
 
 	push_error("dummy-error")
 	push_error("dummy-error")


### PR DESCRIPTION
Add a bit more time for the throttling window to expire because we process it once per frame and it can take a little longer than the specified window.