### PR TITLE
test(dotnet): Add .NET integration tests for managed exception capture

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -96,9 +96,14 @@ runs:
     - name: Download export templates
       if: inputs.export-platform != ''
       shell: bash
+      env:
+        DOTNET: ${{ inputs.dotnet }}
       run: |
-        # Download Godot templates
-        archive_file=Godot_v${GODOT_VERSION}_export_templates.tpz
+        if [ "$DOTNET" = "true" ]; then
+            archive_file=Godot_v${GODOT_VERSION}_mono_export_templates.tpz
+        else
+            archive_file=Godot_v${GODOT_VERSION}_export_templates.tpz
+        fi
         url=https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}/${archive_file}
         echo "Downloading templates from: $url"
         curl -L -o templates.zip "${url}"

--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Which export template will be used, lowercase (e.g., android, ios).
     required: false
     default: ""
+  dotnet:
+    description: Set to "true" to use the Godot .NET (mono) build and build the C# project.
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -58,7 +62,22 @@ runs:
       shell: bash
       env:
         ARCH: ${{ inputs.arch }}
-      run: ./scripts/setup-godot.sh --arch "$ARCH"
+        MONO_FLAG: ${{ inputs.dotnet == 'true' && '--mono' || '' }}
+      run: ./scripts/setup-godot.sh --arch "$ARCH" "$MONO_FLAG"
+
+    - name: Set up .NET
+      if: inputs.dotnet == 'true'
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Build C# demo project
+      if: inputs.dotnet == 'true'
+      shell: bash
+      env:
+        DOTNET_NOLOGO: true
+        DOTNET_CLI_TELEMETRY_OPTOUT: true
+      run: dotnet build "project/Sentry demo project.csproj"
 
     - name: Diagnostic info
       shell: bash

--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -71,14 +71,6 @@ runs:
       with:
         dotnet-version: 8.0.x
 
-    - name: Build C# demo project
-      if: inputs.dotnet == 'true'
-      shell: bash
-      env:
-        DOTNET_NOLOGO: true
-        DOTNET_CLI_TELEMETRY_OPTOUT: true
-      run: dotnet build "project/Sentry demo project.csproj"
-
     - name: Diagnostic info
       shell: bash
       run: |

--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: ""
   dotnet:
-    description: Set to "true" to use the Godot .NET (mono) build and build the C# project.
+    description: Set to "true" to install the .NET SDK and use the Godot mono build.
     required: false
     default: "false"
 

--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -63,7 +63,7 @@ runs:
       env:
         ARCH: ${{ inputs.arch }}
         MONO_FLAG: ${{ inputs.dotnet == 'true' && '--mono' || '' }}
-      run: ./scripts/setup-godot.sh --arch "$ARCH" "$MONO_FLAG"
+      run: ./scripts/setup-godot.sh --arch "$ARCH" $MONO_FLAG
 
     - name: Set up .NET
       if: inputs.dotnet == 'true'

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -93,6 +93,24 @@ jobs:
             dotnet: true
             test-script: tests/integration/Integration.Dotnet.Tests.ps1
 
+          - test-platform: AndroidSauceLabs
+            runner: ubuntu-latest
+            godot-arch: x86_64
+            dotnet: true
+            test-executable: ./exports/android.apk
+            export-platform: android
+            saucelabs-device: Samsung_Galaxy_S25_16_real_sjc1
+            test-script: tests/integration/Integration.Dotnet.Tests.ps1
+
+          - test-platform: iOSSauceLabs
+            runner: macos-latest
+            godot-arch: universal
+            dotnet: true
+            test-executable: ./exports/ios/ios.ipa
+            export-platform: ios
+            saucelabs-device: iPhone_17_Pro_real_sjc1
+            test-script: tests/integration/Integration.Dotnet.Tests.ps1
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   integration-tests:
-    name: Test ${{matrix.test-platform}} ${{matrix.godot-arch}}${{matrix.dotnet && ' (dotnet)' || ''}}
+    name: Test ${{matrix.test-platform}} ${{matrix.godot-arch}}${{matrix.dotnet && ' .NET' || ''}}
     runs-on: ${{matrix.runner}}
     strategy:
       fail-fast: false

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   integration-tests:
-    name: Test ${{matrix.test-platform}} ${{matrix.godot-arch}}
+    name: Test ${{matrix.test-platform}} ${{matrix.godot-arch}}${{matrix.dotnet && ' (dotnet)' || ''}}
     runs-on: ${{matrix.runner}}
     strategy:
       fail-fast: false
@@ -75,6 +75,24 @@ jobs:
             test-executable: ./exports/web
             export-platform: web
 
+          - test-platform: Linux
+            runner: ubuntu-latest
+            godot-arch: x86_64
+            dotnet: true
+            test-script: tests/integration/Integration.Dotnet.Tests.ps1
+
+          - test-platform: Windows
+            runner: windows-latest
+            godot-arch: x86_64
+            dotnet: true
+            test-script: tests/integration/Integration.Dotnet.Tests.ps1
+
+          - test-platform: macOS
+            runner: macos-latest
+            godot-arch: universal
+            dotnet: true
+            test-script: tests/integration/Integration.Dotnet.Tests.ps1
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -87,6 +105,7 @@ jobs:
         with:
           arch: ${{ matrix.godot-arch }}
           export-platform: ${{ matrix.export-platform }}
