### PR TITLE
ref(dotnet): CoreClrExceptionHandler fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- *Experimental*: Add C# (.NET) support ([#629](https://github.com/getsentry/sentry-godot/pull/629))
+- *Experimental*: Add C# (.NET) support ([#629](https://github.com/getsentry/sentry-godot/pull/629), [#644](https://github.com/getsentry/sentry-godot/pull/644))
 
 ### Improvements
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -30,7 +30,7 @@ internal class FirstChanceExceptionPool : IDisposable
     }
 
     private readonly object _pendingLock = new();
-    private readonly Dictionary<long, LinkedList<Exception>> _pending = []; // OSThreadId => pending exceptions
+    private readonly Dictionary<long, Queue<Exception>> _pending = []; // OSThreadId => pending exceptions
 
     public FirstChanceExceptionPool()
     {
@@ -54,7 +54,7 @@ internal class FirstChanceExceptionPool : IDisposable
                 p = [];
                 _pending[osThreadId] = p;
             }
-            p.AddLast(e.Exception);
+            p.Enqueue(e.Exception);
         }
     }
 
@@ -67,24 +67,17 @@ internal class FirstChanceExceptionPool : IDisposable
                 return null;
             }
 
-            var node = list.First!;
-            for (int i = 0; i < drainCount - 1; i++)
+            Exception matched;
+            do
             {
-                node = node.Next!;
-            }
-            var matched = node.Value;
+                matched = list.Dequeue();
+            } while (--drainCount > 0);
 
-            // Drain matched + everything older.
-            for (var n = node; n is not null;)
-            {
-                var prev = n.Previous;
-                list.Remove(n);
-                n = prev;
-            }
             if (list.Count == 0)
             {
                 _pending.Remove(threadId);
             }
+
             return matched;
         }
     }

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using Sentry.Godot.Internal;
 
 namespace Sentry.Godot.ExceptionHandling;
@@ -58,12 +59,21 @@ internal class FirstChanceExceptionPool : IDisposable
     private sealed class ThreadCleanupSentinel(long threadId, FirstChanceExceptionPool owner)
     {
         private readonly long _threadId = threadId;
-        private readonly WeakReference<FirstChanceExceptionPool> _owner = new(owner);
+        private readonly GCHandle _ownerHandle = GCHandle.Alloc(owner, GCHandleType.Weak);
+
         ~ThreadCleanupSentinel()
         {
-            if (_owner.TryGetTarget(out var pool))
+            try
             {
-                pool.ThreadDied?.Invoke(_threadId);
+                if (_ownerHandle.Target is FirstChanceExceptionPool pool)
+                {
+                    GodotLog.Debug($"[diag] Emitting ThreadDied: {_threadId}");
+                    pool.ThreadDied?.Invoke(_threadId);
+                }
+            }
+            finally
+            {
+                _ownerHandle.Free();
             }
         }
     }
@@ -300,6 +310,7 @@ internal class CoreClrExceptionHandler : EventListener
         for (int i = 0; i < _deadThreadsPendingCleanup.Count; i++)
         {
             _threadContexts.Remove(_deadThreadsPendingCleanup[i]);
+            GodotLog.Debug($"CleanupDeadThreads: removed dead thread {_deadThreadsPendingCleanup[i]}");
         }
         _deadThreadsPendingCleanup.Clear();
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -8,8 +8,6 @@ using Sentry.Godot.Internal;
 
 namespace Sentry.Godot.ExceptionHandling;
 
-// TODO: remove debug prints when PR is ready
-
 /// <summary>
 /// Collects managed exceptions via FirstChanceException and keeps them in a
 /// per-thread FIFO queue for later correlation with CLR catch events.
@@ -67,7 +65,6 @@ internal class FirstChanceExceptionPool : IDisposable
             {
                 if (_ownerHandle.Target is FirstChanceExceptionPool pool)
                 {
-                    GodotLog.Debug($"[diag] Emitting ThreadDied: {_threadId}");
                     pool.ThreadDied?.Invoke(_threadId);
                 }
             }
@@ -89,7 +86,6 @@ internal class FirstChanceExceptionPool : IDisposable
         }
 
         long osThreadId = NativeThreadId.GetCurrentThreadId();
