### PR TITLE
chore: Enable logs and set screenshot level to info in test project

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -55,5 +55,7 @@ textures/vram_compression/import_etc2_astc=true
 options/auto_init=false
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
 options/attach_scene_tree=true
+options/enable_logs=true
 logger/include_variables=true
 experimental/attach_screenshot=true
+experimental/screenshot_level=1


### PR DESCRIPTION
This PR enables `options/enable_logs` in the test project, and sets `experimental/screenshot_level` to info.
This only affects the test project.