### PR TITLE
chore: Use Godot 4.5.1 for build testing

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -40,7 +40,7 @@ runs:
           version="$GODOT_VERSION_OVERRIDE"
         else
           major_minor=$(sed -n 's/compatibility_minimum = "\([^"]*\)"/\1/p' project/addons/sentry/sentry.gdextension)
-          version="${major_minor}$-stable"
+          version="${major_minor}-stable"
         fi
 
         echo "Using Godot version: $version"


### PR DESCRIPTION
We keep hitting the issue with the Godot project import crashing in `macos-15` runner with a message:
```
libc++abi: Pure virtual function called!
```
The issue is tracked in #234

Godot 4.5.1 released with a fix for [suspected issue](https://github.com/godotengine/godot/issues/110634), so perhaps bumping the version used in CI will fix this problem.