### PR TITLE
fix: pass log body as format argument instead of format string

### DIFF
--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -207,7 +207,7 @@ void NativeSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_
 		return;
 	}
 
-	String body = p_body;
+	const CharString body_utf8 = p_body.utf8();
 
 	sentry_value_t attributes = sentry_value_new_object();
 
@@ -218,29 +218,36 @@ void NativeSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_
 		}
 	}
 
+	// NOTE: The sentry_log_* functions treat `message` as a printf format
+	// string. When `logs_with_attributes` is enabled (line 418), the first
+	// vararg is consumed as the attributes object, and remaining varargs are
+	// used as format arguments. Passing the log body directly as `message`
+	// causes a crash on Windows (CRT invalid parameter handler) if the body
+	// contains '%' characters, because vsnprintf reads past the va_list.
+	// Fix: use "%s" as the format string and pass the body as a vararg.
 	switch (p_level) {
 		case LOG_LEVEL_TRACE: {
-			sentry_log_trace(body.utf8(), attributes);
+			sentry_log_trace("%s", attributes, body_utf8.get_data());
 		} break;
 		case LOG_LEVEL_DEBUG: {
-			sentry_log_debug(body.utf8(), attributes);
+			sentry_log_debug("%s", attributes, body_utf8.get_data());
 		} break;
 		case LOG_LEVEL_INFO: {
-			sentry_log_info(body.utf8(), attributes);
+			sentry_log_info("%s", attributes, body_utf8.get_data());
 		} break;
 		case LOG_LEVEL_WARN: {
-			sentry_log_warn(body.utf8(), attributes);
+			sentry_log_warn("%s", attributes, body_utf8.get_data());
 		} break;
 		case LOG_LEVEL_ERROR: {
-			sentry_log_error(body.utf8(), attributes);
+			sentry_log_error("%s", attributes, body_utf8.get_data());
 		} break;
 		case LOG_LEVEL_FATAL: {
-			sentry_log_fatal(body.utf8(), attributes);
+			sentry_log_fatal("%s", attributes, body_utf8.get_data());
 		} break;
 		default: {
 			sentry::logging::print_no_logger(LEVEL_WARNING,
 					vformat("Sentry: Unexpected log level: %d, defaulting to info.", static_cast<int>(p_level)));
-			sentry_log_info(body.utf8(), attributes);
+			sentry_log_info("%s", attributes, body_utf8.get_data());
 		} break;
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a crash on Windows where the game process is killed by the CRT invalid parameter handler (`_invoke_watson`) when a log message containing `%` characters flows through the Sentry structured logging path.

### Root Cause

`NativeSDK::log()` passes the user-provided log body directly as the `message` (first) parameter to `sentry_log_*()` functions:

```cpp
sentry_log_info(body.utf8(), attributes);
```

These functions treat `message` as a **printf format string**. When `logs_with_attributes` is enabled (set unconditionally at init), the `attributes` object is consumed from the va_list, leaving it empty. If the log body contains any `%` specifier (e.g. `"50% complete"`, `"Error: %s not found"`, or engine messages with `%`), `vsnprintf` reads past the empty va_list.

On Windows MSVC CRT, this triggers the invalid parameter handler chain: `_invalid_parameter_noinfo` -> `_invoke_watson` -> process termination (non-continuable exception). On other platforms this is undefined behavior that may silently corrupt memory.

### Fix

Use `"%s"` as the format string and pass the body as a format argument:

```cpp
sentry_log_info("%s", attributes, body_utf8.get_data());
```

This ensures user content is never interpreted as format specifiers.

### Evidence

Crash dumps from affected users show all 3 crashes at the same offset (`0xa592c`) inside `libsentry.windows.release.x86_64.dll`, which resolves to `_invoke_watson` (the MSVC CRT invalid parameter crash handler) via PDB symbols from the 1.2.0 release.

### Affected Versions

The bug exists in all versions from 1.2.0 (when `logs_with_attributes` was introduced) through 1.4.1 (current latest).

## Test plan

- [ ] Send a log message containing `%s`, `%d`, or bare `%` through the Sentry logger on Windows and verify no crash
- [ ] Verify structured log messages still appear correctly in the Sentry dashboard with attributes
- [ ] Verify the fix on Linux/macOS (UB on those platforms, may not crash but could corrupt data)