### PR TITLE
ci: Bump setup-emsdk action to v16

### DIFF
--- a/.github/workflows/build_gdextension.yml
+++ b/.github/workflows/build_gdextension.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Install Emscripten
         if: matrix.platform == 'web'
-        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        uses: emscripten-core/setup-emsdk@4528d102f7230f0e7b276855c01ea1159be0e984 # v16
         with:
           version: ${{env.EM_VERSION}}
           no-cache: true


### PR DESCRIPTION
To remove those annoying Node 20 warnings. The action also moved under emscripten-core org.