-        GodotLog.Debug($"[diag] FCE tid={osThreadId} type={e.Exception.GetType().Name}");
 
         lock (_pendingLock)
         {
@@ -242,7 +238,6 @@ internal class CoreClrExceptionHandler : EventListener
     private void HandleExceptionThrown(EventWrittenEventArgs eventData)
     {
         var tid = eventData.OSThreadId;
-        GodotLog.Debug($"[diag] THROW srcTid={tid} handlerTid={NativeThreadId.GetCurrentThreadId()} throwTs={eventData.TimeStamp:HH:mm:ss.fffffff}");
 
         // Track how many exceptions have been thrown before catch.
         if (!_threadContexts.TryGetValue(tid, out var ctx))
@@ -264,8 +259,6 @@ internal class CoreClrExceptionHandler : EventListener
             var sourceThreadId = eventData.OSThreadId;
             string? bridgeName = eventData.Payload?[2] is string methodName ? GetGodotBridgeName(methodName) : null;
 
-            GodotLog.Debug($"[diag] CATCH srcTid={sourceThreadId} handlerTid={NativeThreadId.GetCurrentThreadId()} ts={eventData.TimeStamp:HH:mm:ss.fffffff} method={eventData.Payload?[2] as string ?? "<null>"}");
-
             if (!_threadContexts.TryGetValue(sourceThreadId, out var ctx))
             {
                 ctx = new ThreadContext { throwCount = 0 };
@@ -275,8 +268,6 @@ internal class CoreClrExceptionHandler : EventListener
             var drainCount = Math.Max(ctx.throwCount, 1);
             Exception? matched = _exceptionsPool.DrainPending(sourceThreadId, drainCount);
             ctx.throwCount = 0;
-
-            GodotLog.Debug($"[diag] match tid={sourceThreadId} bridge={bridgeName} matched={matched?.GetType().Name ?? "<null>"}");
 
             if (matched is not null && bridgeName is not null)
             {
@@ -310,7 +301,6 @@ internal class CoreClrExceptionHandler : EventListener
         for (int i = 0; i < _deadThreadsPendingCleanup.Count; i++)
         {
             _threadContexts.Remove(_deadThreadsPendingCleanup[i]);
-            GodotLog.Debug($"CleanupDeadThreads: removed dead thread {_deadThreadsPendingCleanup[i]}");
         }
         _deadThreadsPendingCleanup.Clear();
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -105,6 +105,7 @@ internal class FirstChanceExceptionPool : IDisposable
         {
             if (!_pending.TryGetValue(threadId, out var queue) || queue.Count < drainCount)
             {
+                queue?.Clear();
                 return null;
             }
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Runtime.ExceptionServices;
@@ -47,6 +48,29 @@ internal class FirstChanceExceptionPool : IDisposable
         AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
     }
 
+    public void Dispose()
+    {
+        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
+    }
+
+    internal event Action<long>? ThreadDied;
+
+    private sealed class ThreadCleanupSentinel(long threadId, FirstChanceExceptionPool owner)
+    {
+        private readonly long _threadId = threadId;
+        private readonly WeakReference<FirstChanceExceptionPool> _owner = new(owner);
+        ~ThreadCleanupSentinel()
+        {
+            if (_owner.TryGetTarget(out var pool))
+            {
+                pool.ThreadDied?.Invoke(_threadId);
+            }
+        }
+    }
+
+    [ThreadStatic]
+    private static ThreadCleanupSentinel? _sentinel;
+
     private void OnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
     {
         if (_inCaptureScope)
@@ -63,6 +87,7 @@ internal class FirstChanceExceptionPool : IDisposable
             {
                 p = [];
                 _pending[osThreadId] = p;
+                _sentinel = new ThreadCleanupSentinel(osThreadId, this);
             }
             p.Enqueue(e.Exception);
         }
@@ -72,7 +97,7 @@ internal class FirstChanceExceptionPool : IDisposable
     {
         lock (_pendingLock)
         {
-            if (!_pending.TryGetValue(threadId, out var list) || list.Count < drainCount)
+            if (!_pending.TryGetValue(threadId, out var queue) || queue.Count < drainCount)
             {
                 return null;
             }
@@ -80,21 +105,27 @@ internal class FirstChanceExceptionPool : IDisposable
             Exception matched;
             do
             {
-                matched = list.Dequeue();
+                matched = queue.Dequeue();
             } while (--drainCount > 0);
 
-            if (list.Count == 0)
-            {
-                _pending.Remove(threadId);
-            }
+            // Leaves the queue in place even when emptied; cleanup is handled by RemoveThreads().
 
             return matched;
         }
     }
 
-    public void Dispose()
+    /// <remarks>
+    /// Called by CoreClrExceptionHandler to clean up dead threads from the pending list.
+    /// </remarks>
+    internal void RemoveThreads(IReadOnlyList<long> deadThreads)
     {
-        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
+        lock (_pendingLock)
+        {
+            for (int i = 0; i < deadThreads.Count; i++)
+            {
+                _pending.Remove(deadThreads[i]);
+            }
+        }
     }
 }
 
@@ -143,6 +174,24 @@ internal class CoreClrExceptionHandler : EventListener
     }
     private readonly Dictionary<long, ThreadContext> _threadContexts = []; // only listener thread
 
+    private static readonly TimeSpan CleanupInterval = TimeSpan.FromSeconds(2);
+
+    // Bring out your dead!
+    private readonly ConcurrentQueue<long> _deadThreadsIncoming = new();
+    private readonly List<long> _deadThreadsPendingCleanup = [];
+    private DateTime _lastCleanup = DateTime.UtcNow;
+
+    public CoreClrExceptionHandler()
+    {
+        _exceptionsPool.ThreadDied += _deadThreadsIncoming.Enqueue;
+    }
+
+    public override void Dispose()
+    {
+        _exceptionsPool.Dispose();
+        base.Dispose();
+    }
+
     protected override void OnEventSourceCreated(EventSource eventSource)
     {
         if (eventSource.Name == "Microsoft-Windows-DotNETRuntime")
@@ -172,10 +221,10 @@ internal class CoreClrExceptionHandler : EventListener
                 break;
             case ExceptionCatchStart_EventId:
                 HandleExceptionCatchStart(eventData);
+                CleanupDeadThreads();
                 break;
         }
     }
-
 
     /// <remarks>
     /// Runs on the listener thread.
@@ -234,6 +283,32 @@ internal class CoreClrExceptionHandler : EventListener
         }
     }
 
