### PR TITLE
ci: Use ssh-key input for deploy key in updater workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: modules/sentry-native
           name: Native SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   sentry-cocoa:
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
         with:
           path: modules/sentry-cocoa.properties
           name: Cocoa SDK
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   sentry-android:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
         with:
           path: scripts/android-version.ps1
           name: Sentry Android
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
   gdunit4:
     runs-on: ubuntu-latest
@@ -48,4 +48,4 @@ jobs:
           path: modules/gdUnit4
           name: gdUnit 4
           changelog-entry: false
-          api-token: ${{ secrets.CI_DEPLOY_KEY }}
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
Fix update-deps workflow errors:

```
Error: The api-token input appears to contain an SSH private key.
Error: Please use the ssh-key input for SSH authentication instead of api-token.
```

The updater composite action v3 now validates auth inputs and rejects SSH private keys passed via `api-token` (see https://github.com/getsentry/github-workflows/pull/134).

Move `CI_DEPLOY_KEY` to the new `ssh-key` input. The action falls back to `github.token` for API operations (PR creation, etc.) automatically when no `api-token` is provided.