### PR TITLE
ci: Disable changelog entry for wasm-split updater

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -66,4 +66,5 @@ jobs:
         with:
           path: modules/wasm-split.properties
           name: wasm-split
+          changelog-entry: false
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
Disable changelog entry generation for the wasm-split dependency updater.

The wasm-split properties file is an internal build dependency, not user-facing, so automated updates to it don't need changelog entries.