### PR TITLE
ci: Run CI on all PRs regardless of changed paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
       - "*.md"
 
   pull_request:
-    paths-ignore:
-      - "*.md"
 
 # Cancel in-progress runs on PR update and on push.
 concurrency:


### PR DESCRIPTION
Remove `paths-ignore` filter for pull requests in the CI workflow.

Repository rules require certain CI checks to pass before merging. When PRs only touch `*.md` files, CI was skipped entirely, causing those PRs to be blocked from merging due to missing required checks.

The `paths-ignore` filter is kept for pushes to main/release branches, where skipping CI on docs-only changes is still desirable.