+    /// <remarks>
+    /// Dead threads observed this cycle are removed next cycle, so in-flight
+    /// events have time to drain.
+    /// </remarks>
+    private void CleanupDeadThreads()
+    {
+        if (_lastCleanup + CleanupInterval > DateTime.UtcNow)
+        {
+            return;
+        }
+
+        _lastCleanup = DateTime.UtcNow;
+
+        _exceptionsPool.RemoveThreads(_deadThreadsPendingCleanup);
+        for (int i = 0; i < _deadThreadsPendingCleanup.Count; i++)
+        {
+            _threadContexts.Remove(_deadThreadsPendingCleanup[i]);
+        }
+        _deadThreadsPendingCleanup.Clear();
+
+        while (_deadThreadsIncoming.TryDequeue(out var deadTid))
+        {
+            _deadThreadsPendingCleanup.Add(deadTid);
+        }
+    }
+
     private const string GodotSharpMarker = "[GodotSharp] ";
 
     /// <summary>
@@ -258,11 +333,5 @@ internal class CoreClrExceptionHandler : EventListener
             }
         }
         return null;
-    }
-
-    public override void Dispose()
-    {
-        _exceptionsPool.Dispose();
-        base.Dispose();
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -33,7 +33,7 @@ internal class FirstChanceExceptionPool : IDisposable
 
     private static readonly CaptureScopeToken _statelessCaptureToken = new();
 
-    public static CaptureScopeToken EnterCaptureScope()
+    public static IDisposable EnterCaptureScope()
     {
         _inCaptureScope = true;
         return _statelessCaptureToken; // safe to reuse

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -6,9 +6,19 @@ using Sentry.Godot.Internal;
 
 namespace Sentry.Godot.ExceptionHandling;
 
+// TODO: remove debug prints when PR is ready
 
+/// <summary>
+/// Collects managed exceptions via FirstChanceException and keeps them in a
+/// per-thread FIFO queue for later correlation with CLR catch events.
+/// </summary>
 /// <remarks>
-/// Runs on the throwing thread.
+/// Thread-safety: OnFirstChanceException runs on the throwing thread;
+/// DrainPending() runs on the listener's thread and guarded by lock.
+///
+/// Capture scope: consumers wrap their capture call in EnterCaptureScope().
+/// Any FirstChanceException that fires on the same thread inside that scope is
+/// dropped, preventing feedback loops if the capture path itself throws.
 /// </remarks>
 internal class FirstChanceExceptionPool : IDisposable
 {
@@ -90,20 +100,23 @@ internal class FirstChanceExceptionPool : IDisposable
 
 /// <summary>
 /// Detects "unhandled" C# exceptions in Godot by combining FirstChanceException
-/// with .NET runtime EventSource events. When ExceptionCatchStart reports a Godot
-/// bridge method as the catcher, the exception is classified as unhandled by user
-/// code and sent to Sentry.
-///
-/// See: https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-exception-events
-///
-/// Key insight: FirstChanceException runs on the throwing thread, but EventListener
-/// callbacks run on a dedicated background thread. We correlate via OS thread ID.
-/// A FIFO queue per thread is needed because multiple FirstChanceException events
-/// fire synchronously before the EventListener processes any ExceptionCatchStart.
-/// TODO: ^^ Update this ^^.
+/// with .NET runtime EventSource events. When ExceptionCatchStart reports a
+/// Godot bridge method as the catcher, the exception is classified as unhandled
+/// by user code and sent to Sentry.
 /// </summary>
 /// <remarks>
-/// Runs on the listerner thread.
+/// Key insight: FirstChanceException runs on the throwing thread, but
+/// EventListener callbacks run on a dedicated background thread. We correlate
+/// via OS thread ID. A FIFO queue per thread is needed because multiple
+/// FirstChanceException events fire synchronously before the EventListener
+/// processes any ExceptionCatchStart(250).
+///
+/// ExceptionThrown(80) is emitted before FirstChanceException, but their
+/// arrival order on the listener side is racey, so we must not depend on it.
+/// The only reliable ordering here is that both arrive before
+/// ExceptionCatchStart(250).
+///
+/// See: https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-exception-events
 /// </remarks>
 internal class CoreClrExceptionHandler : EventListener
 {
@@ -165,9 +178,7 @@ internal class CoreClrExceptionHandler : EventListener
 
 
     /// <remarks>
-    /// Runs on the listener thread, emitted before FCE, and before ExceptionCatchStart event.
-    /// Usually it arrives after FCE event, but we should NOT depend on it.
-    /// It's enough that it always arrives before ExceptionCatchStart event.
+    /// Runs on the listener thread.
     /// </remarks>
     private void HandleExceptionThrown(EventWrittenEventArgs eventData)
     {
@@ -184,7 +195,7 @@ internal class CoreClrExceptionHandler : EventListener
     }
 
     /// <remarks>
-    /// Runs on the listener thread, after FCE and ExceptionThrown.
+    /// Runs on the listener thread.
     /// </remarks>
     private void HandleExceptionCatchStart(EventWrittenEventArgs eventData)
     {

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -99,6 +99,8 @@ internal class FirstChanceExceptionPool : IDisposable
         }
     }
 
+    private bool _warnedAboutUnderfill = false;
+
     public Exception? DrainPending(long threadId, int drainCount)
     {
         lock (_pendingLock)
@@ -107,7 +109,7 @@ internal class FirstChanceExceptionPool : IDisposable
             {
                 // This handler is not designed to wait for FCE as "underfilling" is highly unlikely to happen.
                 // But if it does, clear the queue to avoid stale data.
-                GodotLog.Error($"Could not match this exception to the current thread state for thread {threadId}. Found {queue?.Count ?? 0} pending exception(s), but expected at least {drainCount}. The exception will be skipped to avoid using stale data.");
+                GodotLog.ErrorOnce(ref _warnedAboutUnderfill, $"Could not match this exception to the current thread state for thread {threadId}. Found {queue?.Count ?? 0} pending exception(s), but expected at least {drainCount}. The exception will be skipped to avoid using stale data.");
                 queue?.Clear();
                 return null;
             }

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -201,11 +201,6 @@ internal class CoreClrExceptionHandler : EventListener
             EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)ExceptionKeyword);
             GodotLog.Debug("Subscribed to Microsoft-Windows-DotNETRuntime events.");
         }
-        else if (eventSource.Name == "Sentry-Godot-Exceptions")
-        {
-            EnableEvents(eventSource, EventLevel.Informational);
-            GodotLog.Debug("Subscribed to Sentry-Godot-Exceptions events.");
-        }
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -105,6 +105,9 @@ internal class FirstChanceExceptionPool : IDisposable
         {
             if (!_pending.TryGetValue(threadId, out var queue) || queue.Count < drainCount)
             {
+                // This handler is not designed to wait for FCE as "underfilling" is highly unlikely to happen.
+                // But if it does, clear the queue to avoid stale data.
+                GodotLog.Error($"Could not match this exception to the current thread state for thread {threadId}. Found {queue?.Count ?? 0} pending exception(s), but expected at least {drainCount}. The exception will be skipped to avoid using stale data.");
                 queue?.Clear();
                 return null;
             }

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -174,11 +174,7 @@ internal class CoreClrExceptionHandler : EventListener
         ("Godot.GD::", "Godot.GD"),
     };
 
-    private class ThreadContext
-    {
-        public int throwCount;
-    }
-    private readonly Dictionary<long, ThreadContext> _threadContexts = []; // only listener thread
+    private readonly Dictionary<long, int> _throwCounts = []; // tid => pre-catch throw count; only listener thread
 
     private static readonly TimeSpan CleanupInterval = TimeSpan.FromSeconds(2);
 
@@ -240,12 +236,8 @@ internal class CoreClrExceptionHandler : EventListener
         var tid = eventData.OSThreadId;
 
         // Track how many exceptions have been thrown before catch.
-        if (!_threadContexts.TryGetValue(tid, out var ctx))
-        {
-            ctx = new ThreadContext { throwCount = 0 };
-            _threadContexts[tid] = ctx;
-        }
-        ctx.throwCount++;
+        _throwCounts.TryGetValue(tid, out var count);
+        _throwCounts[tid] = count + 1;
     }
 
     /// <remarks>
