### PR TITLE
chore: Remove unnecessary object allocation in dictionary_to_attributes()

### DIFF
--- a/src/sentry/native/native_util.cpp
+++ b/src/sentry/native/native_util.cpp
@@ -163,12 +163,13 @@ sentry_value_t variant_to_attribute(const Variant &p_value) {
 }
 
 sentry_value_t dictionary_to_attributes(const Dictionary &p_attributes) {
+	if (p_attributes.is_empty()) {
+		return sentry_value_new_null();
+	}
 	sentry_value_t rv = sentry_value_new_object();
-	if (!p_attributes.is_empty()) {
-		for (const Variant &key : p_attributes.keys()) {
-			sentry_value_set_by_key(rv, key.stringify().utf8(),
-					variant_to_attribute(p_attributes[key]));
-		}
+	for (const Variant &key : p_attributes.keys()) {
+		sentry_value_set_by_key(rv, key.stringify().utf8(),
+				variant_to_attribute(p_attributes[key]));
 	}
 	return rv;
 }


### PR DESCRIPTION
Remove unnecessary object allocation in dictionary_to_attributes()
- Extracted from #553 
- [ ] Waiting on sentry-native release for https://github.com/getsentry/sentry-native/pull/1552

#skip-changelog