### PR TITLE
ref: Add JSON rules to .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -186,4 +186,9 @@ ObjCBlockIndentWidth: 4
 Language:        Java
 # BreakAfterJavaFieldAnnotations: false
 JavaImportGroups: ['org.godotengine', 'android', 'androidx', 'com.android', 'com.google', 'java', 'javax']
+---
+### JSON specific config ###
+Language: Json
+IndentWidth: 2
+UseTab: Never
 ...


### PR DESCRIPTION
Fix clang formatting issues for Claude rules by adding a JSON-specific section to formatting rules. This ensures JSON data is formatted consistently and fixes current CI failing due to formatting issues in Claude rules.