@@ -259,15 +251,10 @@ internal class CoreClrExceptionHandler : EventListener
             var sourceThreadId = eventData.OSThreadId;
             string? bridgeName = eventData.Payload?[2] is string methodName ? GetGodotBridgeName(methodName) : null;
 
-            if (!_threadContexts.TryGetValue(sourceThreadId, out var ctx))
-            {
-                ctx = new ThreadContext { throwCount = 0 };
-                _threadContexts[sourceThreadId] = ctx;
-            }
-
-            var drainCount = Math.Max(ctx.throwCount, 1);
+            _throwCounts.TryGetValue(sourceThreadId, out var throwCount);
+            var drainCount = Math.Max(throwCount, 1);
             Exception? matched = _exceptionsPool.DrainPending(sourceThreadId, drainCount);
-            ctx.throwCount = 0;
+            _throwCounts[sourceThreadId] = 0;
 
             if (matched is not null && bridgeName is not null)
             {
@@ -300,7 +287,7 @@ internal class CoreClrExceptionHandler : EventListener
         _exceptionsPool.RemoveThreads(_deadThreadsPendingCleanup);
         for (int i = 0; i < _deadThreadsPendingCleanup.Count; i++)
         {
-            _threadContexts.Remove(_deadThreadsPendingCleanup[i]);
+            _throwCounts.Remove(_deadThreadsPendingCleanup[i]);
         }
         _deadThreadsPendingCleanup.Clear();
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -6,6 +6,95 @@ using Sentry.Godot.Internal;
 
 namespace Sentry.Godot.ExceptionHandling;
 
+
+/// <remarks>
+/// Runs on the throwing thread.
+/// </remarks>
+internal class FirstChanceExceptionPool : IDisposable
+{
+    // Prevents collecting exceptions from listener thread if it throws.
+    [ThreadStatic]
+    private static bool _inCaptureScope;
+
+    internal sealed class CaptureScopeToken : IDisposable
+    {
+        public void Dispose() => _inCaptureScope = false;
+    }
+
+    private static readonly CaptureScopeToken _statelessCaptureToken = new();
+
+    public static CaptureScopeToken EnterCaptureScope()
+    {
+        _inCaptureScope = true;
+        return _statelessCaptureToken; // safe to reuse
+    }
+
+    private readonly object _pendingLock = new();
+    private readonly Dictionary<long, LinkedList<Exception>> _pending = []; // OSThreadId => pending exceptions
+
+    public FirstChanceExceptionPool()
+    {
+        AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
+    }
+
+    private void OnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
+    {
+        if (_inCaptureScope)
+        {
+            return;
+        }
+
+        long osThreadId = NativeThreadId.GetCurrentThreadId();
+        GodotLog.Debug($"[diag] FCE tid={osThreadId} type={e.Exception.GetType().Name}");
+
+        lock (_pendingLock)
+        {
+            if (!_pending.TryGetValue(osThreadId, out var p))
+            {
+                p = [];
+                _pending[osThreadId] = p;
+            }
+            p.AddLast(e.Exception);
+        }
+    }
+
+    public Exception? DrainPending(long threadId, int drainCount)
+    {
+        lock (_pendingLock)
+        {
+            if (!_pending.TryGetValue(threadId, out var list) || list.Count < drainCount)
+            {
+                return null;
+            }
+
+            var node = list.First!;
+            for (int i = 0; i < drainCount - 1; i++)
+            {
+                node = node.Next!;
+            }
+            var matched = node.Value;
+
+            // Drain matched + everything older.
+            for (var n = node; n is not null;)
+            {
+                var prev = n.Previous;
+                list.Remove(n);
+                n = prev;
+            }
+            if (list.Count == 0)
+            {
+                _pending.Remove(threadId);
+            }
+            return matched;
+        }
+    }
+
+    public void Dispose()
+    {
+        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
+    }
+}
+
 /// <summary>
 /// Detects "unhandled" C# exceptions in Godot by combining FirstChanceException
 /// with .NET runtime EventSource events. When ExceptionCatchStart reports a Godot
@@ -18,12 +107,18 @@ namespace Sentry.Godot.ExceptionHandling;
 /// callbacks run on a dedicated background thread. We correlate via OS thread ID.
 /// A FIFO queue per thread is needed because multiple FirstChanceException events
 /// fire synchronously before the EventListener processes any ExceptionCatchStart.
+/// TODO: ^^ Update this ^^.
 /// </summary>
+/// <remarks>
+/// Runs on the listerner thread.
+/// </remarks>
 internal class CoreClrExceptionHandler : EventListener
 {
+    private const int ExceptionThrown_EventId = 80;
     private const int ExceptionCatchStart_EventId = 250;
-    private const long ExceptionKeyword = 0x8000;
-    private const int MaxQueueExceptionsPerThread = 32;
+    private const long ExceptionKeyword = 0x8000; // bitmask to target exception events
+
+    private readonly FirstChanceExceptionPool _exceptionsPool = new();
 
     // Godot bridge catch sites: IL signature prefix -> display name.
     // ExceptionCatchStart passes MethodName containing full IL signature, e.g.:
@@ -36,116 +131,102 @@ internal class CoreClrExceptionHandler : EventListener
         ("Godot.GD::", "Godot.GD"),
     };
 
-    // Single lock guards both _threadExceptions and the per-thread queues.
-    private readonly object _lock = new();
-    private readonly Dictionary<long, Queue<(DateTime Timestamp, Exception Exception)>> _threadExceptions = [];
-
-    // Prevents re-entrancy when CaptureException itself throws (e.g. serialization).
-    // ThreadStatic so the EventListener thread and throwing thread are guarded independently.
-    [ThreadStatic]
-    private static bool _isProcessing;
-
-    public CoreClrExceptionHandler()
+    private class ThreadContext
     {
-        AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
+        public int throwCount;
     }
-
-    private void OnFirstChanceException(object? sender, FirstChanceExceptionEventArgs e)
-    {
-        if (_isProcessing)
-        {
-            return;
-        }
-
-        try
-        {
-            _isProcessing = true;
-
-            long osThreadId = NativeThreadId.GetCurrentThreadId();
-            var timestamp = DateTime.UtcNow;
-            lock (_lock)
-            {
-                if (!_threadExceptions.TryGetValue(osThreadId, out var queue))
-                {
-                    queue = [];
-                    _threadExceptions[osThreadId] = queue;
-                }
-                queue.Enqueue((timestamp, e.Exception));
-                if (queue.Count > MaxQueueExceptionsPerThread)
-                {
-                    queue.Dequeue();
-                }
-            }
-        }
-        finally
-        {
-            _isProcessing = false;
-        }
-    }
+    private readonly Dictionary<long, ThreadContext> _threadContexts = []; // only listener thread
 
     protected override void OnEventSourceCreated(EventSource eventSource)
     {
         if (eventSource.Name == "Microsoft-Windows-DotNETRuntime")
         {
             EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)ExceptionKeyword);
-            GodotLog.Debug("Subscribed to Microsoft-Windows-DotNETRuntime exception events.");
+            GodotLog.Debug("Subscribed to Microsoft-Windows-DotNETRuntime events.");
+        }
+        else if (eventSource.Name == "Sentry-Godot-Exceptions")
+        {
+            EnableEvents(eventSource, EventLevel.Informational);
+            GodotLog.Debug("Subscribed to Sentry-Godot-Exceptions events.");
         }
     }
 
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
-        if (eventData.EventId == ExceptionCatchStart_EventId)
+        if (eventData.OSThreadId == NativeThreadId.GetCurrentThreadId())
         {
-            HandleExceptionCatchStart(eventData);
+            // Ignore events from the listener thread to avoid recursions.
+            return;
+        }
+
+        switch (eventData.EventId)
+        {
+            case ExceptionThrown_EventId:
+                HandleExceptionThrown(eventData);
+                break;
+            case ExceptionCatchStart_EventId:
+                HandleExceptionCatchStart(eventData);
+                break;
         }
     }
 
