### PR TITLE
ci: Migrate updater workflow to composite action v3

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,33 +13,39 @@ permissions:
   actions: write # needed for cancelling workflow runs
 
 jobs:
-  deps:
-    name: ${{ matrix.name }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Native SDK
-            path: modules/sentry-native
-          - name: Cocoa SDK
-            path: modules/sentry-cocoa.properties
-          - name: gdUnit 4
-            path: modules/gdUnit4
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      name: ${{ matrix.name }}
-      path: ${{ matrix.path }}
-      pr-strategy: update
-      changelog-entry: ${{ matrix.path != 'modules/gdUnit4' }}
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+  sentry-native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: modules/sentry-native
+          name: Native SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
-  android:
-    name: Sentry Android
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
-    with:
-      name: Sentry Android
-      path: scripts/android-version.ps1
-      pr-strategy: update
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+  sentry-cocoa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: modules/sentry-cocoa.properties
+          name: Cocoa SDK
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  sentry-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: scripts/android-version.ps1
+          name: Sentry Android
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  gdunit4:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@v3
+        with:
+          path: modules/gdUnit4
+          name: gdUnit 4
+          changelog-entry: false
+          api-token: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
Migrate the dependency updater workflow from the reusable workflow (`getsentry/github-workflows/.github/workflows/updater.yml@v2`) to the composite action (`getsentry/github-workflows/updater@v3`), following the recommended usage pattern with separate jobs per dependency.

The reusable workflow approach is being phased out in favor of the composite action which handles checkout internally and provides a simpler interface.

- See https://github.com/getsentry/github-workflows/blob/main/updater/README.md