### PR TITLE
ci(dotnet): Auto-update Sentry .NET SDK dependency

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -49,6 +49,15 @@ jobs:
           name: Sentry JavaScript
           ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
 
+  sentry-dotnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@26f565c05d0dd49f703d238706b775883037d76b # v3
+        with:
+          path: scripts/dotnet-version.ps1
+          name: Sentry .NET SDK
+          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
+
   gdunit4:
     runs-on: ubuntu-latest
     steps:

--- a/project/addons/sentry/dotnet/Sentry.Godot.Versions.props
+++ b/project/addons/sentry/dotnet/Sentry.Godot.Versions.props
@@ -1,0 +1,8 @@
+<!--
+  Shared package versions for Sentry .NET projects and tests.
+-->
+<Project>
+  <PropertyGroup>
+    <SentryVersion>6.2.0</SentryVersion>
+  </PropertyGroup>
+</Project>

--- a/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.csproj
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../Sentry.Godot.Versions.props" />
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
@@ -6,7 +7,7 @@
     <GodotProjectDir>$(MSBuildProjectDirectory)</GodotProjectDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Sentry" Version="6.2.0" />
+    <PackageReference Include="Sentry" Version="$(SentryVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="Sentry.Godot.SourceGenerators/Sentry.Godot.SourceGenerators.csproj"

--- a/scripts/dotnet-version.ps1
+++ b/scripts/dotnet-version.ps1
@@ -1,0 +1,117 @@
+#!/usr/bin/env pwsh
+
+# Updates Sentry .NET SDK dependency version across project files.
+
+Set-StrictMode -Version latest
+
+# Files to update.
+$versionsPropsFile = "$PSScriptRoot/../project/addons/sentry/dotnet/Sentry.Godot.Versions.props"
+
+function Write-Usage
+{
+	Write-Host "Usage: $(Split-Path $MyInvocation.ScriptName -Leaf) <action> [version]"
+	Write-Host "Actions:"
+	Write-Host "  get-version           - return the currently specified dependency version"
+	Write-Host "  get-repo              - return the repository url"
+	Write-Host "  set-version <version> - update the dependency version"
+}
+
+function Test-FileExists($filePath)
+{
+	if (-not(Test-Path $filePath))
+	{
+		Write-Error "$filePath not found"
+		exit 1
+	}
+}
+
+function Get-CurrentVersion
+{
+	Test-FileExists $versionsPropsFile
+
+	$content = Get-Content $versionsPropsFile -Raw
+	$match = [regex]::Match($content, '<SentryVersion>([^<]+)</SentryVersion>')
+	if ($match.Success)
+	{
+		return $match.Groups[1].Value
+	}
+
+	Write-Error "Could not find SentryVersion in $versionsPropsFile"
+	exit 1
+}
+
+function Get-RepositoryUrl
+{
+	return "https://github.com/getsentry/sentry-dotnet"
+}
+
+function Set-SentryDotnetVersion
+{
+	param(
+		[Parameter(Mandatory=$true)]
+		[string]$Version
+	)
+
+	Test-FileExists $versionsPropsFile
+
+	$currentVersion = Get-CurrentVersion
+	if ($currentVersion -eq $Version)
+	{
+		Write-Host "$(Split-Path $versionsPropsFile -Leaf) already declares version $Version"
+		Write-Host "No changes needed."
+		return
+	}
+
+	Write-Host "Updating $(Split-Path $versionsPropsFile -Leaf) from version $currentVersion to $Version"
+	$content = Get-Content $versionsPropsFile -Raw
+	$updated = $content.Replace("<SentryVersion>$currentVersion</SentryVersion>", "<SentryVersion>$Version</SentryVersion>")
+	[System.IO.File]::WriteAllText((Resolve-Path $versionsPropsFile), $updated)
+
+	# Verify write succeeded
+	$verifyVersion = Get-CurrentVersion
+	if ($verifyVersion -ne $Version)
+	{
+		throw "Update failed - read-after-write: '$verifyVersion', expected '$Version'"
+	}
+
+	Write-Host "Successfully updated Sentry .NET dependency to version $Version."
+}
+
+# ----------------------- Main -----------------------
+
+if ($args.Count -eq 0)
+{
+	Write-Usage
+	exit 0
+}
+
+$action = $args[0]
+
+switch ($action)
+{
+	"get-version"
+	{
+		Write-Output (Get-CurrentVersion)
+	}
+	"get-repo"
+	{
+		Write-Output (Get-RepositoryUrl)
+	}
+	"set-version"
+	{
+		if ($args.Count -lt 2)
+		{
+			Write-Error "set-version requires a version argument"
+			Write-Usage
+			exit 1
+		}
+		$version = $args[1]
+		Set-SentryDotnetVersion -Version $version
+	}
+	default
+	{
+		Write-Error "Unknown action: $action"
+		Write-Usage
+		exit 1
+	}
+}

--- a/tests/dotnet/Sentry.Godot.Analyzers.Tests/Sentry.Godot.Analyzers.Tests.csproj
+++ b/tests/dotnet/Sentry.Godot.Analyzers.Tests/Sentry.Godot.Analyzers.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\project\addons\sentry\dotnet\Sentry.Godot.Versions.props" />
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -13,7 +14,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
-    <PackageReference Include="Sentry" Version="6.2.0" />
+    <PackageReference Include="Sentry" Version="$(SentryVersion)" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/dotnet/Sentry.Godot.SourceGenerators.Tests/Sentry.Godot.SourceGenerators.Tests.csproj
+++ b/tests/dotnet/Sentry.Godot.SourceGenerators.Tests/Sentry.Godot.SourceGenerators.Tests.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\project\addons\sentry\dotnet\Sentry.Godot.Versions.props" />
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -13,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-    <PackageReference Include="Sentry" Version="6.2.0" />
+    <PackageReference Include="Sentry" Version="$(SentryVersion)" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageReference Include="Verify.XunitV3" Version="31.16.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
Adds a daily CI job that auto-updates the Sentry .NET SDK package version, mirroring the existing Native, Cocoa, Android, and JavaScript jobs.

- Closes #656

The version is centralized in a new `Sentry.Godot.Versions.props` co-located with the addon, since the repo root isn't shipped in release artifacts. `scripts/dotnet-version.ps1` follows the same `get-version` / `get-repo` / `set-version` contract as the other update scripts.