### PR TITLE
test(dotnet): Test auto-init path in .NET integration tests

### DIFF
--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -48,6 +48,11 @@ public partial class DotnetCliTriggers : RefCounted
         return Sentry.Godot.SentrySdk.CaptureMessage(message).ToString();
     }
 
+    public bool IsSdkEnabled()
+    {
+        return Sentry.Godot.SentrySdk.IsEnabled;
+    }
+
     public void TriggerException()
     {
         GD.Print("Triggering exception...");

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -12,7 +12,7 @@ extends Node
 ## Use "godot --headless --path ./project -- help" to list available commands.
 
 
-enum DotnetInitDriver { GDSCRIPT, DOTNET }
+enum DotnetInitDriver { GDSCRIPT, DOTNET, AUTO }
 
 var exit_code: int
 
@@ -45,6 +45,7 @@ func _register_commands() -> void:
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
 	_parser.add_command("dotnet-capture-via-gdscript-init", _cmd_dotnet_capture_via_gdscript_init, "Capture a .NET exception with GDScript driving init")
+	_parser.add_command("dotnet-capture-via-auto-init", _cmd_dotnet_capture_via_auto_init, "Capture a .NET exception with native auto-init driving init")
 	_parser.add_command("dotnet-cross-layer-capture", _cmd_dotnet_cross_layer_capture, "Capture a native and a .NET event to verify cross-layer synchronization")
 
 
@@ -299,6 +300,10 @@ func _cmd_dotnet_capture_via_gdscript_init() -> int:
 	return await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
 
 
+func _cmd_dotnet_capture_via_auto_init() -> int:
+	return await _run_dotnet_trigger("dotnet-capture-via-auto-init", "TriggerException", DotnetInitDriver.AUTO)
+
+
 ## Captures a native and a managed event in one run to verify cross-layer synchronization.
 func _cmd_dotnet_cross_layer_capture() -> int:
 	var script: Script = load("res://cli/DotnetCliTriggers.cs")
@@ -336,6 +341,12 @@ func _run_dotnet_trigger(p_test_type: String, p_trigger_method: StringName, p_in
 			await _init_sentry()
 		DotnetInitDriver.DOTNET:
 			triggers.InitSentryFromDotnet()
+		DotnetInitDriver.AUTO:
+			# SDK is expected to auto-init via "auto_init" project setting.
+			pass
+
+	print("SENTRY_NATIVE_ENABLED: ", SentrySDK.is_enabled())
+	print("SENTRY_DOTNET_ENABLED: ", triggers.IsSdkEnabled())
 
 	triggers.AddIntegrationTestContext(p_test_type)
 

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -18,6 +18,53 @@ $global:DebugPreference = "Continue"
 . $PSScriptRoot/CommonTestCases.ps1
 . $PSScriptRoot/Utils.ps1
 
+# Testing the auto-init path requires override.cfg to enable it.
+# Mobile exports are sealed, so override.cfg cannot be applied there.
+$script:skipAutoInitTests = ($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs", "iOSSauceLabs"))
+
+$DotnetCommonTestCases = @(
+    @{ Name = "Exits with code zero"; TestBlock = {
+            param($TestSetup, $RunResult)
+            if ($TestSetup.IsAndroid) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
+            $RunResult.ExitCode | Should -Be 0
+        }
+    }
+    @{ Name = "Native layer is enabled"; TestBlock = {
+            param($RunResult)
+            $RunResult.Output | Where-Object { $_ -eq "SENTRY_NATIVE_ENABLED: true" } | Should -Not -BeNullOrEmpty
+        }
+    }
+    @{ Name = ".NET layer is enabled"; TestBlock = {
+            param($RunResult)
+            $RunResult.Output | Where-Object { $_ -eq "SENTRY_DOTNET_ENABLED: true" } | Should -Not -BeNullOrEmpty
+        }
+    }
+    @{ Name = "Has correct exception type"; TestBlock = {
+            param($SentryEvent)
+            $SentryEvent.exception.values[0].type | Should -Be "System.Exception"
+        }
+    }
+    @{ Name = "Has correct exception value"; TestBlock = {
+            param($SentryEvent)
+            $SentryEvent.exception.values[0].value | Should -Be "Exception (should be captured)"
+        }
+    }
+    @{ Name = "Has Godot.Bridge mechanism"; TestBlock = {
+            param($SentryEvent)
+            $SentryEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
+            $SentryEvent.exception.values[0].mechanism.handled | Should -Be $false
+        }
+    }
+    @{ Name = "Has stacktrace frames"; TestBlock = {
+            param($SentryEvent)
+            $SentryEvent.exception.values[0].stacktrace.frames | Should -Not -BeNullOrEmpty
+        }
+    }
+)
+
 BeforeAll {
     function Invoke-TestAction {
         param (
@@ -122,56 +169,36 @@ Describe ".NET Integration Tests" {
             Connect-Device -Platform $script:TestSetup.Platform
             Install-DeviceApp -Path $script:TestSetup.Executable
 
-            $script:exceptionRunResult      = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("plain")
+            $script:dotnetInitRunResult      = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("plain")
             $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")
             $script:wrappedRethrowRunResult = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("wrapped-rethrow")
             $script:gdscriptInitRunResult   = Invoke-TestAction -Action "dotnet-capture-via-gdscript-init"
             $script:crossLayerRunResult     = Invoke-TestAction -Action "dotnet-cross-layer-capture"
+
+            if (-not $script:skipAutoInitTests) {
+                # Auto-init reads options from project settings. Use override.cfg to enable it for this run without
+                # changing checked-in settings.
+                # Keep release/environment/dist aligned with cli_commands.gd, because auto-init runs without an init
+                # callback, but the tests still expect these values.
+                $overridePath = Join-Path $PSScriptRoot "../../project/override.cfg"
+                try {
+                    Set-Content -Path $overridePath -Value @"
+[sentry]
+
+options/auto_init=true
+options/release="test-app@1.0.0"
+options/environment="integration-test"
+options/dist="test-dist"
+options/debug_printing=0
+"@
+                    $script:autoInitRunResult = Invoke-TestAction -Action "dotnet-capture-via-auto-init"
+                } finally {
+                    Remove-Item $overridePath -ErrorAction SilentlyContinue
+                }
+            }
         }
         finally {
             Disconnect-Device
-        }
-    }
-
-    Context "Plain Exception" {
-        BeforeAll {
-            $runResult = $script:exceptionRunResult
-
-            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
-            if ($eventId) {
-                Write-GitHub "::group::Getting event content"
-                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
-                Write-GitHub "::endgroup::"
-            }
-        }
-
-        It "<Name>" -ForEach $CommonTestCases {
-            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-plain" -RunResult $runResult -TestSetup $script:TestSetup
-        }
-
-        It "Exits with code zero" {
-            if ($TestSetup.IsAndroid) {
-                # app-runner doesn't support exit code on Android.
-                return
-            }
-            $runResult.ExitCode | Should -Be 0
-        }
-
-        It "Has correct exception type" {
-            $runEvent.exception.values[0].type | Should -Be "System.Exception"
-        }
-
-        It "Has correct exception value" {
-            $runEvent.exception.values[0].value | Should -Be "Exception (should be captured)"
-        }
-
-        It "Has Godot.Bridge mechanism" {
-            $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
-            $runEvent.exception.values[0].mechanism.handled | Should -Be $false
-        }
-
-        It "Has stacktrace frames" {
-            $runEvent.exception.values[0].stacktrace.frames | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -185,10 +212,6 @@ Describe ".NET Integration Tests" {
                 $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
                 Write-GitHub "::endgroup::"
             }
-        }
-
-        It "<Name>" -ForEach $CommonTestCases {
-            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-bare-rethrow" -RunResult $runResult -TestSetup $script:TestSetup
         }
 
         It "Exits with code zero" {
@@ -225,10 +248,6 @@ Describe ".NET Integration Tests" {
             }
         }
 
-        It "<Name>" -ForEach $CommonTestCases {
-            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-wrapped-rethrow" -RunResult $runResult -TestSetup $script:TestSetup
-        }
-
         It "Exits with code zero" {
             if ($TestSetup.IsAndroid) {
                 # app-runner doesn't support exit code on Android.
@@ -263,6 +282,27 @@ Describe ".NET Integration Tests" {
         }
     }
 
+    Context "Dotnet with CSharp driving init" {
+        BeforeAll {
+            $runResult = $script:dotnetInitRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-plain" -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "<Name>" -ForEach $DotnetCommonTestCases {
+            & $TestBlock -SentryEvent $runEvent -RunResult $runResult -TestSetup $script:TestSetup
+        }
+    }
+
     Context "Dotnet with GDScript driving init" {
         BeforeAll {
             $runResult = $script:gdscriptInitRunResult
@@ -279,25 +319,29 @@ Describe ".NET Integration Tests" {
             & $testBlock -SentryEvent $runEvent -TestType "dotnet-capture-via-gdscript-init" -RunResult $runResult -TestSetup $script:TestSetup
         }
 
-        It "Exits with code zero" {
-            if ($TestSetup.IsAndroid) {
-                # app-runner doesn't support exit code on Android.
-                return
+        It "<Name>" -ForEach $DotnetCommonTestCases {
+            & $TestBlock -SentryEvent $runEvent -RunResult $runResult -TestSetup $script:TestSetup
+        }
+    }
+
+    Context "Dotnet with native auto-init driving init" -Skip:$script:skipAutoInitTests {
+        BeforeAll {
+            $runResult = $script:autoInitRunResult
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
             }
-            $runResult.ExitCode | Should -Be 0
         }
 
-        It "Has correct exception type" {
-            $runEvent.exception.values[0].type | Should -Be "System.Exception"
+        It "<Name>" -ForEach $CommonTestCases {
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-capture-via-auto-init" -RunResult $runResult -TestSetup $script:TestSetup
         }
 
-        It "Has correct exception value" {
-            $runEvent.exception.values[0].value | Should -Be "Exception (should be captured)"
-        }
-
-        It "Has Godot.Bridge mechanism" {
-            $runEvent.exception.values[0].mechanism.type | Should -Be "Godot.Bridge"
-            $runEvent.exception.values[0].mechanism.handled | Should -Be $false
+        It "<Name>" -ForEach $DotnetCommonTestCases {
+            & $TestBlock -SentryEvent $runEvent -RunResult $runResult -TestSetup $script:TestSetup
         }
     }
 

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -34,12 +34,14 @@ $DotnetCommonTestCases = @(
     }
     @{ Name = "Native layer is enabled"; TestBlock = {
             param($RunResult)
-            $RunResult.Output | Where-Object { $_ -eq "SENTRY_NATIVE_ENABLED: true" } | Should -Not -BeNullOrEmpty
+            $line = $RunResult.Output | Where-Object { $_ -like "SENTRY_NATIVE_ENABLED:*" } | Select-Object -First 1
+            $line | Should -Be "SENTRY_NATIVE_ENABLED: true"
         }
     }
     @{ Name = ".NET layer is enabled"; TestBlock = {
             param($RunResult)
-            $RunResult.Output | Where-Object { $_ -eq "SENTRY_DOTNET_ENABLED: true" } | Should -Not -BeNullOrEmpty
+            $line = $RunResult.Output | Where-Object { $_ -like "SENTRY_DOTNET_ENABLED:*" } | Select-Object -First 1
+            $line | Should -Be "SENTRY_DOTNET_ENABLED: true"
         }
     }
     @{ Name = "Has correct exception type"; TestBlock = {

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -18,10 +18,6 @@ $global:DebugPreference = "Continue"
 . $PSScriptRoot/CommonTestCases.ps1
 . $PSScriptRoot/Utils.ps1
 
-# Testing the auto-init path requires override.cfg to enable it.
-# Mobile exports are sealed, so override.cfg cannot be applied there.
-$script:skipAutoInitTests = ($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs", "iOSSauceLabs"))
-
 $DotnetCommonTestCases = @(
     @{ Name = "Exits with code zero"; TestBlock = {
             param($TestSetup, $RunResult)
@@ -182,13 +178,13 @@ Describe ".NET Integration Tests" {
             $script:gdscriptInitRunResult   = Invoke-TestAction -Action "dotnet-capture-via-gdscript-init"
             $script:crossLayerRunResult     = Invoke-TestAction -Action "dotnet-cross-layer-capture"
 
-            if (-not $script:skipAutoInitTests) {
-                # Auto-init reads options from project settings. Use override.cfg to enable it for this run without
-                # changing checked-in settings.
-                # Keep release/environment/dist aligned with cli_commands.gd, because auto-init runs without an init
-                # callback, but the tests still expect these values.
+            # Auto-init reads options from project settings. Use override.cfg to enable it just for this run.
+            # Mobile exports are sealed, so override.cfg cannot be applied there.
+            if ($env:SENTRY_TEST_PLATFORM -notin @("Adb", "AndroidSauceLabs", "iOSSauceLabs")) {
                 $overridePath = Join-Path $PSScriptRoot "../../project/override.cfg"
                 try {
+                    # Keep release/environment/dist aligned with cli_commands.gd, because auto-init runs without an init
+                    # callback, but the tests still expect these values.
                     Set-Content -Path $overridePath -Value @"
 [sentry]
 
@@ -331,7 +327,7 @@ options/debug_printing=0
         }
     }
 
-    Context "Dotnet with native auto-init driving init" -Skip:$script:skipAutoInitTests {
+    Context "Dotnet with native auto-init driving init" -Skip:($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs", "iOSSauceLabs")) {
         BeforeAll {
             $runResult = $script:autoInitRunResult
 

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -34,14 +34,19 @@ $DotnetCommonTestCases = @(
     }
     @{ Name = "Native layer is enabled"; TestBlock = {
             param($RunResult)
-            $line = $RunResult.Output | Where-Object { $_ -like "SENTRY_NATIVE_ENABLED:*" } | Select-Object -First 1
-            $line | Should -Be "SENTRY_NATIVE_ENABLED: true"
+            # On Android each line carries a logcat prefix, so match the marker anywhere in the line.
+            $line = $RunResult.Output | Where-Object {
+                $_ -match "SENTRY_NATIVE_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "SENTRY_NATIVE_ENABLED: true"
         }
     }
     @{ Name = ".NET layer is enabled"; TestBlock = {
             param($RunResult)
-            $line = $RunResult.Output | Where-Object { $_ -like "SENTRY_DOTNET_ENABLED:*" } | Select-Object -First 1
-            $line | Should -Be "SENTRY_DOTNET_ENABLED: true"
+            $line = $RunResult.Output | Where-Object {
+                $_ -match "SENTRY_DOTNET_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "SENTRY_DOTNET_ENABLED: true"
         }
     }
     @{ Name = "Has correct exception type"; TestBlock = {


### PR DESCRIPTION
This PR adds tests for auto-init path in .NET integration tests, and also consolidates common test cases for all three init scenarios:
1. Scenario A: SDK initializes automatically via "auto_init" project setting.
2. Scenario B: SDK is initialized manually from GDScript.
3. Scenario C: SDK is initialized manually from CSharp.

Refs https://github.com/getsentry/sentry-godot/issues/655