+
+    /// <remarks>
+    /// Runs on the listener thread, emitted before FCE, and before ExceptionCatchStart event.
+    /// Usually it arrives after FCE event, but we should NOT depend on it.
+    /// It's enough that it always arrives before ExceptionCatchStart event.
+    /// </remarks>
+    private void HandleExceptionThrown(EventWrittenEventArgs eventData)
+    {
+        var tid = eventData.OSThreadId;
+        GodotLog.Debug($"[diag] THROW srcTid={tid} handlerTid={NativeThreadId.GetCurrentThreadId()} throwTs={eventData.TimeStamp:HH:mm:ss.fffffff}");
+
+        // Track how many exceptions have been thrown before catch.
+        if (!_threadContexts.TryGetValue(tid, out var ctx))
+        {
+            ctx = new ThreadContext { throwCount = 0 };
+            _threadContexts[tid] = ctx;
+        }
+        ctx.throwCount++;
+    }
+
+    /// <remarks>
+    /// Runs on the listener thread, after FCE and ExceptionThrown.
+    /// </remarks>
     private void HandleExceptionCatchStart(EventWrittenEventArgs eventData)
     {
-        var sourceOsTid = eventData.OSThreadId;
-        var catchTimestamp = eventData.TimeStamp;
-        string? bridgeName = eventData.Payload?[2] is string methodName ? GetGodotBridgeName(methodName) : null;
-
+        using var scopeGuard = FirstChanceExceptionPool.EnterCaptureScope();
         try
         {
-            _isProcessing = true;
+            var sourceThreadId = eventData.OSThreadId;
+            string? bridgeName = eventData.Payload?[2] is string methodName ? GetGodotBridgeName(methodName) : null;
 
-            Exception? matched = null;
-            int remainingInQueue = 0;
+            GodotLog.Debug($"[diag] CATCH srcTid={sourceThreadId} handlerTid={NativeThreadId.GetCurrentThreadId()} ts={eventData.TimeStamp:HH:mm:ss.fffffff} method={eventData.Payload?[2] as string ?? "<null>"}");
 
-            lock (_lock)
+            if (!_threadContexts.TryGetValue(sourceThreadId, out var ctx))
             {
-                // Invariant: queues in _threadExceptions are always non-empty.
-                if (_threadExceptions.TryGetValue(sourceOsTid, out var queue))
-                {
-                    // Match most recent exception recorded on this thread at or before the catch event,
-                    // and remove it and any older entries from the queue.
-                    while (queue.Count > 0 && queue.Peek().Timestamp <= catchTimestamp)
-                    {
-                        matched = queue.Dequeue().Exception;
-                    }
-
-                    if (queue.Count == 0)
-                    {
-                        _threadExceptions.Remove(sourceOsTid);
-                    }
-
-                    remainingInQueue = queue.Count;
-                }
+                ctx = new ThreadContext { throwCount = 0 };
+                _threadContexts[sourceThreadId] = ctx;
             }
+
+            var drainCount = Math.Max(ctx.throwCount, 1);
+            Exception? matched = _exceptionsPool.DrainPending(sourceThreadId, drainCount);
+            ctx.throwCount = 0;
+
+            GodotLog.Debug($"[diag] match tid={sourceThreadId} bridge={bridgeName} matched={matched?.GetType().Name ?? "<null>"}");
 
             if (matched is not null && bridgeName is not null)
             {
-                GodotLog.Debug($"Capturing .NET exception caught by {bridgeName} (queue={remainingInQueue}):\n   {matched.GetType().FullName}: \"{matched.Message}\"");
+                GodotLog.Debug($"Capturing .NET exception caught by {bridgeName}:\n   {matched.GetType().FullName}: \"{matched.Message}\"");
                 matched.SetSentryMechanism(bridgeName,
                         "This exception was caught by the Godot engine bridge error handler. The application continued running.",
                         handled: false);
                 Sentry.SentrySdk.CaptureException(matched);
             }
         }
-        finally
+        catch (Exception ex)
         {
-            _isProcessing = false;
+            GodotLog.Error("CoreClrExceptionHandler failed to capture exception due to: " + ex);
         }
     }
 
