### PR TITLE
ref: Extract settings migrations and introduce versioning

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -64,3 +64,4 @@ logger/logs=143
 logger/limits/throttle_window_ms=1000
 experimental/attach_screenshot=true
 experimental/screenshot_level=1
+schema_version=1

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -1,6 +1,7 @@
 #include "sentry_options.h"
 
 #include "sentry/environment.h"
+#include "sentry/settings_migrations.h"
 #include "sentry_sdk.h" // for SentrySDK::Level variant casts
 
 #include <godot_cpp/classes/os.hpp>
@@ -34,34 +35,6 @@ void _define_setting(const godot::PropertyInfo &p_info, const godot::Variant &p_
 	Dictionary info = (Dictionary)p_info;
 	info.erase("usage"); // Fix "usage" not supported warning.
 	ProjectSettings::get_singleton()->add_property_info(info);
-}
-
-void _migrate_setting(const String &p_old_name, const String &p_new_name) {
-	if (ProjectSettings::get_singleton()->has_setting(p_old_name)) {
-		Variant value = ProjectSettings::get_singleton()->get_setting(p_old_name);
-		ProjectSettings::get_singleton()->set_setting(p_new_name, value);
-		ProjectSettings::get_singleton()->set_setting(p_old_name, Variant());
-	}
-}
-
-void _migrate_messages_as_breadcrumbs() {
-	String old_setting = "sentry/logger/messages_as_breadcrumbs";
-	String mask_setting = "sentry/logger/breadcrumbs";
-
-	if (!ProjectSettings::get_singleton()->has_setting(old_setting)) {
-		return;
-	}
-
-	bool was_enabled = ProjectSettings::get_singleton()->get_setting(old_setting);
-	int mask = ProjectSettings::get_singleton()->get_setting(mask_setting,
-			int(sentry::GodotLoggerEventMask::MASK_ALL));
-	if (was_enabled) {
-		mask |= sentry::GodotLoggerEventMask::MASK_MESSAGE;
-	} else {
-		mask &= ~sentry::GodotLoggerEventMask::MASK_MESSAGE;
-	}
-	ProjectSettings::get_singleton()->set_setting(mask_setting, mask);
-	ProjectSettings::get_singleton()->set_setting(old_setting, Variant());
 }
 
 } // unnamed namespace
@@ -117,10 +90,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	ERR_FAIL_COND(p_options.is_null());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
-	// Migrate project settings from earlier SDK versions.
-	// TODO: Fold these into a versioned migration dispatcher in a follow-up.
-	_migrate_setting("sentry/experimental/enable_logs", "sentry/options/enable_logs");
-	_migrate_messages_as_breadcrumbs();
+	sentry::run_settings_migrations();
 
 	_define_setting("sentry/options/auto_init", p_options->auto_init);
 	_define_setting("sentry/options/skip_auto_init_on_editor_play", p_options->skip_auto_init_on_editor_play);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -90,7 +90,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	ERR_FAIL_COND(p_options.is_null());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 
