### PR TITLE
chore(dotnet): Disable session auto tracking in .NET

### DIFF
--- a/project/addons/sentry/dotnet/Sentry.Godot/SentryGodotOptions.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentryGodotOptions.cs
@@ -9,6 +9,10 @@ public sealed class SentryGodotOptions : SentryOptions
     public SentryGodotOptions()
     {
         IsGlobalModeEnabled = true;
+
+        // Native layer owns sessions; .NET-side tracking would double-count.
+        AutoSessionTracking = false;
+
         AddInAppExclude("Godot");
         AddIntegration(new GodotSdkIntegration());
     }


### PR DESCRIPTION
Disables session auto tracking in .NET to avoid double-counting. Native layer will handle this.