@@ -177,7 +258,7 @@ internal class CoreClrExceptionHandler : EventListener
 
     public override void Dispose()
     {
-        AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
+        _exceptionsPool.Dispose();
         base.Dispose();
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/CoreClrExceptionHandler.cs
@@ -89,13 +89,13 @@ internal class FirstChanceExceptionPool : IDisposable
 
         lock (_pendingLock)
         {
-            if (!_pending.TryGetValue(osThreadId, out var p))
+            if (!_pending.TryGetValue(osThreadId, out var queue))
             {
-                p = [];
-                _pending[osThreadId] = p;
+                queue = [];
+                _pending[osThreadId] = queue;
                 _sentinel = new ThreadCleanupSentinel(osThreadId, this);
             }
-            p.Enqueue(e.Exception);
+            queue.Enqueue(e.Exception);
         }
     }
 
@@ -251,10 +251,9 @@ internal class CoreClrExceptionHandler : EventListener
             var sourceThreadId = eventData.OSThreadId;
             string? bridgeName = eventData.Payload?[2] is string methodName ? GetGodotBridgeName(methodName) : null;
 
-            _throwCounts.TryGetValue(sourceThreadId, out var throwCount);
+            _throwCounts.Remove(sourceThreadId, out var throwCount);
             var drainCount = Math.Max(throwCount, 1);
             Exception? matched = _exceptionsPool.DrainPending(sourceThreadId, drainCount);