+          dotnet: ${{ matrix.dotnet || 'false' }}
 
       - name: "Android: Export project"
         if: matrix.export-platform == 'android'
@@ -162,4 +181,5 @@ jobs:
           SAUCE_REGION: us-west-1
           SAUCE_DEVICE_NAME: ${{ matrix.saucelabs-device }}
           SAUCE_SESSION_NAME: Godot ${{matrix.test-platform}} E2E Tests
-        run: Invoke-Pester -Script tests/integration/Integration.Tests.ps1
+          TEST_SCRIPT: ${{ matrix.test-script || 'tests/integration/Integration.Tests.ps1' }}
+        run: Invoke-Pester -Script "$env:TEST_SCRIPT"

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -126,7 +126,7 @@ jobs:
           dotnet: ${{ matrix.dotnet || 'false' }}
 
       - name: "Dotnet: Build project"
-        if: matrix.dotnet == 'true'
+        if: matrix.dotnet
         shell: bash
         env:
           DOTNET_NOLOGO: true

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -125,6 +125,14 @@ jobs:
           export-platform: ${{ matrix.export-platform }}
           dotnet: ${{ matrix.dotnet || 'false' }}
 
+      - name: "Dotnet: Build project"
+        if: matrix.dotnet == 'true'
+        shell: bash
+        env:
+          DOTNET_NOLOGO: true
+          DOTNET_CLI_TELEMETRY_OPTOUT: true
+        run: dotnet build "project/Sentry demo project.csproj"
+
       - name: "Android: Export project"
         if: matrix.export-platform == 'android'
         timeout-minutes: 10

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
@@ -12,8 +12,22 @@ internal sealed class GodotSdkIntegration : ISdkIntegration
         {
             scope.Sdk.Name = "sentry.dotnet.godot";
             scope.Sdk.Version = NativeBridge.GetSdkVersion();
-            scope.Contexts.App.Name = NativeBridge.GetAppName();
-            scope.Contexts.App.Version = NativeBridge.GetAppVersion();
+            if (scope.Contexts.App.Name is null)
+            {
+                string appName = NativeBridge.GetAppName();
+                if (appName.Length > 0)
+                {
+                    scope.Contexts.App.Name = appName;
+                }
+            }
+            if (scope.Contexts.App.Version is null)
+            {
+                string appVersion = NativeBridge.GetAppVersion();
+                if (appVersion.Length > 0)
+                {
+                    scope.Contexts.App.Version = appVersion;
+                }
+            }
         });
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
@@ -12,6 +12,8 @@ internal sealed class GodotSdkIntegration : ISdkIntegration
         {
             scope.Sdk.Name = "sentry.dotnet.godot";
             scope.Sdk.Version = NativeBridge.GetSdkVersion();
+            scope.Contexts.App.Name = NativeBridge.GetAppName();
+            scope.Contexts.App.Version = NativeBridge.GetAppVersion();
         });
     }
 }

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -66,11 +66,11 @@ public partial class DotnetCliTriggers : RefCounted
         GD.Print("Triggering wrapped rethrow...");
         try
         {
-            throw new Exception("Inner (should NOT be captured)");
+            throw new Exception("Inner exception");
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException("Wrapped (should be captured)", ex);
+            throw new InvalidOperationException("Wrapped exception", ex);
         }
     }
 }

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -1,0 +1,76 @@
+using Godot;
+using System;
+
+/// <summary>
+/// Helpers used by GDScript CLI commands to drive .NET integration tests.
+/// </summary>
+public partial class DotnetCliTriggers : RefCounted
+{
+    public void InitSentryFromDotnet()
+    {
+        Sentry.Godot.SentrySdk.Init(options =>
+        {
+            options.Debug = false;
+            options.Release = "test-app@1.0.0";
+            options.Environment = "integration-test";
+            options.Distribution = "test-dist";
+        });
+    }
+
+    public void AddIntegrationTestContext(string testType)
+    {
+        Sentry.Godot.SentrySdk.AddBreadcrumb("Integration test started");
+
+        Sentry.Godot.SentrySdk.ConfigureScope(scope =>
+        {
+            scope.User = new global::Sentry.SentryUser
+            {
+                Id = "12345",
+                Username = "TestUser",
+                Email = "user-mail@test.abc",
+            };
+        });
+
+        Sentry.Godot.SentrySdk.SetTag("test.suite", "integration");
+        Sentry.Godot.SentrySdk.SetTag("test.type", testType);
+
+        Sentry.Godot.SentrySdk.AddBreadcrumb("Context configuration finished");
+    }
+
+    public string GetLastEventId()
+    {
+        return Sentry.Godot.SentrySdk.LastEventId.ToString();
+    }
+
+    public void TriggerException()
+    {
+        GD.Print("Triggering exception...");
+        throw new Exception("Exception (should be captured)");
+    }
+
+    public void TriggerBareRethrow()
+    {
+        GD.Print("Triggering bare rethrow...");
+        try
+        {
+            throw new Exception("Bare rethrow (should be captured)");
+        }
+        catch
+        {
+            throw;
+        }
+    }
+
+    public void TriggerWrappedRethrow()
+    {
+        GD.Print("Triggering wrapped rethrow...");
+        try
+        {
+            throw new Exception("Inner (should NOT be captured)");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Wrapped (should be captured)", ex);
+        }
+    }
+}

