### PR TITLE
feat(dotnet): Sync trace context with .NET layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- *Experimental*: C#/.NET support (started in [#629](https://github.com/getsentry/sentry-godot/pull/629))
+- *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
 	- Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- *Experimental*: C#/.NET support (started in [#629](https://github.com/getsentry/sentry-godot/pull/629))
+	- Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
+
 ### Fixes
 
 - Honor `send_default_pii` option on Web platform ([#695](https://github.com/getsentry/sentry-godot/pull/695))

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -15,6 +15,7 @@ import io.sentry.SentryLogEventAttributeValue
 import io.sentry.SentryLogLevel
 import io.sentry.SentryMetricsEvent
 import io.sentry.SentryOptions
+import io.sentry.android.core.InternalSentrySdk
 import io.sentry.android.core.SentryAndroid
 import io.sentry.logger.SentryLogParameters
 import io.sentry.metrics.SentryMetricsParameters
@@ -398,6 +399,11 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     @UsedByGodot
     fun getLastEventId(): String {
         return Sentry.getLastEventId().toString()
+    }
+
+    @UsedByGodot
+    fun setTrace(traceId: String, parentSpanId: String) {
+        InternalSentrySdk.setTrace(traceId, parentSpanId, null, null)
     }
 
     @UsedByGodot

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/GodotSdkIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using Sentry.Integrations;
 using Sentry.Godot.Interop;
+using Scope = Sentry.Scope;
 
 namespace Sentry.Godot.Internal;
 
@@ -8,26 +9,43 @@ internal sealed class GodotSdkIntegration : ISdkIntegration
 {
     public void Register(IHub hub, SentryOptions options)
     {
-        hub.ConfigureScope(scope =>
+        AdoptNativeTrace(hub);
+        hub.ConfigureScope(ApplyScopeChanges);
+    }
+
+    private static void AdoptNativeTrace(IHub hub)
+    {
+        var (traceId, parentSpanId) = NativeBridge.GetTraceContext();
+        if (!string.IsNullOrEmpty(traceId))
         {
-            scope.Sdk.Name = "sentry.dotnet.godot";
-            scope.Sdk.Version = NativeBridge.GetSdkVersion();
-            if (scope.Contexts.App.Name is null)
+            hub.ContinueTrace(
+                new SentryTraceHeader(
+                    SentryId.Parse(traceId),
+                    string.IsNullOrEmpty(parentSpanId) ? SpanId.Empty : SpanId.Parse(parentSpanId),
+                    isSampled: null),
+                baggageHeader: null);
+        }
+    }
+
+    private static void ApplyScopeChanges(Scope scope)
+    {
+        scope.Sdk.Name = "sentry.dotnet.godot";
+        scope.Sdk.Version = NativeBridge.GetSdkVersion();
+        if (scope.Contexts.App.Name is null)
+        {
+            string appName = NativeBridge.GetAppName();
+            if (appName.Length > 0)
             {
-                string appName = NativeBridge.GetAppName();
-                if (appName.Length > 0)
-                {
-                    scope.Contexts.App.Name = appName;
-                }
+                scope.Contexts.App.Name = appName;
             }
-            if (scope.Contexts.App.Version is null)
+        }
+        if (scope.Contexts.App.Version is null)
+        {
+            string appVersion = NativeBridge.GetAppVersion();
+            if (appVersion.Length > 0)
             {
-                string appVersion = NativeBridge.GetAppVersion();
-                if (appVersion.Length > 0)
-                {
-                    scope.Contexts.App.Version = appVersion;
-                }
+                scope.Contexts.App.Version = appVersion;
             }
-        });
+        }
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -118,6 +118,13 @@ internal static partial class NativeBridge
         public byte enable_metrics;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct NativeTraceContext
+    {
+        public GodotStringHandle trace_id;
+        public GodotStringHandle parent_span_id;
+    }
+
     [LibraryImport(Lib)]
     private static unsafe partial NativeOptions csharp_interop_get_options();
 
@@ -231,6 +238,15 @@ internal static partial class NativeBridge
     public static unsafe string? DetectEnvironment()
     {
         return csharp_interop_detect_environment().TakeString();
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial NativeTraceContext csharp_interop_get_trace_context();
+
+    public static unsafe (string? traceId, string? parentSpanId) GetTraceContext()
+    {
+        var nativeContext = csharp_interop_get_trace_context();
+        return (nativeContext.trace_id.TakeString(), nativeContext.parent_span_id.TakeString());
     }
 
     [LibraryImport(Lib)]

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -82,7 +82,23 @@ public static partial class SentrySdk
         CurrentOptions = godotOptions;
         GodotLog.Debug("Initializing Sentry in .NET...");
         Sentry.SentrySdk.Init(godotOptions);
+        AdoptNativeTrace();
         InitFirstChanceExceptionHandler();
+    }
+
+    private static void AdoptNativeTrace()
+    {
+        var (traceId, parentSpanId) = NativeBridge.GetTraceContext();
+        if (string.IsNullOrEmpty(traceId))
+        {
+            return;
+        }
+        var traceHeader = new SentryTraceHeader(
+            SentryId.Parse(traceId),
+            string.IsNullOrEmpty(parentSpanId) ? SpanId.Empty : SpanId.Parse(parentSpanId),
+            isSampled: null);
+
+        Sentry.SentrySdk.ContinueTrace(traceHeader, baggageHeader: null);
     }
 
     /// <summary>

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -82,23 +82,7 @@ public static partial class SentrySdk
         CurrentOptions = godotOptions;
         GodotLog.Debug("Initializing Sentry in .NET...");
         Sentry.SentrySdk.Init(godotOptions);
-        AdoptNativeTrace();
         InitFirstChanceExceptionHandler();
-    }
-
-    private static void AdoptNativeTrace()
-    {
-        var (traceId, parentSpanId) = NativeBridge.GetTraceContext();
-        if (string.IsNullOrEmpty(traceId))
-        {
-            return;
-        }
-        var traceHeader = new SentryTraceHeader(
-            SentryId.Parse(traceId),
-            string.IsNullOrEmpty(parentSpanId) ? SpanId.Empty : SpanId.Parse(parentSpanId),
-            isSampled: null);
-
-        Sentry.SentrySdk.ContinueTrace(traceHeader, baggageHeader: null);
     }
 
     /// <summary>

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -42,6 +42,12 @@ public partial class DotnetCliTriggers : RefCounted
         return Sentry.Godot.SentrySdk.LastEventId.ToString();
     }
 
+    public string CaptureMessage(string message)
+    {
+        GD.Print("Capturing message in .NET layer: ", message);
+        return Sentry.Godot.SentrySdk.CaptureMessage(message).ToString();
+    }
+
     public void TriggerException()
     {
         GD.Print("Triggering exception...");

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -45,6 +45,7 @@ func _register_commands() -> void:
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
 	_parser.add_command("dotnet-capture-via-gdscript-init", _cmd_dotnet_capture_via_gdscript_init, "Capture a .NET exception with GDScript driving init")
+	_parser.add_command("dotnet-cross-layer-capture", _cmd_dotnet_cross_layer_capture, "Capture a native and a .NET event to verify cross-layer synchronization")
 
 
 ## Shows available commands and their arguments.
@@ -296,6 +297,29 @@ func _cmd_dotnet_exception_capture(p_scenario: String) -> int:
 
 func _cmd_dotnet_capture_via_gdscript_init() -> int:
 	return await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
+
+
+## Captures a native and a managed event in one run to verify cross-layer synchronization.
+func _cmd_dotnet_cross_layer_capture() -> int:
+	var script: Script = load("res://cli/DotnetCliTriggers.cs")
+	if script == null:
+		printerr("Error: DotnetCliTriggers.cs is not available - is this a Godot .NET build?")
+		return 1
+	var triggers: Object = script.new()
+
+	await _init_sentry()
+
+	_add_integration_test_context("dotnet-cross-layer-capture")
+	triggers.AddIntegrationTestContext("dotnet-cross-layer-capture")
+
+	var native_event_id := SentrySDK.capture_message("Cross-layer capture - native side")
+	print("EVENT_CAPTURED: ", native_event_id)
+
+	var managed_event_id: String = triggers.CaptureMessage("Cross-layer capture - .NET side")
+	print("EVENT_CAPTURED: ", managed_event_id)
+
+	_print_test_result("dotnet-cross-layer-capture", true, "Test complete")
+	return 0
 
 
 ## Runs a .NET exception trigger with the chosen init driver.

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -304,6 +304,15 @@ void AndroidSDK::remove_attribute(const String &p_name) {
 	android_plugin->call(ANDROID_SN(removeAttribute), p_name);
 }
 
+void AndroidSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	ERR_FAIL_COND(p_trace_id.is_empty());
+
+	Object *android_plugin = _get_android_plugin();
+	ERR_FAIL_NULL(android_plugin);
+
+	android_plugin->call(ANDROID_SN(setTrace), p_trace_id, p_parent_span_id);
+}
+
 void AndroidSDK::_add_default_attachments() {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -96,6 +96,8 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
+
 	virtual void init() override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -36,6 +36,7 @@ AndroidStringNames::AndroidStringNames() {
 	addFileAttachment = StringName("addFileAttachment");
 	addBytesAttachment = StringName("addBytesAttachment");
 	clearAttachments = StringName("clearAttachments");
+	setTrace = StringName("setTrace");
 
 	// Event methods.
 	eventGetId = StringName("eventGetId");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -47,6 +47,7 @@ public:
 	StringName addFileAttachment;
 	StringName addBytesAttachment;
 	StringName clearAttachments;
+	StringName setTrace;
 
 	// Event methods.
 	StringName eventGetId;

--- a/src/sentry/cocoa/cocoa_includes.h
+++ b/src/sentry/cocoa/cocoa_includes.h
@@ -31,6 +31,7 @@ using SentryFrame = ::SentryFrame;
 using SentryThread = ::SentryThread;
 using SentryFeedback = ::SentryFeedback;
 using SentryLog = ::SentryLog;
+using SentrySpanId = ::SentrySpanId;
 
 } // namespace objc
 

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -47,6 +47,8 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
+
 	virtual void init() override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -287,6 +287,17 @@ void CocoaSDK::remove_attribute(const String &p_name) {
 	}];
 }
 
