### PR TITLE
feat(dotnet): Populate app name and version in .NET layer configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Add Roslyn analyzer that warns on direct `Sentry.SentrySdk` use and suggests `Sentry.Godot.SentrySdk` ([#663](https://github.com/getsentry/sentry-godot/pull/663))
   - Alias bare `SentrySdk` to `Sentry.Godot.SentrySdk` to avoid ambiguity when consumer code also does `using Sentry;` ([#664](https://github.com/getsentry/sentry-godot/pull/664))
   - Import `Sentry.Godot.props` into user's C# project automatically ([#671](https://github.com/getsentry/sentry-godot/pull/671))
+  - Populate app name and version in .NET layer configuration ([#686](https://github.com/getsentry/sentry-godot/pull/686))
 
 ### Dependencies
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
@@ -12,8 +12,22 @@ internal sealed class GodotSdkIntegration : ISdkIntegration
         {
             scope.Sdk.Name = "sentry.dotnet.godot";
             scope.Sdk.Version = NativeBridge.GetSdkVersion();
-            scope.Contexts.App.Name = NativeBridge.GetAppName();
-            scope.Contexts.App.Version = NativeBridge.GetAppVersion();
+            if (scope.Contexts.App.Name is null)
+            {
+                string appName = NativeBridge.GetAppName();
+                if (appName.Length > 0)
+                {
+                    scope.Contexts.App.Name = appName;
+                }
+            }
+            if (scope.Contexts.App.Version is null)
+            {
+                string appVersion = NativeBridge.GetAppVersion();
+                if (appVersion.Length > 0)
+                {
+                    scope.Contexts.App.Version = appVersion;
+                }
+            }
         });
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
@@ -12,6 +12,8 @@ internal sealed class GodotSdkIntegration : ISdkIntegration
         {
             scope.Sdk.Name = "sentry.dotnet.godot";
             scope.Sdk.Version = NativeBridge.GetSdkVersion();
+            scope.Contexts.App.Name = NativeBridge.GetAppName();
+            scope.Contexts.App.Version = NativeBridge.GetAppVersion();
         });
     }
 }


### PR DESCRIPTION
Populate app context in .NET layer. 
- Caught by tests in #685
- Refs #647 
