### PR TITLE
chore: ignore local Claude settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ compile_commands.json
 
 # clang cache
 .cache
+
+# Local Claude Code settings that should not be committed
+.claude/settings.local.json


### PR DESCRIPTION
Ignore .claude/settings.local.json as these are local settings not intended for version control.

#skip-changelog