-	sentry::run_settings_migrations();
+	sentry::run_project_settings_migrations();
 
 	_define_setting("sentry/options/auto_init", p_options->auto_init);
 	_define_setting("sentry/options/skip_auto_init_on_editor_play", p_options->skip_auto_init_on_editor_play);

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -19,9 +19,9 @@ void _define_internal_project_setting(const String &p_name, const Variant &p_def
 }
 
 bool _has_any_persisted_sentry_settings() {
-	TypedArray<Dictionary> properties = ProjectSettings::get_singleton()->get_property_list();
+	const TypedArray<Dictionary> properties = ProjectSettings::get_singleton()->get_property_list();
 	for (int i = 0; i < properties.size(); ++i) {
-		String name = ((Dictionary)properties[i]).get("name", String());
+		const String name = ((Dictionary)properties[i]).get("name", String());
 		if (name.begins_with("sentry/")) {
 			return true;
 		}

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -72,7 +72,7 @@ namespace sentry {
 
 constexpr static int SCHEMA_VERSION = 1;
 
-void run_settings_migrations() {
+void run_project_settings_migrations() {
 	String schema_version_key = "sentry/schema_version";
 
 	bool has_version = ProjectSettings::get_singleton()->has_setting(schema_version_key);

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -73,10 +73,10 @@ namespace sentry {
 constexpr static int SCHEMA_VERSION = 1;
 
 void run_project_settings_migrations() {
-	String schema_version_key = "sentry/schema_version";
+	const String schema_version_key = "sentry/schema_version";
 
-	bool has_version = ProjectSettings::get_singleton()->has_setting(schema_version_key);
-	bool is_fresh_install = !has_version && !_has_any_persisted_sentry_settings();
+	const bool has_version = ProjectSettings::get_singleton()->has_setting(schema_version_key);
+	const bool is_fresh_install = !has_version && !_has_any_persisted_sentry_settings();
 
 	_define_internal_project_setting(schema_version_key, 0);
 
@@ -85,7 +85,7 @@ void run_project_settings_migrations() {
 		return;
 	}
 
-	int from_version = ProjectSettings::get_singleton()->get_setting(schema_version_key, 0);
+	const int from_version = ProjectSettings::get_singleton()->get_setting(schema_version_key, 0);
 
 	if (from_version > SCHEMA_VERSION) {
 		UtilityFunctions::push_warning("Sentry: Project settings are from a newer SDK version than the current version. Migration is not supported.");

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -45,16 +45,13 @@ void _rename_setting(const String &p_old_name, const String &p_new_name) {
 }
 
 void _migrate_messages_as_breadcrumbs() {
-	String old_setting = "sentry/logger/messages_as_breadcrumbs";
-	String mask_setting = "sentry/logger/breadcrumbs";
+	const String old_setting = "sentry/logger/messages_as_breadcrumbs";
+	const String mask_setting = "sentry/logger/breadcrumbs";
 
-	if (!ProjectSettings::get_singleton()->has_setting(old_setting)) {
-		return;
-	}
+	const bool was_enabled = ProjectSettings::get_singleton()->get_setting(old_setting, true);
+	int mask = ProjectSettings::get_singleton()->get_setting(
+			mask_setting, int(sentry::GodotLoggerEventMask::MASK_ALL));
 
-	bool was_enabled = ProjectSettings::get_singleton()->get_setting(old_setting);
-	int mask = ProjectSettings::get_singleton()->get_setting(mask_setting,
-			int(sentry::GodotLoggerEventMask::MASK_ALL));
 	if (was_enabled) {
 		mask |= sentry::GodotLoggerEventMask::MASK_MESSAGE;
 	} else {

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -1,0 +1,110 @@
+#include "settings_migrations.h"
+
+#include "sentry/godot_error_types.h"
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+namespace {
+
+void _define_internal_project_setting(const String &p_name, const Variant &p_default_value) {
+	if (!ProjectSettings::get_singleton()->has_setting(p_name)) {
+		ProjectSettings::get_singleton()->set_setting(p_name, p_default_value);
+	}
+	ProjectSettings::get_singleton()->set_initial_value(p_name, p_default_value);
+	ProjectSettings::get_singleton()->set_as_internal(p_name, true);
+}
+
+bool _has_any_persisted_sentry_settings() {
+	TypedArray<Dictionary> properties = ProjectSettings::get_singleton()->get_property_list();
+	for (int i = 0; i < properties.size(); ++i) {
+		String name = ((Dictionary)properties[i]).get("name", String());
+		if (name.begins_with("sentry/")) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void _set_project_setting_and_save(const String &p_key, const Variant &p_value) {
+	ProjectSettings::get_singleton()->set_setting(p_key, p_value);
+	if (Engine::get_singleton()->is_editor_hint()) {
+		ProjectSettings::get_singleton()->call_deferred("save");
+	}
+}
+
+void _rename_setting(const String &p_old_name, const String &p_new_name) {
+	if (ProjectSettings::get_singleton()->has_setting(p_old_name)) {
+		Variant value = ProjectSettings::get_singleton()->get_setting(p_old_name);
+		ProjectSettings::get_singleton()->set_setting(p_new_name, value);
+		ProjectSettings::get_singleton()->set_setting(p_old_name, Variant());
+	}
+}
+
+void _migrate_messages_as_breadcrumbs() {
+	String old_setting = "sentry/logger/messages_as_breadcrumbs";
+	String mask_setting = "sentry/logger/breadcrumbs";
+
+	if (!ProjectSettings::get_singleton()->has_setting(old_setting)) {
+		return;
+	}
+
+	bool was_enabled = ProjectSettings::get_singleton()->get_setting(old_setting);
+	int mask = ProjectSettings::get_singleton()->get_setting(mask_setting,
+			int(sentry::GodotLoggerEventMask::MASK_ALL));
+	if (was_enabled) {
+		mask |= sentry::GodotLoggerEventMask::MASK_MESSAGE;
+	} else {
+		mask &= ~sentry::GodotLoggerEventMask::MASK_MESSAGE;
+	}
+	ProjectSettings::get_singleton()->set_setting(mask_setting, mask);
+	ProjectSettings::get_singleton()->set_setting(old_setting, Variant());
+}
+
+void _migrate_to_v1() {
+	_rename_setting("sentry/experimental/enable_logs", "sentry/options/enable_logs");
+	_migrate_messages_as_breadcrumbs();
+}
+
+} // unnamed namespace
+
+namespace sentry {
+
+constexpr static int SCHEMA_VERSION = 1;
+
+void run_settings_migrations() {
+	String schema_version_key = "sentry/schema_version";
+
+	bool has_version = ProjectSettings::get_singleton()->has_setting(schema_version_key);
+	bool is_fresh_install = !has_version && !_has_any_persisted_sentry_settings();
+
+	_define_internal_project_setting(schema_version_key, 0);
+
+	if (is_fresh_install) {
+		_set_project_setting_and_save(schema_version_key, SCHEMA_VERSION);
+		return;
+	}
+
+	int from_version = ProjectSettings::get_singleton()->get_setting(schema_version_key, 0);
+
+	if (from_version > SCHEMA_VERSION) {
+		UtilityFunctions::push_warning("Sentry: Project settings are from a newer SDK version than the current version. Migration is not supported.");
+		return;
+	}
+
+	if (from_version < 1) {
+		_migrate_to_v1();
+	}
+
+	if (from_version < SCHEMA_VERSION) {
+		_set_project_setting_and_save(schema_version_key, SCHEMA_VERSION);
+		UtilityFunctions::print(
+				vformat("Sentry: Project settings migrated from schema version %d to %d.",
+						from_version, SCHEMA_VERSION));
+	}
+}
+
+} //namespace sentry

--- a/src/sentry/settings_migrations.h
+++ b/src/sentry/settings_migrations.h
@@ -2,6 +2,8 @@
 
 namespace sentry {
 
-void run_settings_migrations();
+// Runs Sentry project settings migrations, updating schema version and migrating legacy settings.
+// This function should be called before Sentry-related settings are defined (see sentry_options.cpp).
+void run_project_settings_migrations();
 
 } //namespace sentry

--- a/src/sentry/settings_migrations.h
+++ b/src/sentry/settings_migrations.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace sentry {
+
+void run_settings_migrations();
+
+} //namespace sentry


### PR DESCRIPTION
Before this PR, we had a couple of functions helping with project settings migrations. This PR extracts those functions into a separate translation unit and introduces schema versioning, so we can detect which version we are on and apply the relevant migrations.
- Follow up on #680 