### PR TITLE
chore: Update feedback capture in Android bridge

### DIFF
--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -435,7 +435,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         if (associatedEventId.isNotEmpty()) {
             feedback.setAssociatedEventId(SentryId(associatedEventId))
         }
-        Sentry.captureFeedback(feedback)
+        Sentry.feedback().capture(feedback)
     }
 
     @UsedByGodot


### PR DESCRIPTION
Update capture feedback in Android bridge to use new API. Previous API was deprecated in:
- #689