### PR TITLE
feat(dotnet): Import `Sentry.Godot.props` into user's C# project automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Expose the full Sentry .NET SDK API on `Sentry.Godot.SentrySdk` ([#657](https://github.com/getsentry/sentry-godot/pull/657))
   - Add Roslyn analyzer that warns on direct `Sentry.SentrySdk` use and suggests `Sentry.Godot.SentrySdk` ([#663](https://github.com/getsentry/sentry-godot/pull/663))
   - Alias bare `SentrySdk` to `Sentry.Godot.SentrySdk` to avoid ambiguity when consumer code also does `using Sentry;` ([#664](https://github.com/getsentry/sentry-godot/pull/664))
+  - Import `Sentry.Godot.props` into user's C# project automatically ([#671](https://github.com/getsentry/sentry-godot/pull/671))
 
 ### Dependencies
 

--- a/project/Sentry demo project.csproj
+++ b/project/Sentry demo project.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.6.1">
+<Project Sdk="Godot.NET.Sdk/4.5.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>

--- a/project/Sentry demo project.csproj
+++ b/project/Sentry demo project.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.6.1">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <TargetFramework Condition=" '$(GodotTargetPlatform)' == 'android' ">net9.0</TargetFramework>

--- a/project/Sentry demo project.csproj
+++ b/project/Sentry demo project.csproj
@@ -6,7 +6,5 @@
     <RootNamespace>Sentrydemoproject</RootNamespace>
     <DefaultItemExcludes>$(DefaultItemExcludes);**/gdUnit4/**</DefaultItemExcludes>
   </PropertyGroup>
-
-  <Import Project="addons/sentry/dotnet/Sentry.Godot.props" />
-
+  <Import Project="addons/sentry/dotnet/Sentry.Godot.props" Condition="Exists('addons/sentry/dotnet/Sentry.Godot.props')" />
 </Project>

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -131,8 +131,23 @@ std::string_view _read_attribute_value(std::string_view p_tag, std::string_view 
 }
 
 bool _is_same_path(std::string_view p_path1, std::string_view p_path2) {
-	// TODO: Must handle different path separators.
-	return p_path1 == p_path2;
+	if (p_path1.size() != p_path2.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < p_path1.size(); ++i) {
+		const char c1 = p_path1[i];
+		const char c2 = p_path2[i];
+		if (c1 == c2) {
+			continue;
+		}
+		const bool c1_is_sep = (c1 == '/' || c1 == '\\');
+		const bool c2_is_sep = (c2 == '/' || c2 == '\\');
+		if (c1_is_sep && c2_is_sep) {
+			continue;
+		}
+		return false;
+	}
+	return true;
 }
 
 inline void _vector_append(std::vector<uint8_t> &p_vec, std::string_view p_str) {

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -145,10 +145,10 @@ namespace sentry::editor {
 
 CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path) {
 	if (p_csproj_content.empty()) {
-		return Result{ Status::ERR_CONTENT_EMPTY, {} };
+		return Result{ Status::ERROR, {}, "Csproj content is empty" };
 	}
 	if (p_import_path.empty()) {
-		return Result{ Status::ERR_INVALID_PATH, {} };
+		return Result{ Status::ERROR, {}, "Import path is empty" };
 	}
 
 	enum class State {
@@ -249,19 +249,24 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 	}
 
 	if (states.size() > 1) {
+		const char *msg;
 		switch (states.back()) {
-			case State::COMMENT:
-				return Result{ Status::ERR_UNCLOSED_COMMENT, {} };
-			case State::CDATA:
-				return Result{ Status::ERR_UNCLOSED_CDATA, {} };
+			case State::COMMENT: {
+				msg = "XML comment not closed";
+			} break;
+			case State::CDATA: {
+				msg = "XML CDATA not closed";
+			} break;
 			case State::TAG_OPEN:
 			case State::TAG_SINGLE_QUOTES:
-			case State::TAG_DOUBLE_QUOTES:
-				return Result{ Status::ERR_UNCLOSED_TAG, {} };
-			case State::NORMAL:
-				// Should not be possible since NORMAL is only pushed as first state.
-				break;
+			case State::TAG_DOUBLE_QUOTES: {
+				msg = "XML tag not closed";
+			} break;
+			default: {
+				msg = "XML parsing error";
+			} break;
 		}
+		return Result{ Status::ERROR, {}, msg };
 	}
 
 	if (import_found) {
@@ -269,7 +274,7 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 	}
 
 	if (project_closing_tag == SIZE_MAX) {
-		return Result{ Status::ERR_NO_PROJECT_TAG, {} };
+		return Result{ Status::ERROR, {}, "No <Project> tag found" };
 	}
 
 	std::vector<uint8_t> patched;

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -30,7 +30,7 @@ std::string_view _read_tag_name(std::string_view p_tag, bool &r_is_closing_tag) 
 		r_is_closing_tag = true;
 		++i;
 	}
-	size_t start = i;
+	const size_t start = i;
 	while (i < p_tag.size() && !_is_whitespace(p_tag[i]) && p_tag[i] != '/' && p_tag[i] != '>') {
 		++i;
 	}
@@ -57,7 +57,7 @@ AttributeToken _read_next_attribute_token(std::string_view p_tag, size_t &r_idx)
 	}
 
 	// Read attribute name (until '=', whitespace, or end).
-	size_t name_start = r_idx;
+	const size_t name_start = r_idx;
 	while (!_is_end_of_tag(p_tag, r_idx) && !_is_whitespace(p_tag[r_idx]) && p_tag[r_idx] != '=') {
 		++r_idx;
 	}
@@ -86,7 +86,7 @@ AttributeToken _read_next_attribute_token(std::string_view p_tag, size_t &r_idx)
 	}
 
 	++r_idx; // skip opening quote
-	size_t value_start = r_idx;
+	const size_t value_start = r_idx;
 	while (r_idx < p_tag.size() && p_tag[r_idx] != quote) {
 		++r_idx;
 	}
@@ -151,6 +151,15 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 		return Result{ Status::ERR_INVALID_PATH, {} };
 	}
 
+	enum class State {
+		NORMAL,
+		COMMENT,
+		TAG_OPEN,
+		TAG_SINGLE_QUOTES,
+		TAG_DOUBLE_QUOTES,
+		CDATA,
+	};
+
 	std::vector<State> states;
 	states.push_back(State::NORMAL);
 
@@ -199,13 +208,13 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 					states.push_back(State::TAG_DOUBLE_QUOTES);
 					++i;
 				} else if (c == '>') {
-					std::string_view tag = p_csproj_content.substr(tag_start, i + 1 - tag_start);
+					const std::string_view tag = p_csproj_content.substr(tag_start, i + 1 - tag_start);
 					bool is_closing_tag;
-					std::string_view name = _read_tag_name(tag, is_closing_tag);
+					const std::string_view name = _read_tag_name(tag, is_closing_tag);
 					if (is_closing_tag && name == "Project") {
 						project_closing_tag = tag_start;
 					} else if (!is_closing_tag && name == "Import") {
-						std::string_view attr_value = _read_attribute_value(tag, "Project");
+						const std::string_view attr_value = _read_attribute_value(tag, "Project");
 						if (!attr_value.empty() && _is_same_path(attr_value, p_import_path)) {
 							import_found = true;
 						}

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -1,0 +1,287 @@
+#include "csproj_patcher.h"
+
+#include <cstring>
+
+namespace {
+
+struct AttributeToken {
+	std::string_view key;
+	std::string_view value;
+};
+
+bool _begins_with_at(std::string_view p_str, size_t p_pos, std::string_view p_prefix) {
+	if (p_pos + p_prefix.size() > p_str.size()) {
+		return false;
+	}
+	return std::memcmp(p_str.data() + p_pos, p_prefix.data(), p_prefix.size()) == 0;
+}
+
+inline bool _is_whitespace(const char c) {
+	return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+}
+
+std::string_view _read_tag_name(std::string_view p_tag, bool &r_is_closing_tag) {
+	r_is_closing_tag = false;
+	if (p_tag.size() < 2 || p_tag[0] != '<') {
+		return {};
+	}
+	size_t i = 1;
+	if (p_tag[i] == '/') {
+		r_is_closing_tag = true;
+		++i;
+	}
+	size_t start = i;
+	while (i < p_tag.size() && !_is_whitespace(p_tag[i]) && p_tag[i] != '/' && p_tag[i] != '>') {
+		++i;
+	}
+	return p_tag.substr(start, i - start);
+}
+
+inline void _skip_whitespace(std::string_view p_tag, size_t &r_idx) {
+	while (r_idx < p_tag.size() && _is_whitespace(p_tag[r_idx])) {
+		++r_idx;
+	}
+}
+
+inline bool _is_end_of_tag(std::string_view p_tag, size_t p_idx) {
+	return p_idx >= p_tag.size() || p_tag[p_idx] == '>' || p_tag[p_idx] == '/';
+}
+
+AttributeToken _read_next_attribute_token(std::string_view p_tag, size_t &r_idx) {
+	AttributeToken token;
+
+	_skip_whitespace(p_tag, r_idx);
+
+	if (_is_end_of_tag(p_tag, r_idx)) {
+		return {};
+	}
+
+	// Read attribute name (until '=', whitespace, or end).
+	size_t name_start = r_idx;
+	while (!_is_end_of_tag(p_tag, r_idx) && !_is_whitespace(p_tag[r_idx]) && p_tag[r_idx] != '=') {
+		++r_idx;
+	}
+	token.key = p_tag.substr(name_start, r_idx - name_start);
+
+	if (token.key.empty()) {
+		return {};
+	}
+
+	_skip_whitespace(p_tag, r_idx);
+	if (_is_end_of_tag(p_tag, r_idx) || p_tag[r_idx] != '=') {
+		// Attribute without value.
+		return token;
+	}
+	++r_idx; // skip '='
+
+	_skip_whitespace(p_tag, r_idx);
+	if (_is_end_of_tag(p_tag, r_idx)) {
+		return {};
+	}
+
+	// Read quoted value.
+	const char quote = p_tag[r_idx];
+	if (quote != '"' && quote != '\'') {
+		return {};
+	}
+
+	++r_idx; // skip opening quote
+	size_t value_start = r_idx;
+	while (r_idx < p_tag.size() && p_tag[r_idx] != quote) {
+		++r_idx;
+	}
+
+	if (r_idx >= p_tag.size() || p_tag[r_idx] != quote) {
+		return {};
+	}
+
+	token.value = p_tag.substr(value_start, r_idx - value_start);
+	++r_idx; // skip closing quote
+
+	return token;
+}
+
+std::string_view _read_attribute_value(std::string_view p_tag, std::string_view p_attribute_name) {
+	if (p_tag.empty() || p_tag[0] != '<') {
+		return {};
+	}
+
+	size_t i = 1; // past '<'
+	if (i < p_tag.size() && p_tag[i] == '/') {
+		++i;
+	}
+
+	// Skip tag name
+	while (!_is_end_of_tag(p_tag, i) && !_is_whitespace(p_tag[i])) {
+		++i;
+	}
+
+	while (!_is_end_of_tag(p_tag, i)) {
+		AttributeToken token = _read_next_attribute_token(p_tag, i);
+		if (token.key.empty()) {
+			// No attributes or error.
+			break;
+		}
+		if (token.key == p_attribute_name) {
+			return token.value;
+		}
+	}
+
+	return {};
+}
+
+bool _is_same_path(std::string_view p_path1, std::string_view p_path2) {
+	// TODO: Must handle different path separators.
+	return p_path1 == p_path2;
+}
+
+inline void _vector_append(std::vector<uint8_t> &p_vec, std::string_view p_str) {
+	p_vec.insert(p_vec.end(), p_str.begin(), p_str.end());
+}
+
+} // unnamed namespace
+
+namespace sentry::editor {
+
+CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path) {
+	if (p_csproj_content.empty()) {
+		return Result{ Status::ERR_CONTENT_EMPTY, {} };
+	}
+	if (p_import_path.empty()) {
+		return Result{ Status::ERR_INVALID_PATH, {} };
+	}
+
+	std::vector<State> states;
+	states.push_back(State::NORMAL);
+
+	size_t i = 0;
+
+	const size_t content_len = p_csproj_content.size();
+	size_t tag_start = 0;
+	size_t project_closing_tag = SIZE_MAX;
+	bool import_found = false;
+
+	while (i < content_len) {
+		const char c = p_csproj_content[i];
+		switch (states.back()) {
+			case State::NORMAL: {
+				if (c == '<') {
+					if (_begins_with_at(p_csproj_content, i, "<!--")) {
+						states.push_back(State::COMMENT);
+						i += 4;
+						break;
+					}
+					if (_begins_with_at(p_csproj_content, i, "<![CDATA[")) {
+						states.push_back(State::CDATA);
+						i += 9;
+						break;
+					}
+					tag_start = i;
+					states.push_back(State::TAG_OPEN);
+					++i;
+				} else {
+					++i;
+				}
+			} break;
+			case State::COMMENT: {
+				if (_begins_with_at(p_csproj_content, i, "-->")) {
+					i += 3;
+					states.pop_back();
+				} else {
+					++i;
+				}
+			} break;
+			case State::TAG_OPEN: {
+				if (c == '\'') {
+					states.push_back(State::TAG_SINGLE_QUOTES);
+					++i;
+				} else if (c == '"') {
+					states.push_back(State::TAG_DOUBLE_QUOTES);
+					++i;
+				} else if (c == '>') {
+					std::string_view tag = p_csproj_content.substr(tag_start, i + 1 - tag_start);
+					bool is_closing_tag;
+					std::string_view name = _read_tag_name(tag, is_closing_tag);
+					if (is_closing_tag && name == "Project") {
+						project_closing_tag = tag_start;
+					} else if (!is_closing_tag && name == "Import") {
+						std::string_view attr_value = _read_attribute_value(tag, "Project");
+						if (!attr_value.empty() && _is_same_path(attr_value, p_import_path)) {
+							import_found = true;
+						}
+					}
+					states.pop_back();
+					++i;
+				} else {
+					++i;
+				}
+			} break;
+			case State::TAG_SINGLE_QUOTES: {
+				if (c == '\'') {
+					states.pop_back();
+				}
+				++i;
+			} break;
+			case State::TAG_DOUBLE_QUOTES: {
+				if (c == '"') {
+					states.pop_back();
+				}
+				++i;
+			} break;
+			case State::CDATA: {
+				if (_begins_with_at(p_csproj_content, i, "]]>")) {
+					states.pop_back();
+					i += 3;
+				} else {
+					++i;
+				}
+			} break;
+		}
+	}
+
+	if (states.size() > 1) {
+		switch (states.back()) {
+			case State::COMMENT:
+				return Result{ Status::ERR_UNCLOSED_COMMENT, {} };
+			case State::CDATA:
+				return Result{ Status::ERR_UNCLOSED_CDATA, {} };
+			case State::TAG_OPEN:
+			case State::TAG_SINGLE_QUOTES:
+			case State::TAG_DOUBLE_QUOTES:
+				return Result{ Status::ERR_UNCLOSED_TAG, {} };
+			case State::NORMAL:
+				// Should not be possible since NORMAL is only pushed as first state.
+				break;
+		}
+	}
+
+	if (import_found) {
+		return { Status::PATCH_NOT_NEEDED, {} };
+	}
+
+	if (project_closing_tag == SIZE_MAX) {
+		return Result{ Status::ERR_NO_PROJECT_TAG, {} };
+	}
+
+	std::vector<uint8_t> patched;
+	constexpr size_t import_approx_len = 64;
+	patched.reserve(content_len + import_approx_len + 2 * p_import_path.size());
+
+	const uint8_t *src = reinterpret_cast<const uint8_t *>(p_csproj_content.data());
+	patched.insert(patched.end(), src, src + project_closing_tag);
+
+	// TODO: detect whitespace
+	_vector_append(patched, "        <Import Project=\"");
+	_vector_append(patched, p_import_path);
+	_vector_append(patched, "\" Condition=\"Exists('");
+	_vector_append(patched, p_import_path);
+	_vector_append(patched, "')\" />");
+	// TODO: detect line ending
+	_vector_append(patched, "\n");
+
+	patched.insert(patched.end(), src + project_closing_tag, src + p_csproj_content.length());
+
+	return Result{ Status::PATCHED, patched };
+}
+
+} // namespace sentry::editor

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -141,7 +141,7 @@ inline void _vector_append(std::vector<uint8_t> &p_vec, std::string_view p_str) 
 
 } // unnamed namespace
 
-namespace sentry::editor {
+namespace editor {
 
 CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path) {
 	if (p_csproj_content.empty()) {
@@ -298,4 +298,4 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 	return Result{ Status::PATCHED, patched };
 }
 
-} // namespace sentry::editor
+} //namespace editor

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -139,6 +139,49 @@ inline void _vector_append(std::vector<uint8_t> &p_vec, std::string_view p_str) 
 	p_vec.insert(p_vec.end(), p_str.begin(), p_str.end());
 }
 
+std::string_view _detect_line_ending(std::string_view p_content) {
+	bool detected_return = false;
+	for (size_t i = 0; i < p_content.size(); ++i) {
+		const char c = p_content[i];
+		if (c == '\r') {
+			detected_return = true;
+		} else if (c == '\n') {
+			return detected_return ? "\r\n" : "\n";
+		} else {
+			detected_return = false;
+		}
+	}
+	return "\n";
+}
+
+std::string_view _detect_indent(std::string_view p_content, size_t p_project_closing_tag) {
+	constexpr const char *default_indent = "  ";
+	if (p_project_closing_tag == 0) {
+		return default_indent;
+	}
+
+	// Find previous line with a tag.
+	const size_t bracket_above = p_content.rfind('<', p_project_closing_tag - 1);
+	const size_t prev_nl = p_content.rfind('\n', bracket_above);
+	if (prev_nl == std::string_view::npos) {
+		return default_indent;
+	}
+	const size_t prev_line_with_tag = prev_nl + 1;
+
+	// Count indent chars.
+	size_t num_indent = 0;
+	for (size_t i = prev_line_with_tag; i < p_content.size(); ++i) {
+		const char c = p_content[i];
+		if (c == ' ' || c == '\t') {
+			++num_indent;
+		} else {
+			break;
+		}
+	}
+
+	return p_content.substr(prev_line_with_tag, num_indent);
+}
+
 } // unnamed namespace
 
 namespace editor {
@@ -284,14 +327,14 @@ CsprojPatcher::Result CsprojPatcher::ensure_import(const std::string_view p_cspr
 	const uint8_t *src = reinterpret_cast<const uint8_t *>(p_csproj_content.data());
 	patched.insert(patched.end(), src, src + project_closing_tag);
 
-	// TODO: detect whitespace
-	_vector_append(patched, "        <Import Project=\"");
+	std::string_view indent = _detect_indent(p_csproj_content, project_closing_tag);
+	_vector_append(patched, indent);
+	_vector_append(patched, "<Import Project=\"");
 	_vector_append(patched, p_import_path);
 	_vector_append(patched, "\" Condition=\"Exists('");
 	_vector_append(patched, p_import_path);
 	_vector_append(patched, "')\" />");
-	// TODO: detect line ending
-	_vector_append(patched, "\n");
+	_vector_append(patched, _detect_line_ending(p_csproj_content));
 
 	patched.insert(patched.end(), src + project_closing_tag, src + p_csproj_content.length());
 

--- a/src/editor/csproj_patcher.cpp
+++ b/src/editor/csproj_patcher.cpp
@@ -177,6 +177,9 @@ std::string_view _detect_indent(std::string_view p_content, size_t p_project_clo
 
 	// Find previous line with a tag.
 	const size_t bracket_above = p_content.rfind('<', p_project_closing_tag - 1);
+	if (bracket_above == std::string_view::npos) {
+		return default_indent;
+	}
 	const size_t prev_nl = p_content.rfind('\n', bracket_above);
 	if (prev_nl == std::string_view::npos) {
 		return default_indent;

--- a/src/editor/csproj_patcher.h
+++ b/src/editor/csproj_patcher.h
@@ -8,16 +8,6 @@ namespace sentry::editor {
 
 // Patches csproj to import a props file (e.g. Sentry.Godot.props).
 class CsprojPatcher {
-private:
-	enum class State {
-		NORMAL,
-		COMMENT,
-		TAG_OPEN,
-		TAG_SINGLE_QUOTES,
-		TAG_DOUBLE_QUOTES,
-		CDATA,
-	};
-
 public:
 	enum class Status {
 		PATCH_NOT_NEEDED,
@@ -36,6 +26,9 @@ public:
 	};
 
 public:
+	// Adds an import to the csproj content if it is not already present.
+	// p_import_path must not contain XML-special characters (&, <, >, ", ').
+	// Caller is responsible for any necessary escaping.
 	static Result ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path);
 };
 

--- a/src/editor/csproj_patcher.h
+++ b/src/editor/csproj_patcher.h
@@ -12,17 +12,13 @@ public:
 	enum class Status {
 		PATCH_NOT_NEEDED,
 		PATCHED,
-		ERR_UNCLOSED_COMMENT,
-		ERR_UNCLOSED_CDATA,
-		ERR_UNCLOSED_TAG,
-		ERR_NO_PROJECT_TAG,
-		ERR_CONTENT_EMPTY,
-		ERR_INVALID_PATH
+		ERROR
 	};
 
 	struct Result {
 		Status status;
 		std::vector<std::uint8_t> patched_content;
+		std::string_view error_message;
 	};
 
 public:

--- a/src/editor/csproj_patcher.h
+++ b/src/editor/csproj_patcher.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace sentry::editor {
+
+// Patches csproj to import a props file (e.g. Sentry.Godot.props).
+class CsprojPatcher {
+private:
+	enum class State {
+		NORMAL,
+		COMMENT,
+		TAG_OPEN,
+		TAG_SINGLE_QUOTES,
+		TAG_DOUBLE_QUOTES,
+		CDATA,
+	};
+
+public:
+	enum class Status {
+		PATCH_NOT_NEEDED,
+		PATCHED,
+		ERR_UNCLOSED_COMMENT,
+		ERR_UNCLOSED_CDATA,
+		ERR_UNCLOSED_TAG,
+		ERR_NO_PROJECT_TAG,
+		ERR_CONTENT_EMPTY,
+		ERR_INVALID_PATH
+	};
+
+	struct Result {
+		Status status;
+		std::vector<std::uint8_t> patched_content;
+	};
+
+public:
+	static Result ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path);
+};
+
+} // namespace sentry::editor

--- a/src/editor/csproj_patcher.h
+++ b/src/editor/csproj_patcher.h
@@ -6,7 +6,7 @@
 
 namespace sentry::editor {
 
-// Patches csproj to import a props file (e.g. Sentry.Godot.props).
+// Patches C# project file to import a props file (e.g. Sentry.Godot.props).
 class CsprojPatcher {
 public:
 	enum class Status {

--- a/src/editor/csproj_patcher.h
+++ b/src/editor/csproj_patcher.h
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <vector>
 
-namespace sentry::editor {
+namespace editor {
 
 // Patches C# project file to import a props file (e.g. Sentry.Godot.props).
 class CsprojPatcher {
@@ -28,4 +28,4 @@ public:
 	static Result ensure_import(const std::string_view p_csproj_content, std::string_view p_import_path);
 };
 
-} // namespace sentry::editor
+} //namespace editor

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -51,8 +51,12 @@ void _patch_csproj() {
 		f->store_buffer(result.patched_content.data(), result.patched_content.size());
 		f->close();
 
-		Error err = DirAccess::rename_absolute(temp_path, csproj_path);
-		if (err != OK) {
+		if (DirAccess::copy_absolute(csproj_path, csproj_path + ".backup") != OK) {
+			ERR_PRINT_ED("Failed to backup original C# project file. Skipped patching.");
+			return;
+		}
+
+		if (DirAccess::rename_absolute(temp_path, csproj_path) != OK) {
 			ERR_PRINT_ED("Failed to replace C# project file with patched content.");
 			DirAccess::remove_absolute(temp_path);
 		}

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -36,11 +36,11 @@ void _patch_csproj() {
 		return;
 	}
 
-	sentry::editor::CsprojPatcher::Result result = sentry::editor::CsprojPatcher::ensure_import(
+	editor::CsprojPatcher::Result result = editor::CsprojPatcher::ensure_import(
 			{ (const char *)content.ptr(), (size_t)content.size() },
 			PROPS_PATH);
 
-	if (result.status == sentry::editor::CsprojPatcher::Status::PATCHED) {
+	if (result.status == editor::CsprojPatcher::Status::PATCHED) {
 		sentry::logging::print_debug(".NET assembly detected: patching C# project file...");
 		String temp_path = csproj_path + ".tmp";
 		Ref<FileAccess> f = FileAccess::open(temp_path, FileAccess::WRITE);
@@ -60,9 +60,9 @@ void _patch_csproj() {
 			ERR_PRINT_ED("Failed to replace C# project file with patched content.");
 			DirAccess::remove_absolute(temp_path);
 		}
-	} else if (result.status == sentry::editor::CsprojPatcher::Status::ERROR) {
+	} else if (result.status == editor::CsprojPatcher::Status::ERROR) {
 		ERR_PRINT_ED("Failed to patch C# project file: " + String::utf8(result.error_message.data(), result.error_message.size()));
-	} else if (result.status == sentry::editor::CsprojPatcher::Status::PATCH_NOT_NEEDED) {
+	} else if (result.status == editor::CsprojPatcher::Status::PATCH_NOT_NEEDED) {
 		sentry::logging::print_debug(".NET assembly detected: C# project file already patched - skipped.");
 	}
 }

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -53,6 +53,7 @@ void _patch_csproj() {
 
 		if (DirAccess::copy_absolute(csproj_path, csproj_path + ".backup") != OK) {
 			ERR_PRINT_ED("Failed to backup original C# project file. Skipped patching.");
+			DirAccess::remove_absolute(temp_path);
 			return;
 		}
 

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -16,6 +16,17 @@ namespace {
 
 constexpr const char *PROPS_PATH = "addons/sentry/dotnet/Sentry.Godot.props";
 
+String _get_available_backup_path(const String &p_path) {
+	String base_path = p_path + String(".backup");
+	String backup_path = base_path;
+	int i = 1;
+	while (FileAccess::file_exists(backup_path)) {
+		backup_path = base_path + "." + String::num(i);
+		++i;
+	}
+	return backup_path;
+}
+
 void _patch_csproj() {
 	String assembly_name = ProjectSettings::get_singleton()->get_setting("dotnet/project/assembly_name");
 	if (assembly_name.is_empty()) {
@@ -51,7 +62,7 @@ void _patch_csproj() {
 		f->store_buffer(result.patched_content.data(), result.patched_content.size());
 		f->close();
 
-		if (DirAccess::copy_absolute(csproj_path, csproj_path + ".backup") != OK) {
+		if (DirAccess::copy_absolute(csproj_path, _get_available_backup_path(csproj_path)) != OK) {
 			ERR_PRINT_ED("Failed to backup original C# project file. Skipped patching.");
 			DirAccess::remove_absolute(temp_path);
 			return;

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -1,0 +1,76 @@
+#include "dotnet_tools.h"
+
+#ifdef TOOLS_ENABLED
+
+#include "editor/csproj_patcher.h"
+#include "sentry/logging/print.h"
+
+#include <godot_cpp/classes/dir_access.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+using namespace godot;
+
+namespace {
+
+constexpr const char *PROPS_PATH = "addons/sentry/dotnet/Sentry.Godot.props";
+
+void _patch_csproj() {
+	String assembly_name = ProjectSettings::get_singleton()->get_setting("dotnet/project/assembly_name");
+	if (assembly_name.is_empty()) {
+		// No .NET project here.
+		sentry::logging::print_debug(".NET assembly name not detected - skipped C# project patching.");
+		return;
+	}
+
+	String csproj_path = "res://" + assembly_name + ".csproj";
+	PackedByteArray content = FileAccess::get_file_as_bytes(csproj_path);
+	if (FileAccess::get_open_error() != OK) {
+		WARN_PRINT_ED("Failed to read C# project file - skipped patching. Try restarting Godot editor.");
+		return;
+	}
+
+	if (content.is_empty()) {
+		WARN_PRINT_ED("C# project file is empty - skipped patching. Try restarting Godot editor.");
+		return;
+	}
+
+	sentry::editor::CsprojPatcher::Result result = sentry::editor::CsprojPatcher::ensure_import(
+			{ (const char *)content.ptr(), (size_t)content.size() },
+			PROPS_PATH);
+
+	if (result.status == sentry::editor::CsprojPatcher::Status::PATCHED) {
+		sentry::logging::print_debug(".NET assembly detected: patching C# project file...");
+		String temp_path = csproj_path + ".tmp";
+		Ref<FileAccess> f = FileAccess::open(temp_path, FileAccess::WRITE);
+		if (f.is_null()) {
+			ERR_PRINT_ED("Failed to write temporary C# project file.");
+			return;
+		}
+		f->store_buffer(result.patched_content.data(), result.patched_content.size());
+		f->close();
+
+		Error err = DirAccess::rename_absolute(temp_path, csproj_path);
+		if (err != OK) {
+			ERR_PRINT_ED("Failed to replace C# project file with patched content.");
+			DirAccess::remove_absolute(temp_path);
+		}
+	} else if (result.status == sentry::editor::CsprojPatcher::Status::ERROR) {
+		ERR_PRINT_ED("Failed to patch C# project file: " + String(result.error_message.data()));
+	} else if (result.status == sentry::editor::CsprojPatcher::Status::PATCH_NOT_NEEDED) {
+		sentry::logging::print_debug(".NET assembly detected: C# project file already patched - skipped.");
+	}
+}
+
+} // unnamed namespace
+
+namespace editor {
+
+void prepare_csharp_project() {
+	_patch_csproj();
+}
+
+} //namespace editor
+
+#endif // TOOLS_ENABLED

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -36,6 +36,11 @@ void _patch_csproj() {
 	}
 
 	String csproj_path = "res://" + assembly_name + ".csproj";
+	if (!FileAccess::file_exists(csproj_path)) {
+		sentry::logging::print_debug("No C# project file found - skipped patching.");
+		return;
+	}
+
 	PackedByteArray content = FileAccess::get_file_as_bytes(csproj_path);
 	if (FileAccess::get_open_error() != OK) {
 		WARN_PRINT_ED("Failed to read C# project file - skipped patching. Try restarting Godot editor.");

--- a/src/editor/dotnet_tools.cpp
+++ b/src/editor/dotnet_tools.cpp
@@ -61,7 +61,7 @@ void _patch_csproj() {
 			DirAccess::remove_absolute(temp_path);
 		}
 	} else if (result.status == sentry::editor::CsprojPatcher::Status::ERROR) {
-		ERR_PRINT_ED("Failed to patch C# project file: " + String(result.error_message.data()));
+		ERR_PRINT_ED("Failed to patch C# project file: " + String::utf8(result.error_message.data(), result.error_message.size()));
 	} else if (result.status == sentry::editor::CsprojPatcher::Status::PATCH_NOT_NEEDED) {
 		sentry::logging::print_debug(".NET assembly detected: C# project file already patched - skipped.");
 	}

--- a/src/editor/dotnet_tools.h
+++ b/src/editor/dotnet_tools.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef TOOLS_ENABLED
+
+namespace editor {
+
+// Prepare C# project for Sentry
+void prepare_csharp_project();
+
+} //namespace editor
+
+#endif // TOOLS_ENABLED

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -33,6 +33,10 @@
 #include "sentry/javascript/javascript_sdk.h"
 #endif
 
+#ifdef TOOLS_ENABLED
+#include "editor/dotnet_tools.h"
+#endif // TOOLS_ENABLED
+
 using namespace godot;
 using namespace sentry;
 
@@ -408,6 +412,12 @@ void SentrySDK::prepare_and_auto_initialize() {
 	// Always write, even "0", because F5-play child process inherits this from the editor.
 	OS::get_singleton()->set_environment("SENTRY_GODOT_EDITOR_HINT",
 			Engine::get_singleton()->is_editor_hint() ? "1" : "0");
+
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		editor::prepare_csharp_project();
+	}
+#endif // TOOLS_ENABLED
 
 	// Create platform-specific SDK backend (replaces the default DisabledSDK).
 #ifdef SDK_NATIVE


### PR DESCRIPTION
When a .NET project is detected, the editor now patches the user's C# project file (`.csproj`) to import the SDK's `Sentry.Godot.props` automatically, so the .NET build picks up Sentry's library without requiring a manual edit. 

- Closes #653
- Tests in #675 

The patcher uses a small XML-aware scanner (just enough to find `</Project>` and existing `<Import>` siblings), inserts a conditional `<Import Project="..." Condition="Exists(...)">` before `</Project>` if not already present, and detects the file's indentation and line ending so the inserted line matches the surrounding style, backs up the original csproj, and uses an atomic temp-file rename so the file is never left half-written.