--- a/project/cli/DotnetCliTriggers.cs.uid
+++ b/project/cli/DotnetCliTriggers.cs.uid
@@ -1,0 +1,1 @@
+uid://r5m4sim3bcvl

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -40,6 +40,7 @@ func _register_commands() -> void:
 	_parser.add_command("log-capture", _cmd_log_capture, "Capture a structured log to Sentry")
 	_parser.add_command("metric-capture", _cmd_metric_capture, "Capture metrics to Sentry")
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
+	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
 
 
 ## Shows available commands and their arguments.
@@ -230,6 +231,43 @@ func _before_send_metric(metric: SentryMetric) -> SentryMetric:
 	metric.set_attribute("handler_added", "added_value")
 	metric.remove_attribute("deleted_metric_attribute")
 	return metric
+
+
+func _cmd_dotnet_exception_capture(p_scenario: String) -> int:
+	var trigger_method: StringName
+	match p_scenario:
+		"plain":
+			trigger_method = "TriggerException"
+		"bare-rethrow":
+			trigger_method = "TriggerBareRethrow"
+		"wrapped-rethrow":
+			trigger_method = "TriggerWrappedRethrow"
+		_:
+			printerr("Error: Unknown scenario \"%s\". Valid: plain, bare-rethrow, wrapped-rethrow" % p_scenario)
+			return 1
+	return await _run_dotnet_trigger("dotnet-exception-capture-" + p_scenario, trigger_method)
+
+
+## Runs a .NET exception trigger via Scenario C init.
+func _run_dotnet_trigger(p_test_type: String, p_trigger_method: StringName) -> int:
+	var script: Script = load("res://cli/DotnetCliTriggers.cs")
+	if script == null:
+		printerr("Error: DotnetCliTriggers.cs is not available - is this a Godot .NET build?")
+		return 1
+
+	var triggers: Object = script.new()
+	triggers.InitSentryFromDotnet()
+	triggers.AddIntegrationTestContext(p_test_type)
+
+	await get_tree().create_timer(0.5).timeout
+
+	# Bridge catches synchronously; LastEventId is set before this returns.
+	triggers.call(p_trigger_method)
+
+	var event_id: String = triggers.GetLastEventId()
+	print("EVENT_CAPTURED: ", event_id)
+	_print_test_result(p_test_type, true, "Test complete")
+	return 0
 
 
 func _cmd_run_tests(tests: String = "res://test/suites/") -> int:

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -12,6 +12,8 @@ extends Node
 ## Use "godot --headless --path ./project -- help" to list available commands.
 
 
+enum DotnetInitDriver { GDSCRIPT, DOTNET }
+
 var exit_code: int
 
 var _parser := CLIParser.new()
@@ -41,6 +43,7 @@ func _register_commands() -> void:
 	_parser.add_command("metric-capture", _cmd_metric_capture, "Capture metrics to Sentry")
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
+	_parser.add_command("dotnet-capture-via-gdscript-init", _cmd_dotnet_capture_via_gdscript_init, "Capture a .NET exception with GDScript driving init")
 
 
 ## Shows available commands and their arguments.
@@ -245,18 +248,28 @@ func _cmd_dotnet_exception_capture(p_scenario: String) -> int:
 		_:
 			printerr("Error: Unknown scenario \"%s\". Valid: plain, bare-rethrow, wrapped-rethrow" % p_scenario)
 			return 1
-	return await _run_dotnet_trigger("dotnet-exception-capture-" + p_scenario, trigger_method)
+	return await _run_dotnet_trigger("dotnet-exception-capture-" + p_scenario, trigger_method, DotnetInitDriver.DOTNET)
 
 
-## Runs a .NET exception trigger via Scenario C init.
-func _run_dotnet_trigger(p_test_type: String, p_trigger_method: StringName) -> int:
+func _cmd_dotnet_capture_via_gdscript_init() -> int:
+	return await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
+
+
+## Runs a .NET exception trigger with the chosen init driver.
+func _run_dotnet_trigger(p_test_type: String, p_trigger_method: StringName, p_init_driver: DotnetInitDriver) -> int:
 	var script: Script = load("res://cli/DotnetCliTriggers.cs")
 	if script == null:
 		printerr("Error: DotnetCliTriggers.cs is not available - is this a Godot .NET build?")
 		return 1
 
 	var triggers: Object = script.new()
