### PR TITLE
chore: Integrate godot-kaboom library for crash testing

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -125,6 +125,10 @@ runs:
       run: |
         ls -lR project/
 
+    - name: Fetch kaboom addon
+      shell: bash
+      run: scons kaboom
+
     - name: Prepare gdUnit4
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ integration_tests/results/
 # Source tree
 src/gen/
 
+# Kaboom: downloaded automatically.
+project/addons/kaboom/
+
 # Cocoa: downloaded automatically.
 modules/sentry-cocoa/
 

--- a/SConstruct
+++ b/SConstruct
@@ -287,44 +287,23 @@ if env["build_android_lib"]:
     Depends(android_lib, library)
 
 
-
-
 # *** Fetch kaboom addon (addon to trigger test crashes).
 
-def fetch_kaboom_action(target, source, env):
-    env.FetchGithubRelease(
-        properties_file="modules/kaboom.properties",
-        asset="godot-kaboom.zip",
-        target_dir="project/addons/kaboom",
-        strip_prefix="addons/kaboom",
-        clean=True,
-    )
-
-fetch_kaboom = env.Command(
-    "project/addons/kaboom/.version",
+Alias("kaboom", env.FetchGithubRelease(
     "modules/kaboom.properties",
-    fetch_kaboom_action,
-)
+    asset="godot-kaboom.zip",
+    target_dir="project/addons/kaboom",
+    strip_prefix="addons/kaboom",
+    clean=True,
+))
 
-Alias("kaboom", fetch_kaboom)
-
-
-def fetch_kaboom_symbols_action(target, source, env):
-    env.FetchGithubRelease(
-        properties_file="modules/kaboom.properties",
-        asset="godot-kaboom-debug-symbols.zip",
-        target_dir="project/addons/kaboom",
-        strip_prefix="addons/kaboom",
-        version_file=".symbols_version",
-    )
-
-fetch_kaboom_symbols = env.Command(
-    "project/addons/kaboom/.symbols_version",
+Alias("kaboom_symbols", env.FetchGithubRelease(
     "modules/kaboom.properties",
-    fetch_kaboom_symbols_action,
-)
-
-Alias("kaboom_symbols", fetch_kaboom_symbols)
+    asset="godot-kaboom-debug-symbols.zip",
+    target_dir="project/addons/kaboom",
+    strip_prefix="addons/kaboom",
+    version_file=".symbols_version",
+))
 
 
 # *** Add help for optional targets.

--- a/SConstruct
+++ b/SConstruct
@@ -81,6 +81,7 @@ arch = env["arch"]
 env.Tool("copy")
 env.Tool("plist")
 env.Tool("separate_debug_symbols")
+env.Tool("fetch_github_release")
 
 # Restore original ARGUMENTS and add custom options to environment
 ARGUMENTS.clear()
@@ -286,6 +287,44 @@ if env["build_android_lib"]:
     Depends(android_lib, library)
 
 
+
+
+# *** Fetch kaboom addon (addon to trigger test crashes).
+
+def fetch_kaboom_action(target, source, env):
+    env.FetchGithubRelease(
+        properties_file="modules/kaboom.properties",
+        asset="godot-kaboom.zip",
+        target_dir="project/addons/kaboom",
+        strip_prefix="addons/kaboom",
+    )
+
+fetch_kaboom = env.Command(
+    "project/addons/kaboom/.version",
+    "modules/kaboom.properties",
+    fetch_kaboom_action,
+)
+
+Alias("kaboom", fetch_kaboom)
+
+
+def fetch_kaboom_symbols_action(target, source, env):
+    env.FetchGithubRelease(
+        properties_file="modules/kaboom.properties",
+        asset="godot-kaboom-debug-symbols.zip",
+        target_dir="project/addons/kaboom",
+        strip_prefix="addons/kaboom",
+    )
+
+fetch_kaboom_symbols = env.Command(
+    "project/addons/kaboom/.symbols_version",
+    "modules/kaboom.properties",
+    fetch_kaboom_symbols_action,
+)
+
+Alias("kaboom_symbols", fetch_kaboom_symbols)
+
+
 # *** Add help for optional targets.
 
 Help("""
@@ -298,6 +337,12 @@ ios_framework: Create iOS XCFramework from device and simulator builds.
 
 android_lib: Build Android bridge library.
              Usage: scons target=template_release platform=android android_lib
+
+kaboom: Fetch kaboom addon (addon to trigger test crashes).
+        Usage: scons kaboom
+
+kaboom_symbols: Fetch kaboom debug symbols.
+                Usage: scons kaboom_symbols
 """)
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -297,6 +297,7 @@ def fetch_kaboom_action(target, source, env):
         asset="godot-kaboom.zip",
         target_dir="project/addons/kaboom",
         strip_prefix="addons/kaboom",
