### PR TITLE
chore: Fix usage of non-existant OS.get_memory_info() key

### DIFF
--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -119,16 +119,12 @@ Dictionary make_device_context(const Ref<RuntimeConfig> &p_runtime_config) {
 	Dictionary meminfo = OS::get_singleton()->get_memory_info();
 	int64_t mem_size = meminfo["physical"];
 	int64_t mem_free = meminfo["free"];
-	int64_t mem_used = meminfo["used"];
 	int64_t mem_usable = meminfo["available"];
 	if (mem_size > 0) {
 		device_context["memory_size"] = mem_size;
 	}
 	if (mem_free >= 0) {
 		device_context["free_memory"] = mem_free;
-	}
-	if (mem_used > 0) {
-		device_context["used_memory"] = mem_used;
 	}
 	if (mem_usable >= 0) {
 		device_context["usable_memory"] = mem_usable;
@@ -167,12 +163,8 @@ Dictionary make_device_context_update() {
 	const Dictionary &meminfo = OS::get_singleton()->get_memory_info();
 	int64_t mem_free = meminfo["free"];
 	int64_t mem_usable = meminfo["available"];
-	int64_t mem_used = meminfo["used"];
 	if (mem_free >= 0) {
 		device_context["free_memory"] = mem_free;
-	}
-	if (mem_used > 0) {
-		device_context["used_memory"] = mem_used;
 	}
 	if (mem_usable >= 0) {
 		device_context["usable_memory"] = mem_usable;


### PR DESCRIPTION
Looks like I introduced an error via auto-complete in #492 (not released).

<img width="659" height="57" alt="image" src="https://github.com/user-attachments/assets/a49a0bc3-38c6-4165-a18d-1538712942ff" />

And indeed, it doesn't exist: https://docs.godotengine.org/en/4.5/classes/class_os.html#class-os-method-get-memory-info