### PR TITLE
fix(dotnet): Alias bare SentrySdk to Sentry.Godot.SentrySdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - *Experimental*: Add C# (.NET) support ([#629](https://github.com/getsentry/sentry-godot/pull/629), [#644](https://github.com/getsentry/sentry-godot/pull/644))
   - Expose the full Sentry .NET SDK API on `Sentry.Godot.SentrySdk` ([#657](https://github.com/getsentry/sentry-godot/pull/657))
   - Add Roslyn analyzer that warns on direct `Sentry.SentrySdk` use and suggests `Sentry.Godot.SentrySdk` ([#663](https://github.com/getsentry/sentry-godot/pull/663))
+  - Alias bare `SentrySdk` to `Sentry.Godot.SentrySdk` to avoid ambiguity when consumer code also does `using Sentry;` ([#664](https://github.com/getsentry/sentry-godot/pull/664))
 
 ### Dependencies
 

--- a/project/addons/sentry/dotnet/Sentry.Godot.GlobalUsings.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot.GlobalUsings.cs
@@ -1,0 +1,3 @@
+// Create an explicit alias for "SentrySdk" that points to our wrapper.
+// This avoids ambiguity when consumer code also includes "using Sentry;".
+global using SentrySdk = global::Sentry.Godot.SentrySdk;


### PR DESCRIPTION
Ships a global using alias alongside the Sentry.Godot package so bare `SentrySdk` in user code always resolves to the Godot-specific wrapper. Without the alias, consumer code that has both `using Sentry;` and `using Sentry.Godot;` in scope trips on `'SentrySdk' is an ambiguous reference between 'Sentry.Godot.SentrySdk' and 'Sentry.SentrySdk' (CS0104)`.

- Refs #649

The alias complements the `SENTRYGD1001` analyzer added in #663. The analyzer warns on fully-qualified `Sentry.SentrySdk.X`; the alias keeps bare `SentrySdk.X` pointing at our wrapper. Together they close the two paths that previously could route through upstream class.

Before this PR the following code would trip CS0104: 
```csharp
using Sentry;  // for Breadcrumb
using Sentry.Godot;

SentrySdk.AddBreadcrumb(new Breadcrumb("test", "note"));  // trips CS0104
```