### PR TITLE
ci(release): Anchor VERSION matching in package workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -88,7 +88,7 @@ jobs:
           # * Fix crashpad_handler permissions, workaround for https://github.com/actions/upload-artifact/issues/38
           find artifact/addons/sentry/bin/ -name "crashpad_handler" -exec chmod 755 "{}" \;
           # * Create release archive
-          version=$(grep 'VERSION =' SConstruct | cut -d '"' -f 2)
+          version=$(grep '^VERSION =' SConstruct | cut -d '"' -f 2)
           git_short_sha=$(git rev-parse --short HEAD)
           mkdir ${GITHUB_WORKSPACE}/out/
 


### PR DESCRIPTION
Same class of issue as in:
- #645 