### PR TITLE
feat(dotnet): Sync scope changes from .NET to native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
 	- Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
+  - Sync breadcrumbs, tags and user changes from .NET to native ([#701](https://github.com/getsentry/sentry-godot/pull/701))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Features
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
-	- Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
-  - Sync breadcrumbs, tags and user changes from .NET to native ([#701](https://github.com/getsentry/sentry-godot/pull/701))
+  - Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
+  - Sync breadcrumbs, tags and user changes from .NET layer to native layer ([#701](https://github.com/getsentry/sentry-godot/pull/701))
 
 ### Fixes
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
@@ -6,6 +6,9 @@ namespace Sentry.Godot.Interop;
 /// <summary>
 /// Scope Observer to sync changes to native layer.
 /// </summary>
+/// <remarks>
+/// Local scope changes are NOT synced, which prevents them from leaking into the native current scope.
+/// </remarks>
 internal class GodotScopeObserver : IScopeObserver
 {
     [ThreadStatic]
@@ -13,7 +16,7 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void AddBreadcrumb(Breadcrumb breadcrumb)
     {
-        if (_syncing)
+        if (_syncing || SentrySdk.InLocalScope)
         {
             return;
         }
@@ -35,7 +38,7 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void SetTag(string key, string value)
     {
-        if (_syncing)
+        if (_syncing || SentrySdk.InLocalScope)
         {
             return;
         }
@@ -52,7 +55,7 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void UnsetTag(string key)
     {
-        if (_syncing)
+        if (_syncing || SentrySdk.InLocalScope)
         {
             return;
         }
@@ -69,7 +72,7 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void SetUser(SentryUser? user)
     {
-        if (_syncing)
+        if (_syncing || SentrySdk.InLocalScope)
         {
             return;
         }
@@ -86,9 +89,7 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void SetTrace(SentryId traceId, SpanId parentSpanId)
     {
-        // Trace context is owned by the native layer and shared with .NET at init
-        // via NativeBridge.GetTraceContext(). Scope-level trace changes are not
-        // propagated back to native.
+        // TODO: forward to native trace API once wired through NativeBridge.
     }
 
     public void AddAttachment(SentryAttachment attachment)

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
@@ -11,6 +11,7 @@ namespace Sentry.Godot.Interop;
 /// </remarks>
 internal class GodotScopeObserver : IScopeObserver
 {
+    // Prevent feedback loops when syncing scope changes across layers.
     [ThreadStatic] private static bool _syncing;
 
     public void AddBreadcrumb(Breadcrumb breadcrumb)

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
@@ -1,0 +1,103 @@
+using System;
+using Sentry;
+
+namespace Sentry.Godot.Interop;
+
+/// <summary>
+/// Scope Observer to sync changes to native layer.
+/// </summary>
+internal class GodotScopeObserver : IScopeObserver
+{
+    [ThreadStatic]
+    private static bool _syncing;
+
+    public void AddBreadcrumb(Breadcrumb breadcrumb)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+        _syncing = true;
+        try
+        {
+            NativeBridge.AddBreadcrumb(breadcrumb);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    public void SetExtra(string key, object? value)
+    {
+        // NOTE: Godot SDK doesn't support extras.
+    }
+
+    public void SetTag(string key, string value)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+        _syncing = true;
+        try
+        {
+            NativeBridge.SetTag(key, value);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    public void UnsetTag(string key)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+        _syncing = true;
+        try
+        {
+            NativeBridge.RemoveTag(key);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    public void SetUser(SentryUser? user)
+    {
+        if (_syncing)
+        {
+            return;
+        }
+        _syncing = true;
+        try
+        {
+            NativeBridge.SetUser(user);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+
+    public void SetTrace(SentryId traceId, SpanId parentSpanId)
+    {
+        // Trace context is owned by the native layer and shared with .NET at init
+        // via NativeBridge.GetTraceContext(). Scope-level trace changes are not
+        // propagated back to native.
+    }
+
+    public void AddAttachment(SentryAttachment attachment)
+    {
+        // TODO: forward to native attachment API once wired through NativeBridge.
+    }
+
+    public void ClearAttachments()
+    {
+        // TODO: forward to native attachment API once wired through NativeBridge.
+    }
+}

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
@@ -4,15 +4,14 @@ using Sentry;
 namespace Sentry.Godot.Interop;
 
 /// <summary>
-/// Scope Observer to sync changes to native layer.
+/// Synchronizes scope changes to native layer.
 /// </summary>
 /// <remarks>
 /// Local scope changes are NOT synced, which prevents them from leaking into the native current scope.
 /// </remarks>
 internal class GodotScopeObserver : IScopeObserver
 {
-    [ThreadStatic]
-    private static bool _syncing;
+    [ThreadStatic] private static bool _syncing;
 
     public void AddBreadcrumb(Breadcrumb breadcrumb)
     {

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs.uid
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs.uid
@@ -1,0 +1,1 @@
+uid://w3cgksyuscsi

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -524,16 +524,21 @@ internal static partial class NativeBridge
         }
         else
         {
-            fixed (char* usernamePtr = user.Username)
-            fixed (char* emailPtr = user.Email)
-            fixed (char* idPtr = user.Id)
-            fixed (char* ipAddressPtr = user.IpAddress)
+            var username = user.Username ?? "";
+            var email = user.Email ?? "";
+            var id = user.Id ?? "";
+            var ipAddress = user.IpAddress ?? "";
+
+            fixed (char* usernamePtr = username)
+            fixed (char* emailPtr = email)
+            fixed (char* idPtr = id)
+            fixed (char* ipAddressPtr = ipAddress)
             {
                 csharp_interop_sdk_set_user(
-                        usernamePtr, user.Username?.Length ?? 0,
-                        emailPtr, user.Email?.Length ?? 0,
-                        idPtr, user.Id?.Length ?? 0,
-                        ipAddressPtr, user.IpAddress?.Length ?? 0);
+                        usernamePtr, username.Length,
+                        emailPtr, email.Length,
+                        idPtr, id.Length,
+                        ipAddressPtr, ipAddress.Length);
             }
         }
     }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using Sentry.Godot.Internal;
@@ -123,6 +124,72 @@ internal static partial class NativeBridge
     {
         public GodotStringHandle trace_id;
         public GodotStringHandle parent_span_id;
+    }
+
+    // Managed-owned string map for passing Dictionary<string, string> across P/Invoke.
+    // Buffer layout: key1+val1+key2+val2... concatenated as UTF-16.
+    // Lengths array: key1_len, val1_len, key2_len, val2_len, ... (2*pair_count entries).
+    // Must match layout of ManagedStringMap in csharp_interop.cpp.
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct ManagedStringMap
+    {
+        public char* Buffer;
+        public int* Lengths;
+        public int PairCount;
+    }
+
+    private delegate void ManagedStringMapAction(ManagedStringMap map);
+
+    /// <summary>
+    /// Marshals a dictionary into a stack-allocated interleaved buffer and passes the resulting struct to a native
+    /// function call. The map is only valid for the duration of the call (owned by managed code).
+    /// </summary>
+    private static unsafe void MarshallStringMap(IReadOnlyDictionary<string, string>? dict, ManagedStringMapAction nativeFunc)
+    {
+        if (dict == null || dict.Count == 0)
+        {
+            nativeFunc(default);
+            return;
+        }
+
+        int pairCount = dict.Count;
+
+        Span<int> lengthSpan = pairCount * 2 <= 256
+                ? stackalloc int[pairCount * 2]
+                : new int[pairCount * 2];
+        int totalChars = 0;
+        int i = 0;
+        foreach (var kv in dict)
+        {
+            lengthSpan[i++] = kv.Key.Length;
+            lengthSpan[i++] = kv.Value.Length;
+            totalChars += kv.Key.Length + kv.Value.Length;
+        }
+
+        Span<char> buffer = totalChars <= 512
+                ? stackalloc char[totalChars]
+                : new char[totalChars];
+
+        int pos = 0;
+        foreach (var kv in dict)
+        {
+            kv.Key.AsSpan().CopyTo(buffer.Slice(pos));
+            pos += kv.Key.Length;
+            kv.Value.AsSpan().CopyTo(buffer.Slice(pos));
+            pos += kv.Value.Length;
+        }
+
+        fixed (char* bufPtr = buffer)
+        fixed (int* lenPtr = lengthSpan)
+        {
+            var map = new ManagedStringMap
+            {
+                Buffer = bufPtr,
+                Lengths = lenPtr,
+                PairCount = pairCount
+            };
+            nativeFunc(map);
+        }
     }
 
     [LibraryImport(Lib)]
@@ -376,6 +443,98 @@ internal static partial class NativeBridge
         fixed (char* ptr = message)
         {
             csharp_interop_log((int)level, ptr, message.Length);
+        }
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_sdk_add_breadcrumb(
+            char* message, int messageLen,
+            char* category, int categoryLen,
+            char* type, int typeLen,
+            int level,
+            ManagedStringMap data);
+
+    public static unsafe void AddBreadcrumb(Breadcrumb breadcrumb)
+    {
+        var msg = breadcrumb.Message ?? "";
+        var cat = breadcrumb.Category ?? "";
+        var type = breadcrumb.Type ?? "";
+        int level = breadcrumb.Level switch
+        {
+            BreadcrumbLevel.Debug => 0,
+            BreadcrumbLevel.Info => 1,
+            BreadcrumbLevel.Warning => 2,
+            BreadcrumbLevel.Error => 3,
+            BreadcrumbLevel.Fatal => 4,
+            _ => 1,
+        };
+
+        MarshallStringMap(breadcrumb.Data, map =>
+        {
+            fixed (char* msgPtr = msg)
+            fixed (char* catPtr = cat)
+            fixed (char* typePtr = type)
+            {
+                csharp_interop_sdk_add_breadcrumb(
+                        msgPtr, msg.Length,
+                        catPtr, cat.Length,
+                        typePtr, type.Length,
+                        level, map);
+            }
+        });
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_sdk_set_tag(
+            char* key, int keyLen, char* value, int valueLen);
+
+    public static unsafe void SetTag(string key, string value)
+    {
+        fixed (char* keyPtr = key)
+        fixed (char* valPtr = value)
+        {
+            csharp_interop_sdk_set_tag(keyPtr, key.Length, valPtr, value.Length);
+        }
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_sdk_remove_tag(
+            char* key, int keyLen);
+
+    public static unsafe void RemoveTag(string key)
+    {
+        fixed (char* keyPtr = key)
+        {
+            csharp_interop_sdk_remove_tag(keyPtr, key.Length);
+        }
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_sdk_remove_user();
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_sdk_set_user(
+            char* username, int usernameLen, char* email, int emailLen, char* id, int idLen, char* ipAddress, int ipAddressLen);
+
+    public static unsafe void SetUser(SentryUser? user)
+    {
+        if (user is null)
+        {
+            csharp_interop_sdk_remove_user();
+        }
+        else
+        {
+            fixed (char* usernamePtr = user.Username)
+            fixed (char* emailPtr = user.Email)
+            fixed (char* idPtr = user.Id)
+            fixed (char* ipAddressPtr = user.IpAddress)
+            {
+                csharp_interop_sdk_set_user(
+                        usernamePtr, user.Username?.Length ?? 0,
+                        emailPtr, user.Email?.Length ?? 0,
+                        idPtr, user.Id?.Length ?? 0,
+                        ipAddressPtr, user.IpAddress?.Length ?? 0);
+            }
         }
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -163,9 +163,11 @@ internal static partial class NativeBridge
             totalChars += kv.Key.Length + kv.Value.Length;
         }
 
-        Span<char> buffer = totalChars <= 512
-                ? stackalloc char[totalChars]
-                : new char[totalChars];
+        // Allocate at least one char so `fixed` produces a non-null pointer for empty pairs.
+        int bufferLen = Math.Max(totalChars, 1);
+        Span<char> buffer = bufferLen <= 512
+                ? stackalloc char[bufferLen]
+                : new char[bufferLen];
 
         int i = 0;
         int pos = 0;

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -153,16 +153,13 @@ internal static partial class NativeBridge
         }
 
         int pairCount = dict.Count;
-
         Span<int> lengthSpan = pairCount * 2 <= 256
                 ? stackalloc int[pairCount * 2]
                 : new int[pairCount * 2];
+
         int totalChars = 0;
-        int i = 0;
         foreach (var kv in dict)
         {
-            lengthSpan[i++] = kv.Key.Length;
-            lengthSpan[i++] = kv.Value.Length;
             totalChars += kv.Key.Length + kv.Value.Length;
         }
 
@@ -170,9 +167,12 @@ internal static partial class NativeBridge
                 ? stackalloc char[totalChars]
                 : new char[totalChars];
 
+        int i = 0;
         int pos = 0;
         foreach (var kv in dict)
         {
+            lengthSpan[i++] = kv.Key.Length;
+            lengthSpan[i++] = kv.Value.Length;
             kv.Key.AsSpan().CopyTo(buffer.Slice(pos));
             pos += kv.Key.Length;
             kv.Value.AsSpan().CopyTo(buffer.Slice(pos));

--- a/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.SourceGenerators/SentrySdkDelegationGenerator.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.SourceGenerators/SentrySdkDelegationGenerator.cs
@@ -13,45 +13,50 @@ namespace Sentry.Godot.SourceGenerators;
 public sealed class SentrySdkDelegationGenerator : IIncrementalGenerator
 {
     /// <summary>
-    /// Methods to skip — these have custom implementations in the hand-written partial class.
+    /// Names of public SDK members that are implemented manually in the partial class.
+    /// Use this list only when all overloads for a method name, or any property with the
+    /// same name, should be suppressed from generated forwarding wrappers.
     /// </summary>
-    private static readonly HashSet<string> SkipMethods =
+    private static readonly HashSet<string> HandWrittenMembers =
     [
         "Init",
         "Close"
     ];
 
+    /// <summary>
+    /// Method overloads that are implemented manually in the partial class.
+    /// </summary>
     /// <remarks>
-    /// Capture methods with <c>Action&lt;Scope&gt;</c> overloads clone the current scope and replay
-    /// scope mutations through the observer. These overloads are implemented by hand so the
-    /// observer can ignore local-scope changes.
+    /// Entries use <see cref="SignatureFormat"/> so only the listed overload is skipped;
+    /// new upstream overloads are still generated and reviewed via snapshot diffs.
+    /// See <c>SentrySdk.cs</c> for the implementations.
     /// </remarks>
-    private static readonly HashSet<string> LocalScopeCaptureMethods =
+    private static readonly HashSet<string> HandWrittenOverloads =
     [
-        "CaptureEvent",
-        "CaptureException",
-        "CaptureMessage",
-        "CaptureFeedback"
+        // Hand-written wrappers guard local scope changes from leaking into the native layer current scope.
+        "CaptureEvent(SentryEvent, Action<Scope>)",
+        "CaptureEvent(SentryEvent, SentryHint?, Action<Scope>)",
+        "CaptureException(Exception, Action<Scope>)",
+        "CaptureMessage(string, Action<Scope>, SentryLevel)",
+        "CaptureFeedback(SentryFeedback, Action<Scope>, SentryHint?)",
+        "CaptureFeedback(SentryFeedback, out CaptureFeedbackResult, Action<Scope>, SentryHint?)",
     ];
 
-    private static bool IsLocalScopeCapture(IMethodSymbol method)
-    {
-        if (!LocalScopeCaptureMethods.Contains(method.Name))
-        {
-            return false;
-        }
-        foreach (var p in method.Parameters)
-        {
-            if (p.Type is INamedTypeSymbol named &&
-                named.Name == "Action" &&
-                named.TypeArguments.Length == 1 &&
-                named.TypeArguments[0].ToDisplayString() == "Sentry.Scope")
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    private static readonly SymbolDisplayFormat SignatureFormat = new(
+        typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+        genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+        memberOptions: SymbolDisplayMemberOptions.IncludeParameters,
+        parameterOptions:
+            SymbolDisplayParameterOptions.IncludeType |
+            SymbolDisplayParameterOptions.IncludeParamsRefOut,
+        miscellaneousOptions:
+            SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+            SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
+    private static bool IsHandWritten(ISymbol member) =>
+        HandWrittenMembers.Contains(member.Name) ||
+        (member is IMethodSymbol method &&
+         HandWrittenOverloads.Contains(method.ToDisplayString(SignatureFormat)));
 
     private const string DiagnosticCategory = "Sentry.Godot.SourceGenerators";
 
@@ -138,7 +143,7 @@ public sealed class SentrySdkDelegationGenerator : IIncrementalGenerator
 
         foreach (var member in members)
         {
-            if (SkipMethods.Contains(member.Name))
+            if (IsHandWritten(member))
             {
                 continue;
             }
@@ -149,10 +154,6 @@ public sealed class SentrySdkDelegationGenerator : IIncrementalGenerator
                     GenerateProperty(sb, property, indent, "static ", "global::Sentry.SentrySdk", isTopLevel: true);
                     break;
                 case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
-                    if (IsLocalScopeCapture(method))
-                    {
-                        continue;
-                    }
                     GenerateMethod(sb, method, indent, "static ", "global::Sentry.SentrySdk");
                     break;
                 default:

--- a/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.SourceGenerators/SentrySdkDelegationGenerator.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Sentry.Godot.SourceGenerators/SentrySdkDelegationGenerator.cs
@@ -21,6 +21,38 @@ public sealed class SentrySdkDelegationGenerator : IIncrementalGenerator
         "Close"
     ];
 
+    /// <remarks>
+    /// Capture methods with <c>Action&lt;Scope&gt;</c> overloads clone the current scope and replay
+    /// scope mutations through the observer. These overloads are implemented by hand so the
+    /// observer can ignore local-scope changes.
+    /// </remarks>
+    private static readonly HashSet<string> LocalScopeCaptureMethods =
+    [
+        "CaptureEvent",
+        "CaptureException",
+        "CaptureMessage",
+        "CaptureFeedback"
+    ];
+
+    private static bool IsLocalScopeCapture(IMethodSymbol method)
+    {
+        if (!LocalScopeCaptureMethods.Contains(method.Name))
+        {
+            return false;
+        }
+        foreach (var p in method.Parameters)
+        {
+            if (p.Type is INamedTypeSymbol named &&
+                named.Name == "Action" &&
+                named.TypeArguments.Length == 1 &&
+                named.TypeArguments[0].ToDisplayString() == "Sentry.Scope")
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private const string DiagnosticCategory = "Sentry.Godot.SourceGenerators";
 
     private static readonly DiagnosticDescriptor UpstreamSdkNotFound = new(
@@ -117,6 +149,10 @@ public sealed class SentrySdkDelegationGenerator : IIncrementalGenerator
                     GenerateProperty(sb, property, indent, "static ", "global::Sentry.SentrySdk", isTopLevel: true);
                     break;
                 case IMethodSymbol method when method.MethodKind == MethodKind.Ordinary:
+                    if (IsLocalScopeCapture(method))
+                    {
+                        continue;
+                    }
                     GenerateMethod(sb, method, indent, "static ", "global::Sentry.SentrySdk");
                     break;
                 default:

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentryGodotOptions.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentryGodotOptions.cs
@@ -9,6 +9,8 @@ public sealed class SentryGodotOptions : SentryOptions
     public SentryGodotOptions()
     {
         IsGlobalModeEnabled = true;
+        EnableScopeSync = true;
+        ScopeObserver = new GodotScopeObserver();
         AddInAppExclude("Godot");
         AddIntegration(new GodotSdkIntegration());
     }

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Diagnostics;
 using Sentry.Godot.ExceptionHandling;
 using Sentry.Godot.Internal;
 using Sentry.Godot.Interop;
@@ -15,6 +17,16 @@ public static partial class SentrySdk
     // time.
     // Doesn't need locking, because the whole call chain runs on the same thread.
     static bool _initializing;
+
+    [ThreadStatic] private static bool _inLocalScope;
+    internal static bool InLocalScope => _inLocalScope;
+
+    private readonly struct LocalScopeGuard : IDisposable
+    {
+        private readonly bool _prev;
+        public LocalScopeGuard() { _prev = _inLocalScope; _inLocalScope = true; }
+        public void Dispose() => _inLocalScope = _prev;
+    }
 
     internal static SentryGodotOptions? CurrentOptions { get; private set; }
 
@@ -140,5 +152,50 @@ public static partial class SentrySdk
             _exceptionHandler = new LoggerExceptionHandler();
         }
         GodotLog.Debug(".NET first chance exception handler initialized.");
+    }
+
+    [DebuggerStepThrough]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureEvent(evt, configureScope);
+    }
+
+    [DebuggerStepThrough]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureEvent(evt, hint, configureScope);
+    }
+
+    [DebuggerStepThrough]
+    public static SentryId CaptureException(Exception exception, Action<Scope> configureScope)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureException(exception, configureScope);
+    }
+
+    [DebuggerStepThrough]
+    public static SentryId CaptureMessage(string message, Action<Scope> configureScope, SentryLevel level = SentryLevel.Info)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureMessage(message, configureScope, level);
+    }
+
+    [DebuggerStepThrough]
+    public static SentryId CaptureFeedback(SentryFeedback feedback, Action<Scope> configureScope, SentryHint? hint = null)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureFeedback(feedback, configureScope, hint);
+    }
+
+    [DebuggerStepThrough]
+    public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
+        Action<Scope> configureScope, SentryHint? hint = null)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureFeedback(feedback, out result, configureScope, hint);
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -154,6 +154,7 @@ public static partial class SentrySdk
         GodotLog.Debug(".NET first chance exception handler initialized.");
     }
 
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureEvent(Sentry.SentryEvent,System.Action{Sentry.Scope})"/>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static SentryId CaptureEvent(SentryEvent evt, Action<Scope> configureScope)
@@ -162,6 +163,7 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureEvent(evt, configureScope);
     }
 
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureEvent(Sentry.SentryEvent,Sentry.SentryHint,System.Action{Sentry.Scope})"/>
     [DebuggerStepThrough]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static SentryId CaptureEvent(SentryEvent evt, SentryHint? hint, Action<Scope> configureScope)
@@ -170,6 +172,7 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureEvent(evt, hint, configureScope);
     }
 
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureException(System.Exception,System.Action{Sentry.Scope})"/>
     [DebuggerStepThrough]
     public static SentryId CaptureException(Exception exception, Action<Scope> configureScope)
     {
@@ -177,13 +180,7 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureException(exception, configureScope);
     }
 
-    [DebuggerStepThrough]
-    public static SentryId CaptureMessage(string message, Action<Scope> configureScope, SentryLevel level = SentryLevel.Info)
-    {
-        using var _ = new LocalScopeGuard();
-        return Sentry.SentrySdk.CaptureMessage(message, configureScope, level);
-    }
-
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, Action<Scope> configureScope, SentryHint? hint = null)
     {
@@ -191,11 +188,20 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureFeedback(feedback, configureScope, hint);
     }
 
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,Sentry.CaptureFeedbackResult@,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
         Action<Scope> configureScope, SentryHint? hint = null)
     {
         using var _ = new LocalScopeGuard();
         return Sentry.SentrySdk.CaptureFeedback(feedback, out result, configureScope, hint);
+    }
+
+    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureMessage(System.String,System.Action{Sentry.Scope},Sentry.SentryLevel)"/>
+    [DebuggerStepThrough]
+    public static SentryId CaptureMessage(string message, Action<Scope> configureScope, SentryLevel level = SentryLevel.Info)
+    {
+        using var _ = new LocalScopeGuard();
+        return Sentry.SentrySdk.CaptureMessage(message, configureScope, level);
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -180,7 +180,7 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureException(exception, configureScope);
     }
 
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
+    /// <inheritdoc cref="M:Sentry.HubExtensions.CaptureFeedback(Sentry.IHub,Sentry.SentryFeedback,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, Action<Scope> configureScope, SentryHint? hint = null)
     {
@@ -188,7 +188,7 @@ public static partial class SentrySdk
         return Sentry.SentrySdk.CaptureFeedback(feedback, configureScope, hint);
     }
 
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,Sentry.CaptureFeedbackResult@,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
+    /// <inheritdoc cref="M:Sentry.IHub.CaptureFeedback(Sentry.SentryFeedback,Sentry.CaptureFeedbackResult@,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
     [DebuggerStepThrough]
     public static SentryId CaptureFeedback(SentryFeedback feedback, out CaptureFeedbackResult result,
         Action<Scope> configureScope, SentryHint? hint = null)

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -1,5 +1,8 @@
 using Godot;
 using System;
+using System.Collections.Generic;
+using Sentry;
+using Sentry.Godot;
 
 /// <summary>
 /// Helpers used by GDScript CLI commands to drive .NET integration tests.
@@ -35,6 +38,42 @@ public partial class DotnetCliTriggers : RefCounted
         Sentry.Godot.SentrySdk.SetTag("test.type", testType);
 
         Sentry.Godot.SentrySdk.AddBreadcrumb("Context configuration finished");
+    }
+
+    /// <summary>
+    /// Sets .NET-only scope items used by the cross-layer capture test to verify
+    /// that these items propagate to native events (tags, breadcrumbs, etc.).
+    /// </summary>
+    public void AddCrossLayerScopeSyncProbes()
+    {
+        SentrySdk.SetTag("dotnet.scope.synced", "from-dotnet");
+        SentrySdk.SetTag("dotnet.scope.removed", "should-not-appear");
+        SentrySdk.UnsetTag("dotnet.scope.removed");
+        SentrySdk.AddBreadcrumb("Synced from .NET");
+
+        // Breadcrumb with data exercises the ManagedStringMap marshalling path.
+        var data = new Dictionary<string, string>
+        {
+            ["http.url"] = "https://example.test/api/v1/probe",
+            ["http.status"] = "200",
+            ["unicode"] = "Hello 世界! 👋",
+        };
+        SentrySdk.AddBreadcrumb(
+            message: "Synced data breadcrumb from .NET",
+            category: "dotnet.probe",
+            type: "http",
+            data: data);
+
+        SentrySdk.ConfigureScope(scope =>
+        {
+            scope.User = new SentryUser
+            {
+                Id = "99999",
+                Username = "DotnetSyncedUser",
+                Email = "dotnet-synced@test.abc",
+                IpAddress = "1.2.3.4",
+            };
+        });
     }
 
     public string GetLastEventId()

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -75,12 +75,12 @@ public partial class DotnetCliTriggers : RefCounted
             };
         });
 
-        // Per-call scope mutations must NOT leak to the native current scope.
+        // Local scope mutations must NOT leak to the native current scope.
         // Verified by assertions in the cross-layer test.
-        SentrySdk.CaptureMessage("Per-call scope probe", scope =>
+        SentrySdk.CaptureMessage("Local scope probe", scope =>
         {
-            scope.SetTag("dotnet.per_call_scope.tag", "should_not_leak");
-            scope.AddBreadcrumb("Per-call leak breadcrumb");
+            scope.SetTag("dotnet.local_scope.tag", "should_not_leak");
+            scope.AddBreadcrumb("Local scope leak breadcrumb");
             scope.UnsetTag("dotnet.scope.synced");
             scope.User = new SentryUser
             {

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -74,6 +74,21 @@ public partial class DotnetCliTriggers : RefCounted
                 IpAddress = "1.2.3.4",
             };
         });
+
+        // Per-call scope mutations must NOT leak to the native current scope.
+        // Verified by assertions in the cross-layer test.
+        SentrySdk.CaptureMessage("Per-call scope probe", scope =>
+        {
+            scope.SetTag("dotnet.per_call_scope.tag", "should_not_leak");
+            scope.AddBreadcrumb("Per-call leak breadcrumb");
+            scope.UnsetTag("dotnet.scope.synced");
+            scope.User = new SentryUser
+            {
+                Id = "should_not_leak",
+                Username = "should_not_leak",
+                Email = "should_not_leak@test.abc",
+            };
+        });
     }
 
     public string GetLastEventId()

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -316,6 +316,7 @@ func _cmd_dotnet_cross_layer_capture() -> int:
 
 	_add_integration_test_context("dotnet-cross-layer-capture")
 	triggers.AddIntegrationTestContext("dotnet-cross-layer-capture")
+	triggers.AddCrossLayerScopeSyncProbes()
 
 	var native_event_id := SentrySDK.capture_message("Cross-layer capture - native side")
 	print("EVENT_CAPTURED: ", native_event_id)

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -337,7 +337,8 @@ CSHARP_EXPORT void csharp_interop_sdk_set_user(
 		const char16_t *email, int32_t email_len,
 		const char16_t *id, int32_t id_len,
 		const char16_t *ip_address, int32_t ip_address_len) {
-	Ref<SentryUser> user = SentryUser::create_default();
+	Ref<SentryUser> user;
+	user.instantiate();
 	user->set_username(String::utf16(username, username_len));
 	user->set_email(String::utf16(email, email_len));
 	user->set_id(String::utf16(id, id_len));

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -54,6 +54,9 @@ struct ManagedStringMap {
 // Decode a ManagedStringMap into a Godot Dictionary (String -> String).
 static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map) {
 	Dictionary dict;
+	if (map.pair_count <= 0 || map.buffer == nullptr || map.lengths == nullptr) {
+		return dict;
+	}
 	const char16_t *ptr = map.buffer;
 	for (int32_t i = 0; i < map.pair_count; i++) {
 		int32_t key_len = map.lengths[i * 2];

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -1,7 +1,9 @@
 #include "gen/sdk_version.gen.h"
 #include "sentry/environment.h"
 #include "sentry/logging/print.h"
+#include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_sdk.h"
+#include "sentry/sentry_user.h"
 
 #include <godot_cpp/classes/engine_debugger.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
@@ -37,6 +39,32 @@ CSHARP_EXPORT void csharp_interop_string_free(void *p_handle) {
 	if (p_handle) {
 		memdelete((String *)p_handle);
 	}
+}
+
+// Managed-owned string map for passing Dictionary<string, string> across P/Invoke.
+// C# builds and pins this; native reads it synchronously during the call.
+// Buffer layout: key1+val1+key2+val2... concatenated as UTF-16.
+// Lengths array: key1_len, val1_len, key2_len, val2_len, ... (2*pair_count entries).
+struct ManagedStringMap {
+	const char16_t *buffer;
+	const int32_t *lengths;
+	int32_t pair_count;
+};
+
+// Decode a ManagedStringMap into a Godot Dictionary (String -> String).
+static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map) {
+	Dictionary dict;
+	const char16_t *ptr = map.buffer;
+	for (int32_t i = 0; i < map.pair_count; i++) {
+		int32_t key_len = map.lengths[i * 2];
+		int32_t val_len = map.lengths[i * 2 + 1];
+		String key = String::utf16(ptr, key_len);
+		ptr += key_len;
+		String val = String::utf16(ptr, val_len);
+		ptr += val_len;
+		dict[key] = val;
+	}
+	return dict;
 }
 
 // Must match layout of LoggerLimitsData in NativeBridge.cs.
@@ -277,6 +305,48 @@ CSHARP_EXPORT void csharp_interop_sdk_init(ManagedOptions managed_opts) {
 
 CSHARP_EXPORT void csharp_interop_sdk_close() {
 	SentrySDK::get_singleton()->close();
+}
+
+CSHARP_EXPORT void csharp_interop_sdk_add_breadcrumb(
+		const char16_t *message, int32_t message_len,
+		const char16_t *category, int32_t category_len,
+		const char16_t *type, int32_t type_len,
+		int32_t level,
+		ManagedStringMap data) {
+	Ref<SentryBreadcrumb> crumb = SentryBreadcrumb::create(String::utf16(message, message_len));
+	crumb->set_category(String::utf16(category, category_len));
+	crumb->set_type(String::utf16(type, type_len));
+	crumb->set_level((Level)level);
+	crumb->set_data(_managed_string_map_to_dictionary(data));
+	SentrySDK::get_singleton()->add_breadcrumb(crumb);
+}
+
+CSHARP_EXPORT void csharp_interop_sdk_set_tag(const char16_t *key, int32_t key_len, const char16_t *value, int32_t value_len) {
+	String k = String::utf16(key, key_len);
+	String v = String::utf16(value, value_len);
+	SentrySDK::get_singleton()->set_tag(k, v);
+}
+
+CSHARP_EXPORT void csharp_interop_sdk_remove_tag(const char16_t *key, int key_len) {
+	String k = String::utf16(key, key_len);
+	SentrySDK::get_singleton()->remove_tag(k);
+}
+
+CSHARP_EXPORT void csharp_interop_sdk_set_user(
+		const char16_t *username, int32_t username_len,
+		const char16_t *email, int32_t email_len,
+		const char16_t *id, int32_t id_len,
+		const char16_t *ip_address, int32_t ip_address_len) {
+	Ref<SentryUser> user = SentryUser::create_default();
+	user->set_username(String::utf16(username, username_len));
+	user->set_email(String::utf16(email, email_len));
+	user->set_id(String::utf16(id, id_len));
+	user->set_ip_address(String::utf16(ip_address, ip_address_len));
+	SentrySDK::get_singleton()->set_user(user);
+}
+
+CSHARP_EXPORT void csharp_interop_sdk_remove_user() {
+	SentrySDK::get_singleton()->remove_user();
 }
 
 CSHARP_EXPORT const char *csharp_interop_get_sdk_version() {

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -330,7 +330,7 @@ CSHARP_EXPORT void csharp_interop_sdk_set_tag(const char16_t *key, int32_t key_l
 	SentrySDK::get_singleton()->set_tag(k, v);
 }
 
-CSHARP_EXPORT void csharp_interop_sdk_remove_tag(const char16_t *key, int key_len) {
+CSHARP_EXPORT void csharp_interop_sdk_remove_tag(const char16_t *key, int32_t key_len) {
 	String k = String::utf16(key, key_len);
 	SentrySDK::get_singleton()->remove_tag(k);
 }

--- a/tests/dotnet/Sentry.Godot.SourceGenerators.Tests/SentrySdkDelegationGeneratorTests.Run.verified.txt
+++ b/tests/dotnet/Sentry.Godot.SourceGenerators.Tests/SentrySdkDelegationGeneratorTests.Run.verified.txt
@@ -51,37 +51,10 @@ public static partial class SentrySdk
     public static global::Sentry.SentryId CaptureEvent(global::Sentry.SentryEvent evt, global::Sentry.Scope? scope = null, global::Sentry.SentryHint? hint = null)
         => global::Sentry.SentrySdk.CaptureEvent(evt, scope, hint);
 
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureEvent(Sentry.SentryEvent,System.Action{Sentry.Scope})"/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureEvent(global::Sentry.SentryEvent evt, global::System.Action<global::Sentry.Scope> configureScope)
-        => global::Sentry.SentrySdk.CaptureEvent(evt, configureScope);
-
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureEvent(Sentry.SentryEvent,Sentry.SentryHint,System.Action{Sentry.Scope})"/>
-    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureEvent(global::Sentry.SentryEvent evt, global::Sentry.SentryHint? hint, global::System.Action<global::Sentry.Scope> configureScope)
-        => global::Sentry.SentrySdk.CaptureEvent(evt, hint, configureScope);
-
     /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureException(System.Exception)"/>
     [DebuggerStepThrough]
     public static global::Sentry.SentryId CaptureException(global::System.Exception exception)
         => global::Sentry.SentrySdk.CaptureException(exception);
-
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureException(System.Exception,System.Action{Sentry.Scope})"/>
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureException(global::System.Exception exception, global::System.Action<global::Sentry.Scope> configureScope)
-        => global::Sentry.SentrySdk.CaptureException(exception, configureScope);
-
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureFeedback(global::Sentry.SentryFeedback feedback, global::System.Action<global::Sentry.Scope> configureScope, global::Sentry.SentryHint? hint = null)
-        => global::Sentry.SentrySdk.CaptureFeedback(feedback, configureScope, hint);
-
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,Sentry.CaptureFeedbackResult@,System.Action{Sentry.Scope},Sentry.SentryHint)"/>
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureFeedback(global::Sentry.SentryFeedback feedback, out global::Sentry.CaptureFeedbackResult result, global::System.Action<global::Sentry.Scope> configureScope, global::Sentry.SentryHint? hint = null)
-        => global::Sentry.SentrySdk.CaptureFeedback(feedback, out result, configureScope, hint);
 
     /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureFeedback(Sentry.SentryFeedback,Sentry.Scope,Sentry.SentryHint)"/>
     [DebuggerStepThrough]
@@ -102,11 +75,6 @@ public static partial class SentrySdk
     [DebuggerStepThrough]
     public static global::Sentry.SentryId CaptureMessage(string message, global::Sentry.SentryLevel level = global::Sentry.SentryLevel.Info)
         => global::Sentry.SentrySdk.CaptureMessage(message, level);
-
-    /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureMessage(System.String,System.Action{Sentry.Scope},Sentry.SentryLevel)"/>
-    [DebuggerStepThrough]
-    public static global::Sentry.SentryId CaptureMessage(string message, global::System.Action<global::Sentry.Scope> configureScope, global::Sentry.SentryLevel level = global::Sentry.SentryLevel.Info)
-        => global::Sentry.SentrySdk.CaptureMessage(message, configureScope, level);
 
     /// <inheritdoc cref="M:Sentry.SentrySdk.CaptureSession(Sentry.SessionUpdate)"/>
     [DebuggerStepThrough]

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -380,5 +380,37 @@ options/debug_printing=0
         It "Native and managed events share the same trace_id" {
             $nativeEvent.contexts.trace.trace_id | Should -Be $managedEvent.contexts.trace.trace_id
         }
+
+        It "Native event contains tag set from .NET" {
+            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.scope.synced" }).value | Should -Be "from-dotnet"
+        }
+
+        It "Native event omits tag removed from .NET" {
+            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.scope.removed" }) | Should -BeNullOrEmpty
+        }
+
+        It "Native event includes breadcrumb added from .NET" {
+            $nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from .NET" } | Should -Not -BeNullOrEmpty
+        }
+
+        It "Native event contains user context set from .NET" {
+            $nativeEvent.user | Should -Not -BeNullOrEmpty
+            $nativeEvent.user.id | Should -Be "99999"
+            $nativeEvent.user.username | Should -Be "DotnetSyncedUser"
+            $nativeEvent.user.email | Should -Be "dotnet-synced@test.abc"
+            $nativeEvent.user.ip_address | Should -Be "1.2.3.4"
+        }
+
+        It "Native event includes breadcrumb data marshalled from .NET" {
+            $crumbs = @($nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced data breadcrumb from .NET" })
+            $crumbs | Should -HaveCount 1
+            $crumb = $crumbs[0]
+            $crumb.category | Should -Be "dotnet.probe"
+            $crumb.type | Should -Be "http"
+            $crumb.data | Should -Not -BeNullOrEmpty
+            $crumb.data."http.url" | Should -Be "https://example.test/api/v1/probe"
+            $crumb.data."http.status" | Should -Be "200"
+            $crumb.data."unicode" | Should -Be "Hello 世界! 👋"
+        }
     }
 }

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -413,24 +413,24 @@ options/debug_printing=0
             $crumb.data."unicode" | Should -Be "Hello 世界! 👋"
         }
 
-        It "Managed event omits tag set in per-call scope callback" {
+        It "Managed event omits tag set in local scope callback" {
             # Sanity check: upstream CaptureEvent clones the current scope and discards it.
-            ($managedEvent.tags | Where-Object { $_.key -eq "dotnet.per_call_scope.tag" }) | Should -BeNullOrEmpty
+            ($managedEvent.tags | Where-Object { $_.key -eq "dotnet.local_scope.tag" }) | Should -BeNullOrEmpty
         }
 
-        It "Native event omits tag set in per-call scope callback" {
-            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.per_call_scope.tag" }) | Should -BeNullOrEmpty
+        It "Native event omits tag set in local scope callback" {
+            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.local_scope.tag" }) | Should -BeNullOrEmpty
         }
 
-        It "Native event omits breadcrumb added in per-call scope callback" {
-            $nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Per-call leak breadcrumb" } | Should -BeNullOrEmpty
+        It "Native event omits breadcrumb added in local scope callback" {
+            $nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Local scope leak breadcrumb" } | Should -BeNullOrEmpty
         }
 
-        It "Native event preserves tag despite UnsetTag in per-call scope callback" {
+        It "Native event preserves tag despite UnsetTag in local scope callback" {
             ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.scope.synced" }).value | Should -Be "from-dotnet"
         }
 
-        It "Native event preserves user despite SetUser in per-call scope callback" {
+        It "Native event preserves user despite SetUser in local scope callback" {
             $nativeEvent.user.id | Should -Be "99999"
             $nativeEvent.user.username | Should -Be "DotnetSyncedUser"
             $nativeEvent.user.email | Should -Be "dotnet-synced@test.abc"

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -412,5 +412,28 @@ options/debug_printing=0
             $crumb.data."http.status" | Should -Be "200"
             $crumb.data."unicode" | Should -Be "Hello 世界! 👋"
         }
+
+        It "Managed event omits tag set in per-call scope callback" {
+            # Sanity check: upstream CaptureEvent clones the current scope and discards it.
+            ($managedEvent.tags | Where-Object { $_.key -eq "dotnet.per_call_scope.tag" }) | Should -BeNullOrEmpty
+        }
+
+        It "Native event omits tag set in per-call scope callback" {
+            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.per_call_scope.tag" }) | Should -BeNullOrEmpty
+        }
+
+        It "Native event omits breadcrumb added in per-call scope callback" {
+            $nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Per-call leak breadcrumb" } | Should -BeNullOrEmpty
+        }
+
+        It "Native event preserves tag despite UnsetTag in per-call scope callback" {
+            ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.scope.synced" }).value | Should -Be "from-dotnet"
+        }
+
+        It "Native event preserves user despite SetUser in per-call scope callback" {
+            $nativeEvent.user.id | Should -Be "99999"
+            $nativeEvent.user.username | Should -Be "DotnetSyncedUser"
+            $nativeEvent.user.email | Should -Be "dotnet-synced@test.abc"
+        }
     }
 }


### PR DESCRIPTION
Syncs scope mutations made via .NET's `SentrySdk` with the native layer. After this PR: breadcrumbs, tags and user changes made in C# also appear on native events. Attachments I want to address in a follow-up.

- Depends on #700 
- Refs #650