-            _throwCounts[sourceThreadId] = 0;
 
             if (matched is not null && bridgeName is not null)
             {

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotLog.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotLog.cs
@@ -44,4 +44,14 @@ internal static class GodotLog
             NativeBridge.Log(SentryLevel.Error, message);
         }
     }
+
+    internal static void ErrorOnce(ref bool printed, string message)
+    {
+        if (printed || !ShouldPrint(SentryLevel.Error))
+        {
+            return;
+        }
+        printed = true;
+        NativeBridge.Log(SentryLevel.Error, message);
+    }
 }

--- a/project/views/DotnetActions.cs
+++ b/project/views/DotnetActions.cs
@@ -13,9 +13,13 @@ public partial class DotnetActions : VBoxContainer
     public void TriggerThreadException()
     {
         GD.Print("Triggering thread exception (likely to crash)...");
-        var thread = new Thread(() => throw new Exception("Thread exception (should be captured)"));
+        var thread = new Thread(() => { try { throw new Exception("Thread exception (should be captured)"); } catch { } });
         thread.Start();
         thread.Join();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
     }
 
     public void TriggerUserHandled()

--- a/project/views/DotnetActions.cs
+++ b/project/views/DotnetActions.cs
@@ -7,36 +7,35 @@ public partial class DotnetActions : VBoxContainer
     public void TriggerException()
     {
         GD.Print("Triggering exception...");
-        throw new Exception("Test CSharp exceptions");
+        throw new Exception("Exception (should be captured)");
     }
 
     public void TriggerThreadException()
     {
-        GD.Print("Triggering exception from thread...");
-        var thread = new Thread(() => throw new Exception("Test CSharp thread exception"));
+        GD.Print("Triggering thread exception (likely to crash)...");
+        var thread = new Thread(() => throw new Exception("Thread exception (should be captured)"));
         thread.Start();
         thread.Join();
     }
 
-    public void TriggerHandledException()
+    public void TriggerUserHandled()
     {
-        GD.Print("Triggering handled exception...");
+        GD.Print("Triggering user-handled exception...");
         try
         {
-            throw new InvalidOperationException("This is handled by user code and should not be captured");
+            throw new InvalidOperationException("User-handled (should NOT be captured)");
         }
-        catch (Exception e)
+        catch
         {
-            GD.Print($"User caught: {e.Message}");
         }
     }
 
-    public void TriggerRethrow()
+    public void TriggerBareRethrow()
     {
-        GD.Print("Triggering rethrow...");
+        GD.Print("Triggering bare rethrow...");
         try
         {
-            throw new Exception("Rethrow with throw;");
+            throw new Exception("Bare rethrow (should be captured)");
         }
         catch
         {
@@ -49,48 +48,44 @@ public partial class DotnetActions : VBoxContainer
         GD.Print("Triggering wrapped rethrow...");
         try
         {
-            throw new Exception("Inner exception");
+            throw new Exception("Inner (should NOT be captured)");
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException("Wrapped rethrow", ex);
+            throw new InvalidOperationException("Wrapped (should be captured)", ex);
         }
     }
 
-    // Regression test for listener-lag correlation: an exception is replaced by
-    // another thrown from a finally block, swallowed by user code, and then a
-    // real exception is thrown that should reach the bridge. The bridge must
-    // report "Real bridge exception", not the earlier swallowed exception.
-    public void TriggerNestedException()
+    public void TriggerNestedFinally()
     {
-        GD.Print("Triggering nested finally-replaced exception...");
+        GD.Print("Triggering nested finally throw...");
         try
         {
             try
             {
-                throw new InvalidOperationException("Replaced in finally");
+                throw new InvalidOperationException("Replaced in finally (should NOT be captured)");
             }
             finally
             {
-                throw new ArgumentException("Replaces in-flight exception");
+                throw new ArgumentException("Thrown from finally, user-caught (should NOT be captured)");
             }
         }
         catch (ArgumentException)
         {
         }
 
-        throw new Exception("Real bridge exception");
+        throw new Exception("Post-catch throw (should be captured)");
     }
 
     public void TriggerReplacedThenRethrown()
     {
-        GD.Print("Triggering replaced-then-rethrown exception...");
+        GD.Print("Triggering replaced-then-rethrown...");
 
         try
         {
-            try { throw new Exception("X (should NOT be captured)"); }
-            finally { throw new Exception("Y (should be captured)"); }   // Y replaces X
+            try { throw new Exception("Replaced in finally (should NOT be captured)"); }
+            finally { throw new Exception("Thrown from finally, rethrown (should be captured)"); }
         }
-        catch { throw; }       // rethrow Y
+        catch { throw; }
     }
 }

--- a/project/views/DotnetActions.cs
+++ b/project/views/DotnetActions.cs
@@ -13,13 +13,9 @@ public partial class DotnetActions : VBoxContainer
     public void TriggerThreadException()
     {
         GD.Print("Triggering thread exception (likely to crash)...");
-        var thread = new Thread(() => { try { throw new Exception("Thread exception (should be captured)"); } catch { } });
+        var thread = new Thread(() => throw new Exception("Thread exception (should be captured)"));
         thread.Start();
         thread.Join();
-
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
     }
 
     public void TriggerUserHandled()