+void CocoaSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	ERR_FAIL_COND(p_trace_id.is_empty());
+
+	objc::SentryId *trace_id = [[objc::SentryId alloc] initWithUUIDString:string_to_objc(p_trace_id)];
+	objc::SentrySpanId *span_id = p_parent_span_id.is_empty()
+			? [[objc::SentrySpanId alloc] init]
+			: [[objc::SentrySpanId alloc] initWithValue:string_to_objc(p_parent_span_id)];
+
+	[PrivateSentrySDKOnly setTrace:trace_id spanId:span_id];
+}
+
 void CocoaSDK::init() {
 	[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.godot"];
 

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -40,6 +40,8 @@ class DisabledSDK : public InternalSDK {
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override {}
 	virtual void remove_attribute(const String &p_name) override {}
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override {}
+
 	virtual void init() override {}
 	virtual void close() override {}
 	virtual bool is_enabled() const override { return false; }

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -126,6 +126,11 @@ struct ManagedOptions {
 	uint8_t enable_metrics;
 };
 
+struct NativeTraceContext {
+	GodotStringHandle trace_id;
+	GodotStringHandle parent_span_id;
+};
+
 static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions> options) {
 	Ref<SentryLoggerLimits> logger_limits = options->get_logger_limits();
 	if (logger_limits.is_null()) {
@@ -218,6 +223,16 @@ CSHARP_EXPORT void csharp_interop_register_dotnet_init(void (*fn)()) {
 CSHARP_EXPORT void csharp_interop_register_logger_error_handler(
 		void (*fn)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len)) {
 	s_dotnet_logger_error_fn = fn;
+}
+
+CSHARP_EXPORT NativeTraceContext csharp_interop_get_trace_context() {
+	auto ctx = SentrySDK::get_singleton()->get_trace_context();
+
+	NativeTraceContext interop_ctx;
+	interop_ctx.trace_id = _make_handle(ctx.trace_id);
+	interop_ctx.parent_span_id = _make_handle(ctx.parent_span_id);
+
+	return interop_ctx;
 }
 
 CSHARP_EXPORT GodotStringHandle csharp_interop_detect_environment() {

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -50,6 +50,8 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) = 0;
 	virtual void remove_attribute(const String &p_name) = 0;
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) = 0;
+
 	virtual void init() = 0;
 	virtual void close() = 0;
 	virtual bool is_enabled() const = 0;

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -296,6 +296,10 @@ void JavaScriptSDK::remove_attribute(const String &p_name) {
 	js_bridge()->call("removeAttribute", p_name.utf8());
 }
 
+void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	SENTRY_PRINT_ONCE(sentry::LEVEL_DEBUG, "Setting trace info not implemented on Web platform - skipped.");
+}
+
 void JavaScriptSDK::init() {
 	ERR_FAIL_COND(!js_bridge());
 

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -45,6 +45,8 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
+
 	virtual void init() override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;

--- a/src/sentry/logging/print.h
+++ b/src/sentry/logging/print.h
@@ -122,4 +122,14 @@ void print_fatal(const Variant &p_arg1, const Args &...p_args) {
 		return;                              \
 	}
 
+#define SENTRY_PRINT_ONCE(m_level, m_msg)             \
+	if (true) {                                       \
+		static bool first_time = false;               \
+		if (first_time) {                             \
+			::sentry::logging::print(m_level, m_msg); \
+			first_time = false;                       \
+		}                                             \
+	} else                                            \
+		((void)0)
+
 } //namespace sentry::logging

--- a/src/sentry/logging/print.h
+++ b/src/sentry/logging/print.h
@@ -124,7 +124,7 @@ void print_fatal(const Variant &p_arg1, const Args &...p_args) {
 
 #define SENTRY_PRINT_ONCE(m_level, m_msg)             \
 	if (true) {                                       \
-		static bool first_time = false;               \
+		static bool first_time = true;                \
 		if (first_time) {                             \
 			::sentry::logging::print(m_level, m_msg); \
 			first_time = false;                       \

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -382,6 +382,15 @@ void NativeSDK::remove_attribute(const String &p_name) {
 	sentry_remove_attribute(p_name.utf8());
 }
 
+void NativeSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	ERR_FAIL_COND(p_trace_id.is_empty());
+	if (p_parent_span_id.is_empty()) {
+		sentry_set_trace(p_trace_id.utf8(), NULL);
+	} else {
+		sentry_set_trace(p_trace_id.utf8(), p_parent_span_id.utf8());
+	}
+}
+
 void NativeSDK::init() {
 	ERR_FAIL_NULL(OS::get_singleton());
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -48,6 +48,8 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
+
 	virtual void init() override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -13,6 +13,7 @@
 #include "sentry/sentry_options.h"
 #include "sentry/util/library_path.h"
 #include "sentry/util/simple_bind.h"
+#include "sentry/uuid.h"
 
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/engine.hpp>
@@ -171,6 +172,11 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 			internal_sdk->add_attachment(att);
 		}
 		options->clear_custom_attachments();
+
+		// Generate a new trace on init to tie native and managed errors together.
+		trace_context.trace_id = sentry::uuid::make_uuid_no_dashes();
+		trace_context.parent_span_id = sentry::uuid::make_rand_hex_16();
+		internal_sdk->set_trace(trace_context.trace_id, trace_context.parent_span_id);
 
 		if (is_auto_initializing) {
 			// Delay contexts initialization until engine singletons are ready during early initialization.

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -175,7 +175,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 
 		// Generate a new trace on init to tie native and managed errors together.
 		trace_context.trace_id = sentry::uuid::make_uuid_no_dashes();
-		trace_context.parent_span_id = sentry::uuid::make_rand_hex_16();
+		trace_context.parent_span_id = sentry::uuid::make_span_id();
 		internal_sdk->set_trace(trace_context.trace_id, trace_context.parent_span_id);
 
 		if (is_auto_initializing) {

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -30,12 +30,12 @@ public:
 	// This structure is needed to avoid circular dependencies between this and other headers that use Level enum.
 	using Level = sentry::Level;
 
-private:
 	struct TraceContext {
 		String trace_id;
 		String parent_span_id;
 	};
 
+private:
 	static SentrySDK *singleton;
 
 	Ref<SentryOptions> options;

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -31,6 +31,11 @@ public:
 	using Level = sentry::Level;
 
 private:
+	struct TraceContext {
+		String trace_id;
+		String parent_span_id;
+	};
+
 	static SentrySDK *singleton;
 
 	Ref<SentryOptions> options;
@@ -39,6 +44,8 @@ private:
 	Ref<sentry::logging::SentryGodotLogger> godot_logger;
 	bool is_auto_initializing = false;
 	bool is_configuring = false;
+
+	TraceContext trace_context;
 
 	// Public API for logs and metrics
 	SentryLogger *logger = nullptr;
@@ -104,6 +111,8 @@ public:
 	Callable get_before_send() { return options->get_before_send(); }
 
 	void prepare_and_auto_initialize();
+
+	_FORCE_INLINE_ TraceContext get_trace_context() const { return trace_context; }
 
 	SentrySDK();
 	~SentrySDK();

--- a/src/sentry/uuid.cpp
+++ b/src/sentry/uuid.cpp
@@ -46,4 +46,15 @@ String make_uuid_no_dashes() {
 	return _uuid_to_string(_generate_uuid_v4(), FORMAT_NO_DASHES);
 }
 
+String make_rand_hex_16() {
+	std::random_device rd;
+	std::mt19937_64 gen{ rd() };
+	std::uniform_int_distribution<unsigned long long> dist;
+	const unsigned long long value = dist(gen);
+
+	char buffer[17];
+	std::snprintf(buffer, sizeof(buffer), "%016llx", value);
+	return String(buffer);
+}
+
 } // namespace sentry::uuid

--- a/src/sentry/uuid.cpp
+++ b/src/sentry/uuid.cpp
@@ -1,20 +1,34 @@
 #include "uuid.h"
 
+#include <cstdint>
+#include <cstring>
 #include <random>
 
 #include <godot_cpp/variant/packed_byte_array.hpp>
 
 namespace {
 
+std::mt19937_64 &_rng() {
+	thread_local std::mt19937_64 engine = [] {
+		std::random_device rd;
+		// 256 bits of entropy.
+		std::seed_seq seq{ rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd() };
+		return std::mt19937_64(seq);
+	}();
+	return engine;
+}
+
+inline uint64_t _random_uint64() {
+	return _rng()();
+}
+
 inline PackedByteArray _generate_uuid_v4() {
 	PackedByteArray data;
 	data.resize(16);
-	std::random_device rd;
-	std::mt19937 gen{ rd() };
-	std::uniform_int_distribution<int> dist{ 0, 255 }; // Limits
-	for (int i = 0; i < 16; i++) {
-		data[i] = ((unsigned char)dist(gen));
-	}
+	uint64_t lo = _random_uint64();
+	uint64_t hi = _random_uint64();
+	std::memcpy(data.ptrw(), &lo, 8);
+	std::memcpy(data.ptrw() + 8, &hi, 8);
 	data[6] = (data[6] & 0x0F) | 0x40; // Version 4
 	data[8] = (data[8] & 0x3F) | 0x80; // Variant 10xx
 	return data;
@@ -46,14 +60,10 @@ String make_uuid_no_dashes() {
 	return _uuid_to_string(_generate_uuid_v4(), FORMAT_NO_DASHES);
 }
 
-String make_rand_hex_16() {
-	std::random_device rd;
-	std::mt19937_64 gen{ rd() };
-	std::uniform_int_distribution<unsigned long long> dist;
-	const unsigned long long value = dist(gen);
-
+String make_span_id() {
 	char buffer[17];
-	std::snprintf(buffer, sizeof(buffer), "%016llx", value);
+	std::snprintf(buffer, sizeof(buffer), "%016llx",
+			(unsigned long long)_random_uint64());
 	return String(buffer);
 }
 

--- a/src/sentry/uuid.h
+++ b/src/sentry/uuid.h
@@ -8,6 +8,6 @@ namespace sentry::uuid {
 
 String make_uuid();
 String make_uuid_no_dashes();
-String make_rand_hex_16();
+String make_span_id();
 
 } // namespace sentry::uuid

--- a/src/sentry/uuid.h
+++ b/src/sentry/uuid.h
@@ -8,5 +8,6 @@ namespace sentry::uuid {
 
 String make_uuid();
 String make_uuid_no_dashes();
+String make_rand_hex_16();
 
 } // namespace sentry::uuid

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -126,6 +126,7 @@ Describe ".NET Integration Tests" {
             $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")
             $script:wrappedRethrowRunResult = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("wrapped-rethrow")
             $script:gdscriptInitRunResult   = Invoke-TestAction -Action "dotnet-capture-via-gdscript-init"
+            $script:crossLayerRunResult     = Invoke-TestAction -Action "dotnet-cross-layer-capture"
         }
         finally {
             Disconnect-Device
@@ -297,6 +298,40 @@ Describe ".NET Integration Tests" {
         It "Has Godot.Bridge mechanism" {
             $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
             $runEvent.exception.values[0].mechanism.handled | Should -Be $false
+        }
+    }
+
+    Context "Cross-layer capture" {
+        BeforeAll {
+            $runResult = $script:crossLayerRunResult
+
+            $eventIds = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 2
+            Write-GitHub "::group::Getting event content"
+            $script:nativeEvent  = Get-SentryTestEvent -EventId $eventIds[0]
+            $script:managedEvent = Get-SentryTestEvent -EventId $eventIds[1]
+            Write-GitHub "::endgroup::"
+        }
+
+        It "Exits with code zero" {
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Native event has trace context with non-empty trace_id" {
+            $nativeEvent.contexts.trace | Should -Not -BeNullOrEmpty
+            $nativeEvent.contexts.trace.trace_id | Should -Not -BeNullOrEmpty
+        }
+
+        It "Managed event has trace context with non-empty trace_id" {
+            $managedEvent.contexts.trace | Should -Not -BeNullOrEmpty
+            $managedEvent.contexts.trace.trace_id | Should -Not -BeNullOrEmpty
+        }
+
+        It "Native and managed events share the same trace_id" {
+            $nativeEvent.contexts.trace.trace_id | Should -Be $managedEvent.contexts.trace.trace_id
         }
     }
 }


### PR DESCRIPTION
Managed and native events need to be on the same trace. Otherwise, managed events don't see native errors and logs, and vice versa.
- Closes #652 