-	triggers.InitSentryFromDotnet()
+	match p_init_driver:
+		DotnetInitDriver.GDSCRIPT:
+			# GDScript inits native; .NET auto-inits via InitFromNative().
+			await _init_sentry()
+		DotnetInitDriver.DOTNET:
+			triggers.InitSentryFromDotnet()
+
 	triggers.AddIntegrationTestContext(p_test_type)
 
 	await get_tree().create_timer(0.5).timeout

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -274,8 +274,12 @@ func _run_dotnet_trigger(p_test_type: String, p_trigger_method: StringName, p_in
 
 	await get_tree().create_timer(0.5).timeout
 
-	# Bridge catches synchronously; LastEventId is set before this returns.
 	triggers.call(p_trigger_method)
+
+	# Give CoreClrExceptionHandler time to capture on its background thread.
+	# Currently unexercised (this suite only runs LoggerExceptionHandler), but
+	# kept so the test stays correct if that changes.
+	await get_tree().create_timer(0.5).timeout
 
 	var event_id: String = triggers.GetLastEventId()
 	print("EVENT_CAPTURED: ", event_id)

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -74,7 +74,9 @@ $CommonTestCases = @(
     @{ Name = "Has correct OS tag"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
             if ($TestSetup.Platform -ieq "Linux") {
-                $expectedOS = "Linux|SteamOS|Bazzite"
+                # Sentry .NET reports the distro name on Linux (e.g. "Ubuntu")
+                # while the native SDK uses the kernel name ("Linux").
+                $expectedOS = "Linux|SteamOS|Bazzite|Ubuntu"
             } elseif ($TestSetup.Platform -ieq "macOS") {
                 $expectedOS = "macOS"
             } elseif ($TestSetup.Platform -ieq "Windows") {

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -75,16 +75,15 @@ $CommonTestCases = @(
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
 
             if ($TestSetup.IsDotnet -and $TestSetup.Platform -ieq "Linux") {
-                # TODO: On Linux .NET-captured events the os tag is absent
-                # on some distros (only contexts.os.raw_description is
-                # reliably populated). Investigate upstream.
+                # TODO: On Linux .NET-captured events the os tag is absent on some distros
+                # (only contexts.os.raw_description is reliably populated).
                 # See: https://github.com/getsentry/sentry-godot/issues/687
                 return
             }
 
             if ($TestSetup.IsDotnet -and ($TestSetup.IsAndroid -or $TestSetup.Platform -match "iOS")) {
-                # TODO: On mobile, .NET-captured events report the underlying
-                # kernel ("Linux"/"Darwin") instead of the mobile OS.
+                # TODO: On mobile, .NET-captured events report the underlying kernel ("Linux"/"Darwin")
+                # instead of the mobile OS.
                 # See: https://github.com/getsentry/sentry-godot/issues/688
                 return
             }
@@ -158,21 +157,17 @@ $CommonTestCases = @(
             $SentryEvent.contexts.os | Should -Not -BeNullOrEmpty
 
             if ($TestSetup.IsDotnet -and $TestSetup.Platform -ieq "Linux") {
-                # TODO: On Linux .NET-captured events only
-                # contexts.os.raw_description is reliably populated;
-                # os.os/os.name/os.version are absent on some distros and
-                # os.kernel_version holds the distro version (e.g.
-                # "24.04.4") rather than the kernel version. Investigate
-                # upstream.
+                # TODO: On Linux .NET-captured events only contexts.os.raw_description is reliably populated;
+                # os.os/os.name/os.version are absent on some distros and os.kernel_version holds the distro version
+                # (e.g. "24.04.4") rather than the kernel version.
                 # See: https://github.com/getsentry/sentry-godot/issues/687
                 $SentryEvent.contexts.os.raw_description | Should -Not -BeNullOrEmpty
                 return
             }
 
             if ($TestSetup.IsDotnet -and ($TestSetup.IsAndroid -or $TestSetup.Platform -match "iOS")) {
-                # TODO: On mobile, .NET-captured events report the underlying
-                # kernel in contexts.os.{os,name,version} instead of the
-                # mobile OS. raw_description is still populated.
+                # TODO: On mobile, .NET-captured events report the underlying kernel in contexts.os.{os,name,version}
+                # instead of the mobile OS. raw_description is still populated.
                 # See: https://github.com/getsentry/sentry-godot/issues/688
                 $SentryEvent.contexts.os.raw_description | Should -Not -BeNullOrEmpty
                 return
@@ -193,9 +188,9 @@ $CommonTestCases = @(
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
 
             if ($TestSetup.IsDotnet) {
-                # TODO: Sync godot_engine and godot_performance contexts from the
-                # native layer to .NET-captured events. Re-enable this assertion once
-                # the cross-layer context sync lands.
+                # TODO: Sync godot_engine and godot_performance contexts from the native layer to .NET-captured events.
+                # Re-enable this assertion once the cross-layer context sync lands.
+                # See: https://github.com/getsentry/sentry-godot/issues/650
                 return
             }
 

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -73,10 +73,16 @@ $CommonTestCases = @(
     }
     @{ Name = "Has correct OS tag"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
+
+            if ($TestSetup.IsDotnet -and $TestSetup.Platform -ieq "Linux") {
+                # TODO: On Linux .NET-captured events the os tag is absent
+                # on some distros (only contexts.os.raw_description is
+                # reliably populated). Investigate upstream.
+                return
+            }
+
             if ($TestSetup.Platform -ieq "Linux") {
-                # Sentry .NET reports the distro name on Linux (e.g. "Ubuntu")
-                # while the native SDK uses the kernel name ("Linux").
-                $expectedOS = "Linux|SteamOS|Bazzite|Ubuntu"
+                $expectedOS = "Linux|SteamOS|Bazzite"
             } elseif ($TestSetup.Platform -ieq "macOS") {
                 $expectedOS = "macOS"
             } elseif ($TestSetup.Platform -ieq "Windows") {
@@ -142,18 +148,26 @@ $CommonTestCases = @(
     @{ Name = "Contains OS context"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
             $SentryEvent.contexts.os | Should -Not -BeNullOrEmpty
+
+            if ($TestSetup.IsDotnet -and $TestSetup.Platform -ieq "Linux") {
+                # TODO: On Linux .NET-captured events only
+                # contexts.os.raw_description is reliably populated;
+                # os.os/os.name/os.version are absent on some distros and
+                # os.kernel_version holds the distro version (e.g.
+                # "24.04.4") rather than the kernel version. Investigate
+                # upstream.
+                $SentryEvent.contexts.os.raw_description | Should -Not -BeNullOrEmpty
+                return
+            }
+
             $SentryEvent.contexts.os.os | Should -Not -BeNullOrEmpty
             $SentryEvent.contexts.os.name | Should -Not -BeNullOrEmpty
+
             if ($TestSetup.IsWeb) {
                 # On Web, OS version may not be available.
                 return
             }
-            if ($TestSetup.IsDotnet) {
-                # TODO: On Linux .NET-captured events, os.version is null and
-                # os.kernel_version holds the distro version (e.g. "24.04.4")
-                # rather than the actual kernel version. Investigate upstream.
-                return
-            }
+
             $SentryEvent.contexts.os.version | Should -Not -BeNullOrEmpty
         }
     }

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -144,10 +144,17 @@ $CommonTestCases = @(
             $SentryEvent.contexts.os | Should -Not -BeNullOrEmpty
             $SentryEvent.contexts.os.os | Should -Not -BeNullOrEmpty
             $SentryEvent.contexts.os.name | Should -Not -BeNullOrEmpty
-            if (-not $TestSetup.IsWeb) {
+            if ($TestSetup.IsWeb) {
                 # On Web, OS version may not be available.
-                $SentryEvent.contexts.os.version | Should -Not -BeNullOrEmpty
+                return
             }
+            if ($TestSetup.IsDotnet) {
+                # TODO: On Linux .NET-captured events, os.version is null and
+                # os.kernel_version holds the distro version (e.g. "24.04.4")
+                # rather than the actual kernel version. Investigate upstream.
+                return
+            }
+            $SentryEvent.contexts.os.version | Should -Not -BeNullOrEmpty
         }
     }
     @{ Name = "Contains Godot contexts"; TestBlock = {

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -33,6 +33,11 @@ $CommonTestCases = @(
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
             $SentryEvent.platform | Should -Not -BeNullOrEmpty
 
+            if ($TestSetup.IsDotnet) {
+                $SentryEvent.platform | Should -Be "csharp"
+                return
+            }
+
             $expectedPlatform = @{
                 "Windows" = "native"
                 "Linux" = "native"
@@ -145,6 +150,13 @@ $CommonTestCases = @(
     }
     @{ Name = "Contains Godot contexts"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
+
+            if ($TestSetup.IsDotnet) {
+                # TODO: Sync godot_engine and godot_performance contexts from the
+                # native layer to .NET-captured events. Re-enable this assertion once
+                # the cross-layer context sync lands.
+                return
+            }
 
             if ($TestSetup.IsAndroid -and $TestType -eq "crash-capture") {
                 # Skip Godot context tests for Android crashes

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -78,6 +78,14 @@ $CommonTestCases = @(
                 # TODO: On Linux .NET-captured events the os tag is absent
                 # on some distros (only contexts.os.raw_description is
                 # reliably populated). Investigate upstream.
+                # See: https://github.com/getsentry/sentry-godot/issues/687
+                return
+            }
+
+            if ($TestSetup.IsDotnet -and ($TestSetup.IsAndroid -or $TestSetup.Platform -match "iOS")) {
+                # TODO: On mobile, .NET-captured events report the underlying
+                # kernel ("Linux"/"Darwin") instead of the mobile OS.
+                # See: https://github.com/getsentry/sentry-godot/issues/688
                 return
             }
 
@@ -156,6 +164,16 @@ $CommonTestCases = @(
                 # os.kernel_version holds the distro version (e.g.
                 # "24.04.4") rather than the kernel version. Investigate
                 # upstream.
+                # See: https://github.com/getsentry/sentry-godot/issues/687
+                $SentryEvent.contexts.os.raw_description | Should -Not -BeNullOrEmpty
+                return
+            }
+
+            if ($TestSetup.IsDotnet -and ($TestSetup.IsAndroid -or $TestSetup.Platform -match "iOS")) {
+                # TODO: On mobile, .NET-captured events report the underlying
+                # kernel in contexts.os.{os,name,version} instead of the
+                # mobile OS. raw_description is still populated.
+                # See: https://github.com/getsentry/sentry-godot/issues/688
                 $SentryEvent.contexts.os.raw_description | Should -Not -BeNullOrEmpty
                 return
             }

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -1,0 +1,240 @@
+#!/usr/bin/env pwsh
+#
+# .NET integration tests for Sentry Godot SDK
+#
+# Environment variables:
+#   SENTRY_TEST_EXECUTABLE: command line to run the project
+#   SENTRY_TEST_ARGS: arguments
+#   SENTRY_TEST_DSN: test DSN
+#   SENTRY_AUTH_TOKEN: authentication token for Sentry API
+#   SENTRY_TEST_PLATFORM: test platform (aka device provider) such as "Local"
+#   GODOT_DOTNET: path to a Godot mono binary, used when SENTRY_TEST_EXECUTABLE is unset
+
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+$global:DebugPreference = "Continue"
+
+. $PSScriptRoot/../../modules/app-runner/import-modules.ps1
+. $PSScriptRoot/CommonTestCases.ps1
+. $PSScriptRoot/Utils.ps1
+
+BeforeAll {
+    function Invoke-TestAction {
+        param (
+            [Parameter(Mandatory=$true)]
+            [string]$Action,
+            [string[]]$AdditionalArgs = @()
+        )
+
+        Write-Host "Running $Action..."
+
+        $args = $script:TestSetup.Args + @($Action) + $AdditionalArgs
+        $execPath = $script:TestSetup.Executable
+
+        $runResult = Invoke-DeviceApp -ExecutablePath $execPath -Arguments $args
+
+        $runResult | ConvertTo-Json -Depth 5 | Out-File -FilePath (Get-OutputFilePath "${Action}-result.json")
+
+        return $runResult
+    }
+
+    New-Item -ItemType Directory -Path "$PSScriptRoot/results/" -ErrorAction Continue 2>&1 | Out-Null
+    Set-OutputDir -Path "$PSScriptRoot/results/"
+
+    $script:TestSetup = [PSCustomObject]@{
+        Executable = $env:SENTRY_TEST_EXECUTABLE
+        Args = @()
+        Dsn = $env:SENTRY_TEST_DSN
+        AuthToken = $env:SENTRY_AUTH_TOKEN
+        Platform = $env:SENTRY_TEST_PLATFORM
+        IsAndroid = $false
+        IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or
+            (($env:SENTRY_TEST_PLATFORM -ieq "Local" -or [string]::IsNullOrEmpty($env:SENTRY_TEST_PLATFORM)) -and $IsMacOS))
+        IsWeb = $false
+        IsDotnet = $true
+    }
+
+    if ([string]::IsNullOrEmpty($script:TestSetup.Executable)) {
+        if (-not [string]::IsNullOrEmpty($env:GODOT_DOTNET)) {
+            Write-Warning "SENTRY_TEST_EXECUTABLE environment variable is not set. Defaulting to env:GODOT_DOTNET."
+            $script:TestSetup.Executable = $env:GODOT_DOTNET
+        } else {
+            Write-Warning "SENTRY_TEST_EXECUTABLE and GODOT_DOTNET environment variables are not set. Defaulting to env:GODOT."
+            $script:TestSetup.Executable = $env:GODOT
+        }
+        $script:TestSetup.Args += @("--disable-crash-handler", "--headless", "--path", "project", "--")
+    } else {
+        $script:TestSetup.Args += @("--")
+    }
+    if (-not (Test-Path $script:TestSetup.Executable)) {
+        throw "Executable not found at: $($script:TestSetup.Executable)"
+    }
+
+    if ([string]::IsNullOrEmpty($script:TestSetup.Dsn)) {
+        $projectGodotPath = Join-Path $PSScriptRoot "../../project/project.godot"
+        if (Test-Path $projectGodotPath) {
+            Write-Warning "SENTRY_TEST_DSN environment variable is not set. Reading DSN from project.godot..."
+            $projectContent = Get-Content $projectGodotPath -Raw
+            if ($projectContent -match 'options/dsn="([^"]+)"') {
+                $script:TestSetup.Dsn = $matches[1]
+            } else {
+                throw "Could not find DSN in project.godot file"
+            }
+        } else {
+            throw "Could not find project.godot file at $projectGodotPath"
+        }
+    }
+
+    if ([string]::IsNullOrEmpty($script:TestSetup.AuthToken)) {
+        throw "SENTRY_AUTH_TOKEN environment variable is not set."
+    }
+
+    if ([string]::IsNullOrEmpty($script:TestSetup.Platform)) {
+        Write-Warning "SENTRY_TEST_PLATFORM environment variable is not set. Defaulting to 'Local'."
+        $script:TestSetup.Platform = "Local"
+    }
+
+    Connect-SentryApi `
+        -ApiToken $script:TestSetup.AuthToken `
+        -DSN $script:TestSetup.Dsn
+}
+
+
+AfterAll {
+    Disconnect-SentryApi
+}
+
+
+Describe ".NET Integration Tests" {
+    BeforeAll {
+        try {
+            Connect-Device -Platform $script:TestSetup.Platform
+            Install-DeviceApp -Path $script:TestSetup.Executable
+
+            $script:exceptionRunResult      = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("plain")
+            $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")
+            $script:wrappedRethrowRunResult = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("wrapped-rethrow")
+        }
+        finally {
+            Disconnect-Device
+        }
+    }
+
+    Context "Plain Exception" {
+        BeforeAll {
+            $runResult = $script:exceptionRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-plain" -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "Exits with code zero" {
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Has correct exception type" {
+            $runEvent.exception.values[0].type | Should -Be "System.Exception"
+        }
+
+        It "Has correct exception value" {
+            $runEvent.exception.values[0].value | Should -Be "Exception (should be captured)"
+        }
+
+        It "Has Godot.Bridge mechanism" {
+            $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
+            $runEvent.exception.values[0].mechanism.handled | Should -Be $false
+        }
+
+        It "Has stacktrace frames" {
+            $runEvent.exception.values[0].stacktrace.frames | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "Bare Rethrow" {
+        BeforeAll {
+            $runResult = $script:bareRethrowRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-bare-rethrow" -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "Exits with code zero" {
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Has correct exception type" {
+            $runEvent.exception.values[0].type | Should -Be "System.Exception"
+        }
+
+        It "Has correct exception value" {
+            $runEvent.exception.values[0].value | Should -Be "Bare rethrow (should be captured)"
+        }
+
+        It "Has Godot.Bridge mechanism" {
+            $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
+            $runEvent.exception.values[0].mechanism.handled | Should -Be $false
+        }
+    }
+
+    Context "Wrapped Rethrow" {
+        BeforeAll {
+            $runResult = $script:wrappedRethrowRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-wrapped-rethrow" -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "Exits with code zero" {
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Has wrapper as the outermost captured exception" {
+            # exception.values is innermost-first per Sentry's protocol; the
+            # wrapper is the outermost throw, so it lands last.
+            $values = $runEvent.exception.values
+            $values | Should -Not -BeNullOrEmpty
+            $outermost = $values[$values.Count - 1]
+            $outermost.type | Should -Be "System.InvalidOperationException"
+            $outermost.value | Should -Be "Wrapped (should be captured)"
+        }
+
+        It "Includes the inner exception in the chain" {
+            $values = $runEvent.exception.values
+            $values.Count | Should -BeGreaterOrEqual 2
+            $inner = $values[0]
+            $inner.type | Should -Be "System.Exception"
+            $inner.value | Should -Be "Inner (should NOT be captured)"
+        }
+
+        It "Has Godot.Bridge mechanism on outermost exception" {
+            $values = $runEvent.exception.values
+            $outermost = $values[$values.Count - 1]
+            $outermost.mechanism.type | Should -Be "Godot.Bridge"
+            $outermost.mechanism.handled | Should -Be $false
+        }
+    }
+}

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -31,7 +31,15 @@ BeforeAll {
         $args = $script:TestSetup.Args + @($Action) + $AdditionalArgs
         $execPath = $script:TestSetup.Executable
 
-        $runResult = Invoke-DeviceApp -ExecutablePath $execPath -Arguments $args
+        if ($script:TestSetup.IsAndroid) {
+            $args = ConvertTo-AndroidExtras -Arguments $args
+            $execPath = $script:TestSetup.AndroidComponent
+        } elseif ($script:TestSetup.Platform -match "iOS") {
+            $execPath = $script:TestSetup.iOSBundleId
+        }
+
+        $logFilePath = if ($script:TestSetup.Platform -eq "iOSSauceLabs") { $script:TestSetup.iOSApplicationLogFile } else { $null }
+        $runResult = Invoke-DeviceApp -ExecutablePath $execPath -Arguments $args -LogFilePath $logFilePath
 
         $runResult | ConvertTo-Json -Depth 5 | Out-File -FilePath (Get-OutputFilePath "${Action}-result.json")
 
@@ -47,11 +55,14 @@ BeforeAll {
         Dsn = $env:SENTRY_TEST_DSN
         AuthToken = $env:SENTRY_AUTH_TOKEN
         Platform = $env:SENTRY_TEST_PLATFORM
-        IsAndroid = $false
-        IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or
+        AndroidComponent = "io.sentry.godot.project/com.godot.game.GodotApp"
+        IsAndroid = ($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs"))
+        IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or $env:SENTRY_TEST_PLATFORM -match "iOS" -or
             (($env:SENTRY_TEST_PLATFORM -ieq "Local" -or [string]::IsNullOrEmpty($env:SENTRY_TEST_PLATFORM)) -and $IsMacOS))
         IsWeb = $false
         IsDotnet = $true
+        iOSBundleId = "io.sentry.SentryGodotProject"
+        iOSApplicationLogFile = "@io.sentry.SentryGodotProject:documents/logs/godot.log"
     }
 
     if ([string]::IsNullOrEmpty($script:TestSetup.Executable)) {
@@ -138,6 +149,10 @@ Describe ".NET Integration Tests" {
         }
 
         It "Exits with code zero" {
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
             $runResult.ExitCode | Should -Be 0
         }
 
@@ -176,6 +191,10 @@ Describe ".NET Integration Tests" {
         }
 
         It "Exits with code zero" {
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
             $runResult.ExitCode | Should -Be 0
         }
 
@@ -210,6 +229,10 @@ Describe ".NET Integration Tests" {
         }
 
         It "Exits with code zero" {
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
             $runResult.ExitCode | Should -Be 0
         }
 
@@ -256,6 +279,10 @@ Describe ".NET Integration Tests" {
         }
 
         It "Exits with code zero" {
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
             $runResult.ExitCode | Should -Be 0
         }
 

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -114,6 +114,7 @@ Describe ".NET Integration Tests" {
             $script:exceptionRunResult      = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("plain")
             $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")
             $script:wrappedRethrowRunResult = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("wrapped-rethrow")
+            $script:gdscriptInitRunResult   = Invoke-TestAction -Action "dotnet-capture-via-gdscript-init"
         }
         finally {
             Disconnect-Device
@@ -235,6 +236,40 @@ Describe ".NET Integration Tests" {
             $outermost = $values[$values.Count - 1]
             $outermost.mechanism.type | Should -Be "Godot.Bridge"
             $outermost.mechanism.handled | Should -Be $false
+        }
+    }
+
+    Context "Dotnet with GDScript driving init" {
+        BeforeAll {
+            $runResult = $script:gdscriptInitRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-capture-via-gdscript-init" -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "Exits with code zero" {
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Has correct exception type" {
+            $runEvent.exception.values[0].type | Should -Be "System.Exception"
+        }
+
+        It "Has correct exception value" {
+            $runEvent.exception.values[0].value | Should -Be "Exception (should be captured)"
+        }
+
+        It "Has Godot.Bridge mechanism" {
+            $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
+            $runEvent.exception.values[0].mechanism.handled | Should -Be $false
         }
     }
 }

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -243,7 +243,7 @@ Describe ".NET Integration Tests" {
             $values | Should -Not -BeNullOrEmpty
             $outermost = $values[$values.Count - 1]
             $outermost.type | Should -Be "System.InvalidOperationException"
-            $outermost.value | Should -Be "Wrapped (should be captured)"
+            $outermost.value | Should -Be "Wrapped exception"
         }
 
         It "Includes the inner exception in the chain" {
@@ -251,7 +251,7 @@ Describe ".NET Integration Tests" {
             $values.Count | Should -BeGreaterOrEqual 2
             $inner = $values[0]
             $inner.type | Should -Be "System.Exception"
-            $inner.value | Should -Be "Inner (should NOT be captured)"
+            $inner.value | Should -Be "Inner exception"
         }
 
         It "Has Godot.Bridge mechanism on outermost exception" {

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -141,6 +141,7 @@ BeforeAll {
         IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or $env:SENTRY_TEST_PLATFORM -match "iOS" -or
             (($env:SENTRY_TEST_PLATFORM -ieq "Local" -or [string]::IsNullOrEmpty($env:SENTRY_TEST_PLATFORM)) -and $IsMacOS))
         IsWeb = ($env:SENTRY_TEST_PLATFORM -ieq "Web")
+        IsDotnet = $false
         iOSBundleId = "io.sentry.SentryGodotProject"
         iOSApplicationLogFile = "@io.sentry.SentryGodotProject:documents/logs/godot.log"
     }


### PR DESCRIPTION
Add a Pester suite that runs the Godot mono build and validates that managed exceptions caught by Godot's bridge surface as Sentry events with the expected shape. Coverage spans plain throws, bare rethrows, wrapped rethrows, and the GDScript-driven init path where the .NET layer auto-inits in response to native init.

- Refs #655

CI runs the suite across desktop (Linux/Windows x86_64, macOS universal) and mobile (AndroidSauceLabs, iOSSauceLabs). The `prepare-testing` composite action gains a `dotnet` input that pulls a Godot mono build, builds the C# demo project, and downloads the mono export templates when set; the workflow picks the Pester script per matrix entry via a new `test-script` field. .NET-captured events misreport the OS on Linux (#687) and on mobile (#688), so the affected OS-context assertions are skipped on those entries.