### PR TITLE
ci: Ship only addons/sentry/ in build artifacts and release zip

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -295,10 +295,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sentry.${{matrix.platform}}.${{matrix.target}}.${{matrix.arch}}${{ contains(matrix.scons-flags, 'threads=no') && '.nothreads' || '' }}
+          # NOTE: Include-exclude pattern forces archive to start with project/ as root directory.
           path: |
             project/
-            !project/addons/gdUnit4
-            !project/test/
+            !project/
+            project/addons/sentry/
 
   android-plugin:
     name: 🤖 Android Plugin AARs

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,7 +93,7 @@ jobs:
           archive_file="sentry-godot-gdextension-${version}+${git_short_sha}.zip"
           cd artifact/
           mkdir ${GITHUB_WORKSPACE}/out/
-          zip -r ${GITHUB_WORKSPACE}/out/${archive_file} ./*
+          zip -r ${GITHUB_WORKSPACE}/out/${archive_file} addons/sentry/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ship only `addons/sentry/` in CI build artifacts and the final release zip, instead of the full test project directory. This makes the release archive compatible with Godot AssetLib, which expects `addons/<plugin>/` at the root.

- Fixes #502

Previously, build artifacts included the entire `project/` directory (minus `test/` and `gdUnit4`), and the release zip contained everything in the artifact. Users installing from AssetLib would get demo scenes, test scripts, and project files alongside the actual addon. And this creates a lot of noise, and file conflicts in the existing projects.