### PR TITLE
fix(web): Honor `send_default_pii` option on Web platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Honor `send_default_pii` option on Web platform ([#695](https://github.com/getsentry/sentry-godot/pull/695))
+
 ### Dependencies
 
 - Bump Sentry Android from v8.40.0 to v8.41.0 ([#689](https://github.com/getsentry/sentry-godot/pull/689))

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -39,6 +39,7 @@ func _register_commands() -> void:
 	_parser.add_command("attachment-capture", _cmd_attachment_capture, "Capture a message with custom attachments")
 	_parser.add_command("log-capture", _cmd_log_capture, "Capture a structured log to Sentry")
 	_parser.add_command("metric-capture", _cmd_metric_capture, "Capture metrics to Sentry")
+	_parser.add_command("pii-capture", _cmd_pii_capture, "Capture a message with send_default_pii enabled")
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 
 
@@ -232,6 +233,20 @@ func _before_send_metric(metric: SentryMetric) -> SentryMetric:
 	return metric
 
 
+## Captures a message with `send_default_pii` enabled to verify correct PII forwarding.
+func _cmd_pii_capture() -> int:
+	await _init_sentry(func(options: SentryOptions) -> void:
+		options.send_default_pii = true
+	)
+
+	_add_integration_test_context("pii-capture")
+
+	var event_id := SentrySDK.capture_message("PII test message")
+	print("EVENT_CAPTURED: ", event_id)
+	_print_test_result("pii-capture", true, "Test complete")
+	return 0
+
+
 func _cmd_run_tests(tests: String = "res://test/suites/") -> int:
 	if FileAccess.file_exists("res://test/util/test_runner.gd"):
 		print(">>> Initializing testing")
@@ -270,6 +285,7 @@ func _init_sentry(p_extra_config: Callable = Callable()) -> void:
 		options.release = "test-app@1.0.0"
 		options.environment = "integration-test"
 		options.dist = "test-dist"
+		options.send_default_pii = false # PII test relies on this; see CommonTestCases.ps1
 		if p_extra_config.is_valid():
 			p_extra_config.call(options)
 	)
@@ -282,7 +298,7 @@ func _init_sentry(p_extra_config: Callable = Callable()) -> void:
 func _add_integration_test_context(p_command: String) -> void:
 	SentrySDK.add_breadcrumb(SentryBreadcrumb.create("Integration test started"))
 
-	var user := SentryUser.new()
+	var user := SentryUser.create_default()
 	user.id = "12345"
 	user.username = "TestUser"
 	user.email = "user-mail@test.abc"

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -116,6 +116,7 @@ class SentryBridge {
     maxBreadcrumbs: number,
     enableLogs: boolean,
     enableMetrics: boolean,
+    sendDefaultPii: boolean,
     sdkVersion: string,
   ): void {
     if (debug) {
@@ -132,6 +133,7 @@ class SentryBridge {
       maxBreadcrumbs,
       enableLogs,
       enableMetrics,
+      sendDefaultPii,
       _metadata: {
         sdk: {
           name: "sentry.javascript.godot",

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -105,7 +105,7 @@ try {
 		console.log("\n🧪 Functional tests:");
 
 		runTest("init()", () => {
-			bridge.init(() => {}, null, null, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, "0.1.0");
+			bridge.init(() => {}, null, null, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
 		});
 
 		runTest("isEnabled()", () => {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -327,6 +327,7 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),
 			SENTRY_OPTIONS()->get_enable_logs(),
 			SENTRY_OPTIONS()->get_experimental()->get_enable_metrics(),
+			SENTRY_OPTIONS()->is_send_default_pii_enabled(),
 			SENTRY_GODOT_SDK_VERSION);
 
 	if (is_enabled()) {

--- a/tests/integration/CommonTestCases.ps1
+++ b/tests/integration/CommonTestCases.ps1
@@ -93,6 +93,16 @@ $CommonTestCases = @(
             $SentryEvent.user.id | Should -Be "12345"
         }
     }
+    @{ Name = "Does not contain user.ip_address (PII disabled)"; TestBlock = {
+            param($TestSetup, $TestType, $SentryEvent, $RunResult)
+            # This test relies on PII to be disabled in normal runs.
+            # The dedicated "pii-capture" run verifies the inverse; see Integration.Tests.ps1.
+            if ($TestType -eq "pii-capture") {
+                return
+            }
+            $SentryEvent.user.ip_address | Should -BeNullOrEmpty
+        }
+    }
     @{ Name = "Contains breadcrumbs"; TestBlock = {
             param($TestSetup, $TestType, $SentryEvent, $RunResult)
             $SentryEvent.breadcrumbs | Should -Not -BeNullOrEmpty

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -219,6 +219,7 @@ Describe "Platform Integration Tests" {
             $script:runtimeErrorRunResult = Invoke-TestAction -Action "runtime-error-capture"
             $script:logRunResult = Invoke-TestAction -Action "log-capture"
             $script:metricRunResult = Invoke-TestAction -Action "metric-capture"
+            $script:piiRunResult = Invoke-TestAction -Action "pii-capture"
         }
         finally {
             if (-not $script:TestSetup.IsWeb) {
@@ -792,6 +793,32 @@ Describe "Platform Integration Tests" {
             $counter.deleted_global_attribute | Should -BeNullOrEmpty
             $distribution.deleted_global_attribute | Should -BeNullOrEmpty
             $gauge.deleted_global_attribute | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "PII Capture" {
+        BeforeAll {
+            $runResult = $script:piiRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "Exits with code zero" {
+            if ($TestSetup.Platform -in @("Adb", "AndroidSauceLabs")) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Has user.ip_address populated" {
+            $runEvent.user | Should -Not -BeNullOrEmpty
+            $runEvent.user.ip_address | Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
The Web layer was not forwarding `send_default_pii` to JavaScript SDK. This PR fixes it and also adds tests.