### PR TITLE
ref: Use unique entry point

### DIFF
--- a/src/manifest.gdextension
+++ b/src/manifest.gdextension
@@ -1,6 +1,6 @@
 [configuration]
 
-entry_symbol = "gdextension_init"
+entry_symbol = "sentry_gdextension_init"
 compatibility_minimum = "{compatibility_minimum}"
 
 [libraries]

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -126,7 +126,7 @@ void uninitialize_module(ModuleInitializationLevel p_level) {
 
 extern "C" {
 // Initialization.
-GDExtensionBool GDE_EXPORT gdextension_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+GDExtensionBool GDE_EXPORT sentry_gdextension_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
 	godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
 
 	init_obj.register_initializer(initialize_module);


### PR DESCRIPTION
Use unique entry point in our GDExtension libraries to differentiate it from other extensions.
  - Related to #457
  
On iOS, all GDExtension entry points are compiled into a single dummy.cpp during export. The generated glue code derives helper function and struct names from the entry symbol. If two extensions share the same default gdextension_init, the generated code will contain duplicate definitions. Additionally, iOS uses flat namespace, so one symbol name resolves to one address, and I think only one extension would initialize correctly. On other platforms, this doesn't cause issues due to `dlopen` scoping each lib's namespace.