+        clean=True,
     )
 
 fetch_kaboom = env.Command(
@@ -314,6 +315,7 @@ def fetch_kaboom_symbols_action(target, source, env):
         asset="godot-kaboom-debug-symbols.zip",
         target_dir="project/addons/kaboom",
         strip_prefix="addons/kaboom",
+        version_file=".symbols_version",
     )
 
 fetch_kaboom_symbols = env.Command(

--- a/modules/kaboom.properties
+++ b/modules/kaboom.properties
@@ -1,2 +1,2 @@
 repo=https://github.com/limbonaut/godot-kaboom
-version=0.0.3
+version=0.0.4

--- a/modules/kaboom.properties
+++ b/modules/kaboom.properties
@@ -1,2 +1,2 @@
 repo=https://github.com/limbonaut/godot-kaboom
-version=0.0.2
+version=0.0.3

--- a/modules/kaboom.properties
+++ b/modules/kaboom.properties
@@ -1,2 +1,2 @@
 repo=https://github.com/limbonaut/godot-kaboom
-version=0.0.1
+version=0.0.2

--- a/modules/kaboom.properties
+++ b/modules/kaboom.properties
@@ -1,0 +1,2 @@
+repo=https://github.com/limbonaut/godot-kaboom
+version=0.0.1

--- a/modules/sentry-cocoa.SConscript
+++ b/modules/sentry-cocoa.SConscript
@@ -11,7 +11,7 @@ from pathlib import Path
 
 Import("env")
 
-from utils import get_property
+from utils import read_property
 
 
 def remove_if_exists(filesystem_path):
@@ -75,8 +75,8 @@ def update_cocoa_framework():
         print(f"ERROR: Properties file not found at {properties_file}")
         Exit(1)
 
-    cocoa_repo = get_property("repo", properties_file)
-    cocoa_version = get_property("version", properties_file)
+    cocoa_repo = read_property("repo", properties_file)
+    cocoa_version = read_property("version", properties_file)
 
     cocoa_dir = project_root / "modules/sentry-cocoa"
     version_file = cocoa_dir / ".version"

--- a/modules/sentry-cocoa.SConscript
+++ b/modules/sentry-cocoa.SConscript
@@ -11,14 +11,7 @@ from pathlib import Path
 
 Import("env")
 
-
-def get_property(prop_name, file_path):
-    """Read property from .properties file"""
-    with open(file_path, 'r') as file:
-        for line in file:
-            if line.startswith(prop_name):
-                return line.split('=')[1].strip().strip('"')
-    raise KeyError(f"Property '{prop_name}' not found in {file_path}")
+from utils import get_property
 
 
 def remove_if_exists(filesystem_path):

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -65,8 +65,7 @@ func _cmd_crash_capture() -> int:
 	# NOTE: On Android, NDK scope sync seems to happen with delay.
 	await get_tree().create_timer(0.5).timeout
 
-	# Use the same crash method as the demo
-	SentrySDK._demo_helper_crash_app()
+	Kaboom.crash_with_null_dereference()
 	return 0
 
 

--- a/project/views/capture_events.gd
+++ b/project/views/capture_events.gd
@@ -67,11 +67,6 @@ func _on_capture_button_pressed() -> void:
 	DemoOutput.print_info("Captured message event. Event ID: " + event_id)
 
 
-func _on_crash_button_pressed() -> void:
-	DemoOutput.print_info("Crashing app...")
-	SentrySDK._demo_helper_crash_app()
-
-
 func _on_set_user_button_pressed() -> void:
 	DemoOutput.print_info("Setting user info...")
 	var user := SentryUser.new()
@@ -114,3 +109,23 @@ func _generate_native_error() -> void:
 
 func _on_user_feedback_button_pressed() -> void:
 	_user_feedback_gui.show()
+
+
+func _on_crash_with_null_dereference_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with null dereference...")
+	Kaboom.crash_with_null_dereference()
+
+
+func _on_crash_with_stack_overflow_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with stack overflow...")
+	Kaboom.crash_with_stack_overflow()
+
+
+func _on_crash_with_abort_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with abort...")
+	Kaboom.crash_with_abort()
+
+
+func _on_crash_with_div_by_zero_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with division by zero...")
+	Kaboom.crash_with_division_by_zero()

--- a/project/views/capture_events.tscn
+++ b/project/views/capture_events.tscn
@@ -80,6 +80,39 @@ text = "GDScript error from thread"
 layout_mode = 2
 text = "C++ error"
 
+[node name="Header - Generate Crashes" type="Label" parent="."]
+custom_minimum_size = Vector2(0, 40.505)
+layout_mode = 2
+text = "GENERATE CRASHES"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="GenerateCrashes" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="Crash" type="HBoxContainer" parent="GenerateCrashes"]
+layout_mode = 2
+
+[node name="CrashWithNullDereferenceButton" type="Button" parent="GenerateCrashes/Crash"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "NULL DEREFERENCE"
+
+[node name="CrashWithStackOverflowButton" type="Button" parent="GenerateCrashes/Crash"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "STACK OVERFLOW"
+
+[node name="CrashWithAbortButton" type="Button" parent="GenerateCrashes/Crash"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "ABORT"
+
+[node name="CrashWithDivByZeroButton" type="Button" parent="GenerateCrashes/Crash"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "DIV BY ZERO"
+
 [node name="Header - Capture" type="Label" parent="."]
 custom_minimum_size = Vector2(0, 40.505)
 layout_mode = 2
@@ -123,22 +156,13 @@ flat = false
 layout_mode = 2
 text = "Capture Event"
 
-[node name="Crash" type="HBoxContainer" parent="."]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="Crash"]
-layout_mode = 2
-text = "Crash program: "
-
-[node name="CrashButton" type="Button" parent="Crash"]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CRASH!"
-
 [connection signal="pressed" from="SetUserButton" to="." method="_on_set_user_button_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenScriptError" to="." method="_on_gen_script_error_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenScriptErrorFromThread" to="." method="_on_gen_script_error_from_thread_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenNativeError" to="." method="_on_gen_native_error_pressed"]
+[connection signal="pressed" from="GenerateCrashes/Crash/CrashWithNullDereferenceButton" to="." method="_on_crash_with_null_dereference_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/Crash/CrashWithStackOverflowButton" to="." method="_on_crash_with_stack_overflow_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/Crash/CrashWithAbortButton" to="." method="_on_crash_with_abort_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/Crash/CrashWithDivByZeroButton" to="." method="_on_crash_with_div_by_zero_button_pressed"]
 [connection signal="pressed" from="UserFeedback/UserFeedbackButton" to="." method="_on_user_feedback_button_pressed"]
 [connection signal="pressed" from="MessageEvent/CaptureButton" to="." method="_on_capture_button_pressed"]
-[connection signal="pressed" from="Crash/CrashButton" to="." method="_on_crash_button_pressed"]

--- a/site_scons/site_tools/fetch_github_release.py
+++ b/site_scons/site_tools/fetch_github_release.py
@@ -50,6 +50,9 @@ def fetch_github_release(env, properties_file, asset, target_dir, strip_prefix="
 
         # Clean existing directory to remove stale files from previous versions.
         if clean and target_path.exists():
+            if not target_path.resolve().is_relative_to(project_root.resolve()):
+                print(f"ERROR: Refusing to clean directory outside project root: {target_path}")
+                Exit(1)
             shutil.rmtree(target_path)
 
         url = f"{repo}/releases/download/{version}/{asset}"

--- a/site_scons/site_tools/fetch_github_release.py
+++ b/site_scons/site_tools/fetch_github_release.py
@@ -1,0 +1,97 @@
+"""
+Tool to fetch a zip asset from a GitHub release.
+
+Downloads a zip asset from a GitHub release, extracts it to a
+target directory, and caches by version to avoid re-downloading.
+
+Usage in SConstruct:
+    env.Tool("fetch_github_release")
+    env.FetchGithubRelease(
+        properties_file="my-package.properties",
+        asset="me-package.zip",
+        target_dir="target/directory/",
+        strip_prefix="some/prefix/directory/",
+    )
+"""
+
+import shutil
+import urllib.request
+import zipfile
+from pathlib import Path
+from SCons.Script import Exit
+from utils import read_property
+
+
+def fetch_github_release(env, properties_file, asset, target_dir, strip_prefix="", clean=False, version_file=".version"):
+    """Download and extract a zip asset from a GitHub release."""
+    project_root = Path(env.Dir("#").abspath)
+    properties_path = project_root / properties_file
+
+    if not properties_path.exists():
+        print(f"ERROR: Properties file not found at {properties_path}")
+        Exit(1)
+
+    repo = read_property("repo", properties_path)
+    version = read_property("version", properties_path)
+
+    target_path = project_root / target_dir
+    version_file = target_path / version_file
+
+    # Check if we need to download.
+    should_download = True
+    if version_file.exists():
+        stored_version = version_file.read_text().strip()
+        if stored_version == version:
+            should_download = False
+            print(f"Detected {asset} v{version} -- up-to-date!")
+
+    if should_download:
+        print(f"Fetching {asset} v{version}")
+
+        # Clean existing directory to remove stale files from previous versions.
+        if clean and target_path.exists():
+            shutil.rmtree(target_path)
+
+        url = f"{repo}/releases/download/{version}/{asset}"
+        zip_path = target_path / asset
+
+        target_path.mkdir(parents=True, exist_ok=True)
+
+        try:
+            print(f"Downloading {url}")
+            urllib.request.urlretrieve(url, zip_path)
+
+            print(f"Extracting {zip_path}")
+            with zipfile.ZipFile(zip_path, "r") as z:
+                prefix = strip_prefix.strip("/") + "/" if strip_prefix else ""
+                for info in z.infolist():
+                    if not info.filename.startswith(prefix):
+                        continue
+                    # Strip the prefix from the path.
+                    rel_path = info.filename[len(prefix):]
+                    if not rel_path:
+                        continue
+                    out_path = target_path / rel_path
+                    if info.is_dir():
+                        out_path.mkdir(parents=True, exist_ok=True)
+                    else:
+                        out_path.parent.mkdir(parents=True, exist_ok=True)
+                        with z.open(info) as src, open(out_path, "wb") as dst:
+                            dst.write(src.read())
+
+            zip_path.unlink()
+            version_file.write_text(version)
+
+            print(f"Successfully fetched {asset} v{version}.")
+
+        except Exception as e:
+            print(f"ERROR: Failed to download {asset}: {e}")
+            Exit(1)
+
+
+def generate(env):
+    env.AddMethod(fetch_github_release, "FetchGithubRelease")
+
+
+def exists(env):
+    return True

--- a/site_scons/utils.py
+++ b/site_scons/utils.py
@@ -1,4 +1,4 @@
-def get_property(prop_name, file_path):
+def read_property(prop_name, file_path):
     """Read property from .properties file"""
     with open(file_path, 'r') as file:
         for line in file:

--- a/site_scons/utils.py
+++ b/site_scons/utils.py
@@ -1,0 +1,7 @@
+def get_property(prop_name, file_path):
+    """Read property from .properties file"""
+    with open(file_path, 'r') as file:
+        for line in file:
+            if line.startswith(prop_name):
+                return line.split('=')[1].strip().strip('"')
+    raise KeyError(f"Property '{prop_name}' not found in {file_path}")

--- a/site_scons/utils.py
+++ b/site_scons/utils.py
@@ -3,5 +3,5 @@ def read_property(prop_name, file_path):
     with open(file_path, 'r') as file:
         for line in file:
             if line.startswith(prop_name + "="):
-                return line.split('=')[1].strip().strip('"')
+                return line.split('=', 1)[1].strip().strip('"')
     raise KeyError(f"Property '{prop_name}' not found in {file_path}")

--- a/site_scons/utils.py
+++ b/site_scons/utils.py
@@ -2,6 +2,6 @@ def read_property(prop_name, file_path):
     """Read property from .properties file"""
     with open(file_path, 'r') as file:
         for line in file:
-            if line.startswith(prop_name):
+            if line.startswith(prop_name + "="):
                 return line.split('=')[1].strip().strip('"')
     raise KeyError(f"Property '{prop_name}' not found in {file_path}")

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -320,11 +320,6 @@ void SentrySDK::_auto_initialize() {
 	is_auto_initializing = false;
 }
 
-void SentrySDK::_demo_helper_crash_app() {
-	char *ptr = (char *)1;
-	sentry::logging::print_fatal("Crash by access violation ", ptr); // this is going to crash the app
-}
-
 void SentrySDK::prepare_and_auto_initialize() {
 	// Create platform-specific SDK backend (replaces the default DisabledSDK).
 #ifdef SDK_NATIVE
@@ -409,7 +404,6 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_before_send", "callable"), &SentrySDK::set_before_send);
 	ClassDB::bind_method(D_METHOD("_unset_before_send"), &SentrySDK::unset_before_send);
 	ClassDB::bind_method(D_METHOD("_get_before_send"), &SentrySDK::get_before_send);
-	ClassDB::bind_method(D_METHOD("_demo_helper_crash_app"), &SentrySDK::_demo_helper_crash_app);
 
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "logger", PROPERTY_HINT_TYPE_STRING, "SentryLogger", PROPERTY_USAGE_NONE), get_logger);
 }

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -46,7 +46,6 @@ private:
 	void _init_user();
 	PackedStringArray _get_global_attachments();
 	void _auto_initialize();
-	void _demo_helper_crash_app();
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Integrate [godot-kaboom](https://github.com/limbonaut/godot-kaboom) - a GDExtension library that triggers controlled native crashes for testing Sentry's crash reporting. The repo can be adopted in getsentry.

- Closes #510 

Adds a general-purpose `FetchGithubRelease` SCons tool that downloads zip assets from GitHub releases with version caching and prefix stripping. Used to fetch the pre-built kaboom addon via `scons kaboom` and its debug symbols via `scons kaboom_symbols`.

Also extracts the shared `read_property()` utility from sentry-cocoa's SConscript into `site_scons/utils.py` for reuse across tools.

Removes the internal `SentrySDK._demo_helper_crash_app()` method - crash triggering is now fully handled by the kaboom library. Both the demo project and CLI integration tests (`crash-capture` command) use Kaboom. CI fetches the addon automatically via the `prepare-testing` action.