--- a/project/views/DotnetActions.cs
+++ b/project/views/DotnetActions.cs
@@ -81,4 +81,16 @@ public partial class DotnetActions : VBoxContainer
 
         throw new Exception("Real bridge exception");
     }
+
+    public void TriggerReplacedThenRethrown()
+    {
+        GD.Print("Triggering replaced-then-rethrown exception...");
+
+        try
+        {
+            try { throw new Exception("X (should NOT be captured)"); }
+            finally { throw new Exception("Y (should be captured)"); }   // Y replaces X
+        }
+        catch { throw; }       // rethrow Y
+    }
 }

--- a/project/views/dotnet_actions.tscn
+++ b/project/views/dotnet_actions.tscn
@@ -38,9 +38,14 @@ text = "Wrapped rethrow"
 layout_mode = 2
 text = "Nested finally throw"
 
+[node name="TriggerReplacedThenRethrown" type="Button" parent="."]
+layout_mode = 2
+text = "Replaced then rethrown"
+
 [connection signal="pressed" from="TriggerException" to="." method="TriggerException"]
 [connection signal="pressed" from="TriggerThreadException" to="." method="TriggerThreadException"]
 [connection signal="pressed" from="TriggerHandledException" to="." method="TriggerHandledException"]
 [connection signal="pressed" from="TriggerRethrow" to="." method="TriggerRethrow"]
 [connection signal="pressed" from="TriggerWrappedRethrow" to="." method="TriggerWrappedRethrow"]
 [connection signal="pressed" from="TriggerNestedException" to="." method="TriggerNestedException"]
+[connection signal="pressed" from="TriggerReplacedThenRethrown" to="." method="TriggerReplacedThenRethrown"]

--- a/project/views/dotnet_actions.tscn
+++ b/project/views/dotnet_actions.tscn
@@ -20,23 +20,23 @@ text = "Exception"
 
 [node name="TriggerThreadException" type="Button" parent="."]
 layout_mode = 2
-text = "Exception from thread (will CRASH!)"
+text = "Thread exception (will CRASH!)"
 
-[node name="TriggerHandledException" type="Button" parent="."]
+[node name="TriggerUserHandled" type="Button" parent="."]
 layout_mode = 2
-text = "Handled exception"
+text = "User-handled"
 
-[node name="TriggerRethrow" type="Button" parent="."]
+[node name="TriggerBareRethrow" type="Button" parent="."]
 layout_mode = 2
-text = "Rethrow"
+text = "Bare rethrow"
 
 [node name="TriggerWrappedRethrow" type="Button" parent="."]
 layout_mode = 2
 text = "Wrapped rethrow"
 
-[node name="TriggerNestedException" type="Button" parent="."]
+[node name="TriggerNestedFinally" type="Button" parent="."]
 layout_mode = 2
-text = "Nested finally throw"
+text = "Nested finally"
 
 [node name="TriggerReplacedThenRethrown" type="Button" parent="."]
 layout_mode = 2
@@ -44,8 +44,8 @@ text = "Replaced then rethrown"
 
 [connection signal="pressed" from="TriggerException" to="." method="TriggerException"]
 [connection signal="pressed" from="TriggerThreadException" to="." method="TriggerThreadException"]
-[connection signal="pressed" from="TriggerHandledException" to="." method="TriggerHandledException"]
-[connection signal="pressed" from="TriggerRethrow" to="." method="TriggerRethrow"]
+[connection signal="pressed" from="TriggerUserHandled" to="." method="TriggerUserHandled"]
+[connection signal="pressed" from="TriggerBareRethrow" to="." method="TriggerBareRethrow"]
 [connection signal="pressed" from="TriggerWrappedRethrow" to="." method="TriggerWrappedRethrow"]
-[connection signal="pressed" from="TriggerNestedException" to="." method="TriggerNestedException"]
+[connection signal="pressed" from="TriggerNestedFinally" to="." method="TriggerNestedFinally"]
 [connection signal="pressed" from="TriggerReplacedThenRethrown" to="." method="TriggerReplacedThenRethrown"]


### PR DESCRIPTION
Follow-up fixes and improvements to the CoreCLR exception handler introduced in #629 as part of the experimental C# (.NET) support.

- Refs #629

The main change is replacing timestamp-based matching of `FirstChanceException` to `ExceptionCatchStart` with strict order-based draining of a per-thread FIFO queue. Timestamps proved unreliable because `FirstChanceException` runs on the throwing thread while ETW events dispatch on the listener thread, and the two clocks drifted relative to each other.

To still match the right exception when more than one throw fires on a thread before a single catch — e.g. an in-flight exception replaced from a `finally` block, or similar patterns — the handler counts `ExceptionThrown` (EventId 80) events per thread and drains that many entries from the queue on `ExceptionCatchStart` (EventId 250).

Other changes:

- **Dead-thread cleanup.** Per-thread pending queues and throw counters are reclaimed when a thread exits, via a `[ThreadStatic]` finalizable sentinel that signals the pool. Previously these could accumulate for the lifetime of the process.
- **Structure.** `FirstChanceException` collection is split out into `FirstChanceExceptionPool`, and the re-entry guard is now an explicit disposable scope (`EnterCaptureScope()`) instead of an ad-hoc `_isProcessing` flag.
- **Demo tool buttons.** Renamed and reorganized the .NET exception test buttons in the demo project, and added one new case: an in-flight exception replaced in `finally` and then rethrown from the outer catch.