### PR TITLE
ci: Fix release workflow corrupting SConstruct due to unanchored regex

### DIFF
--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -6,7 +6,7 @@ Set-StrictMode -Version latest
 
 $sconsFile = "$PSScriptRoot/../SConstruct"
 $content = Get-Content $sconsFile
-$content -replace 'VERSION = ".*"', ('VERSION = "' + $newVersion + '"') | Out-File $sconsFile
+$content -replace '^VERSION = "[^"]*"', ('VERSION = "' + $newVersion + '"') | Out-File $sconsFile
 
 # Check that the version was updated.
 if ("$content" -eq "$(Get-Content $sconsFile)") {


### PR DESCRIPTION
See https://github.com/getsentry/sentry-godot/commit/e43640fe5d483f43992132cf80929ebeb165036b