### PR TITLE
chore: Add .clangd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ compile_commands.json
 # clang cache
 .cache
 
+# clangd config (local/user-specific)
+.clangd
+
 # Web tests
 test_web/node_modules/
 test_web/playwright-report/


### PR DESCRIPTION
Ignore the `.clangd` configuration dir which is user-specific and should not be tracked in the repository.

The `.cache` directory (clangd's index cache) was already ignored.