### PR TITLE
ci: Exclude MSVC linker byproducts from build artifact

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -300,6 +300,8 @@ jobs:
             project/
             !project/
             project/addons/sentry/
+            !project/addons/sentry/bin/**/*.lib
+            !project/addons/sentry/bin/**/*.exp
 
   android-plugin:
     name: 🤖 Android Plugin AARs


### PR DESCRIPTION
Exclude `.lib` and `.exp` files generated by MSVC from the uploaded build artifact. These are linker import libraries and export files that are not needed in the release package.