### PR TITLE
feat(dotnet): Sync scope changes from native to .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
   - Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
-  - Sync breadcrumbs, tags and user changes from .NET layer to native layer ([#701](https://github.com/getsentry/sentry-godot/pull/701))
+  - Sync breadcrumbs, tags and user changes between .NET and native layers ([#701](https://github.com/getsentry/sentry-godot/pull/701), [#710](https://github.com/getsentry/sentry-godot/pull/710))
 
 ### Fixes
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/LoggerExceptionHandler.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/ExceptionHandling/LoggerExceptionHandler.cs
@@ -30,7 +30,7 @@ internal class LoggerExceptionHandler : IDisposable
     public LoggerExceptionHandler()
     {
         AppDomain.CurrentDomain.FirstChanceException += OnFirstChanceException;
-        NativeBridge.RegisterLoggerErrorHandler(OnLogError);
+        NativeBridge.SetLoggerErrorHandler(OnLogError);
         GodotLog.Debug("Registered Logger-based exception handler.");
     }
 
@@ -80,6 +80,6 @@ internal class LoggerExceptionHandler : IDisposable
     public void Dispose()
     {
         AppDomain.CurrentDomain.FirstChanceException -= OnFirstChanceException;
-        NativeBridge.UnregisterLoggerErrorHandler();
+        NativeBridge.ClearLoggerErrorHandler();
     }
 }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Internal/SentryGodotInitializer.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Internal/SentryGodotInitializer.cs
@@ -18,7 +18,7 @@ public static class SentryGodotInitializer
             return;
         }
 
-        NativeBridge.RegisterDotnetInit();
+        NativeBridge.RegisterManagedFunctions();
         if (NativeBridge.IsEnabled())
         {
             GodotLog.Debug("Native is already initialized, proceeding with .NET initialization.");

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/GodotScopeObserver.cs
@@ -12,23 +12,24 @@ namespace Sentry.Godot.Interop;
 internal class GodotScopeObserver : IScopeObserver
 {
     // Prevent feedback loops when syncing scope changes across layers.
-    [ThreadStatic] private static bool _syncing;
+    // Incremented here for outbound updates and by native callers in NativeBridge for inbound updates.
+    [ThreadStatic] private static uint _syncDepth;
+    internal static bool IsSyncing => _syncDepth > 0;
+
+    internal readonly struct SyncGuard : IDisposable
+    {
+        public SyncGuard() { ++_syncDepth; }
+        public void Dispose() => --_syncDepth;
+    }
 
     public void AddBreadcrumb(Breadcrumb breadcrumb)
     {
-        if (_syncing || SentrySdk.InLocalScope)
+        if (IsSyncing || SentrySdk.InLocalScope)
         {
             return;
         }
-        _syncing = true;
-        try
-        {
-            NativeBridge.AddBreadcrumb(breadcrumb);
-        }
-        finally
-        {
-            _syncing = false;
-        }
+        using var _ = new SyncGuard();
+        NativeBridge.AddBreadcrumb(breadcrumb);
     }
 
     public void SetExtra(string key, object? value)
@@ -38,53 +39,32 @@ internal class GodotScopeObserver : IScopeObserver
 
     public void SetTag(string key, string value)
     {
-        if (_syncing || SentrySdk.InLocalScope)
+        if (IsSyncing || SentrySdk.InLocalScope)
         {
             return;
         }
-        _syncing = true;
-        try
-        {
-            NativeBridge.SetTag(key, value);
-        }
-        finally
-        {
-            _syncing = false;
-        }
+        using var _ = new SyncGuard();
+        NativeBridge.SetTag(key, value);
     }
 
     public void UnsetTag(string key)
     {
-        if (_syncing || SentrySdk.InLocalScope)
+        if (IsSyncing || SentrySdk.InLocalScope)
         {
             return;
         }
-        _syncing = true;
-        try
-        {
-            NativeBridge.RemoveTag(key);
-        }
-        finally
-        {
-            _syncing = false;
-        }
+        using var _ = new SyncGuard();
+        NativeBridge.RemoveTag(key);
     }
 
     public void SetUser(SentryUser? user)
     {
-        if (_syncing || SentrySdk.InLocalScope)
+        if (IsSyncing || SentrySdk.InLocalScope)
         {
             return;
         }
-        _syncing = true;
-        try
-        {
-            NativeBridge.SetUser(user);
-        }
-        finally
-        {
-            _syncing = false;
-        }
+        using var _ = new SyncGuard();
+        NativeBridge.SetUser(user);
     }
 
     public void SetTrace(SentryId traceId, SpanId parentSpanId)

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -203,6 +203,8 @@ internal static partial class NativeBridge
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, int, void> add_breadcrumb;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> set_tag;
         public delegate* unmanaged[Cdecl]<char*, int, void> remove_tag;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, char*, int, void> set_user;
+        public delegate* unmanaged[Cdecl]<void> remove_user;
     }
 
     [LibraryImport(Lib)]
@@ -221,6 +223,8 @@ internal static partial class NativeBridge
             add_breadcrumb = &AddBreadcrumbCallback,
             set_tag = &SetTagCallback,
             remove_tag = &RemoveTagCallback,
+            set_user = &SetUserCallback,
+            remove_user = &RemoveUserCallback,
         });
     }
 
@@ -299,14 +303,70 @@ internal static partial class NativeBridge
         char* key, int keyLen,
         char* value, int valueLen)
     {
-        Sentry.Godot.SentrySdk.SetTag(new string(key, 0, keyLen), new string(value, 0, valueLen));
+        try
+        {
+            Sentry.Godot.SentrySdk.SetTag(new string(key, 0, keyLen), new string(value, 0, valueLen));
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward set_tag to Sentry .NET layer: {ex}");
+        }
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
     private static unsafe void RemoveTagCallback(
         char* key, int keyLen)
     {
-        Sentry.Godot.SentrySdk.UnsetTag(new string(key, 0, keyLen));
+        try
+        {
+            Sentry.Godot.SentrySdk.UnsetTag(new string(key, 0, keyLen));
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward remove_tag to Sentry .NET layer: {ex}");
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void SetUserCallback(
+        char* id, int idLen,
+        char* username, int usernameLen,
+        char* email, int emailLen,
+        char* ip, int ipLen)
+    {
+        try
+        {
+            Sentry.Godot.SentrySdk.ConfigureScope(scope =>
+            {
+                scope.User = new Sentry.SentryUser
+                {
+                    Id = new string(id, 0, idLen),
+                    Username = new string(username, 0, usernameLen),
+                    Email = new string(email, 0, emailLen),
+                    IpAddress = new string(ip, 0, ipLen)
+                };
+            });
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward set_user to Sentry .NET layer: {ex}");
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void RemoveUserCallback()
+    {
+        try
+        {
+            Sentry.Godot.SentrySdk.ConfigureScope(scope =>
+            {
+                scope.User = new Sentry.SentryUser();
+            });
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward remove_user to Sentry .NET layer: {ex}");
+        }
     }
 
     [LibraryImport(Lib)]
@@ -575,7 +635,7 @@ internal static partial class NativeBridge
 
     [LibraryImport(Lib)]
     private static unsafe partial void csharp_interop_sdk_set_user(
-            char* username, int usernameLen, char* email, int emailLen, char* id, int idLen, char* ipAddress, int ipAddressLen);
+            char* id, int idLen, char* username, int usernameLen, char* email, int emailLen, char* ipAddress, int ipAddressLen);
 
     public static unsafe void SetUser(SentryUser? user)
     {
@@ -596,9 +656,9 @@ internal static partial class NativeBridge
             fixed (char* ipAddressPtr = ipAddress)
             {
                 csharp_interop_sdk_set_user(
+                        idPtr, id.Length,
                         usernamePtr, username.Length,
                         emailPtr, email.Length,
-                        idPtr, id.Length,
                         ipAddressPtr, ipAddress.Length);
             }
         }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -200,7 +200,9 @@ internal static partial class NativeBridge
     {
         public delegate* unmanaged[Cdecl]<void> init;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> logger_error;
-        public delegate* unmanaged[Cdecl]<char*, int, char*, int, int, char*, int, void> add_breadcrumb;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, int, void> add_breadcrumb;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> set_tag;
+        public delegate* unmanaged[Cdecl]<char*, int, void> remove_tag;
     }
 
     [LibraryImport(Lib)]
@@ -217,6 +219,8 @@ internal static partial class NativeBridge
             init = &DotnetInitCallback,
             logger_error = &LoggerErrorCallback,
             add_breadcrumb = &AddBreadcrumbCallback,
+            set_tag = &SetTagCallback,
+            remove_tag = &RemoveTagCallback,
         });
     }
 
@@ -264,13 +268,13 @@ internal static partial class NativeBridge
     private static unsafe void AddBreadcrumbCallback(
         char* message, int messageLen,
         char* category, int categoryLen,
-        int level,
-        char* type, int typeLen
+        char* type, int typeLen,
+        int level
     )
     {
         try
         {
-            SentrySdk.AddBreadcrumb(
+            Sentry.Godot.SentrySdk.AddBreadcrumb(
                 message: new string(message, 0, messageLen),
                 category: new string(category, 0, categoryLen),
                 level: level switch
@@ -288,6 +292,21 @@ internal static partial class NativeBridge
         {
             GodotLog.Error($"Failed to forward breadcrumb to Sentry .NET layer: {ex}");
         }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void SetTagCallback(
+        char* key, int keyLen,
+        char* value, int valueLen)
+    {
+        Sentry.Godot.SentrySdk.SetTag(new string(key, 0, keyLen), new string(value, 0, valueLen));
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void RemoveTagCallback(
+        char* key, int keyLen)
+    {
+        Sentry.Godot.SentrySdk.UnsetTag(new string(key, 0, keyLen));
     }
 
     [LibraryImport(Lib)]

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -278,6 +278,7 @@ internal static partial class NativeBridge
     {
         try
         {
+            using var _ = new GodotScopeObserver.SyncGuard();
             Sentry.Godot.SentrySdk.AddBreadcrumb(
                 message: new string(message, 0, messageLen),
                 category: new string(category, 0, categoryLen),
@@ -305,6 +306,7 @@ internal static partial class NativeBridge
     {
         try
         {
+            using var _ = new GodotScopeObserver.SyncGuard();
             Sentry.Godot.SentrySdk.SetTag(new string(key, 0, keyLen), new string(value, 0, valueLen));
         }
         catch (Exception ex)
@@ -319,6 +321,7 @@ internal static partial class NativeBridge
     {
         try
         {
+            using var _ = new GodotScopeObserver.SyncGuard();
             Sentry.Godot.SentrySdk.UnsetTag(new string(key, 0, keyLen));
         }
         catch (Exception ex)
@@ -336,6 +339,7 @@ internal static partial class NativeBridge
     {
         try
         {
+            using var _ = new GodotScopeObserver.SyncGuard();
             Sentry.Godot.SentrySdk.ConfigureScope(scope =>
             {
                 scope.User = new Sentry.SentryUser
@@ -358,6 +362,7 @@ internal static partial class NativeBridge
     {
         try
         {
+            using var _ = new GodotScopeObserver.SyncGuard();
             Sentry.Godot.SentrySdk.ConfigureScope(scope =>
             {
                 scope.User = new Sentry.SentryUser();

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -258,12 +258,12 @@ internal static partial class NativeBridge
         }
     }
 
-    public static unsafe void RegisterLoggerErrorHandler(Action<string, string> handler)
+    public static unsafe void SetLoggerErrorHandler(Action<string, string> handler)
     {
         _loggerErrorHandler = handler;
     }
 
-    public static unsafe void UnregisterLoggerErrorHandler()
+    public static unsafe void ClearLoggerErrorHandler()
     {
         _loggerErrorHandler = null;
     }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -340,10 +340,10 @@ internal static partial class NativeBridge
             {
                 scope.User = new Sentry.SentryUser
                 {
-                    Id = new string(id, 0, idLen),
-                    Username = new string(username, 0, usernameLen),
-                    Email = new string(email, 0, emailLen),
-                    IpAddress = new string(ip, 0, ipLen)
+                    Id = idLen > 0 ? new string(id, 0, idLen) : null,
+                    Username = usernameLen > 0 ? new string(username, 0, usernameLen) : null,
+                    Email = emailLen > 0 ? new string(email, 0, emailLen) : null,
+                    IpAddress = ipLen > 0 ? new string(ip, 0, ipLen) : null,
                 };
             });
         }

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -194,6 +194,102 @@ internal static partial class NativeBridge
         }
     }
 
+    // Must match ManagedFunctions struct in csharp_interop.cpp
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct ManagedFunctions
+    {
+        public delegate* unmanaged[Cdecl]<void> init;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> logger_error;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, int, char*, int, void> add_breadcrumb;
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_register_managed_functions(
+        ManagedFunctions functions);
+
+    /// <summary>
+    /// Registers managed functions that are called from native layer.
+    /// </summary>
+    public static unsafe void RegisterManagedFunctions()
+    {
+        csharp_interop_register_managed_functions(new ManagedFunctions
+        {
+            init = &DotnetInitCallback,
+            logger_error = &LoggerErrorCallback,
+            add_breadcrumb = &AddBreadcrumbCallback,
+        });
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static void DotnetInitCallback()
+    {
+        try
+        {
+            SentrySdk.InitFromNative();
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to initialize Sentry .NET layer: {ex}");
+        }
+    }
+
+    private static Action<string, string>? _loggerErrorHandler;
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void LoggerErrorCallback(char* code, int codeLen, char* file, int fileLen)
+    {
+        try
+        {
+            _loggerErrorHandler?.Invoke(
+                    new string(file, 0, fileLen),
+                    new string(code, 0, codeLen));
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward Godot logger error to Sentry .NET layer: {ex}");
+        }
+    }
+
+    public static unsafe void RegisterLoggerErrorHandler(Action<string, string> handler)
+    {
+        _loggerErrorHandler = handler;
+    }
+
+    public static unsafe void UnregisterLoggerErrorHandler()
+    {
+        _loggerErrorHandler = null;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void AddBreadcrumbCallback(
+        char* message, int messageLen,
+        char* category, int categoryLen,
+        int level,
+        char* type, int typeLen
+    )
+    {
+        try
+        {
+            SentrySdk.AddBreadcrumb(
+                message: new string(message, 0, messageLen),
+                category: new string(category, 0, categoryLen),
+                level: level switch
+                {
+                    0 => BreadcrumbLevel.Debug,
+                    1 => BreadcrumbLevel.Info,
+                    2 => BreadcrumbLevel.Warning,
+                    3 => BreadcrumbLevel.Error,
+                    4 => BreadcrumbLevel.Fatal,
+                    _ => BreadcrumbLevel.Info,
+                },
+                type: new string(type, 0, typeLen));
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward breadcrumb to Sentry .NET layer: {ex}");
+        }
+    }
+
     [LibraryImport(Lib)]
     private static unsafe partial NativeOptions csharp_interop_get_options();
 
@@ -243,62 +339,6 @@ internal static partial class NativeBridge
     public static void ApplyNativeOptionsDefaults(SentryGodotOptions opts)
     {
         ApplyNativeOptions(csharp_interop_get_options_defaults(), opts);
-    }
-
-    [LibraryImport(Lib)]
-    private static unsafe partial void csharp_interop_register_dotnet_init(
-            delegate* unmanaged[Cdecl]<void> fn);
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static void DotnetInitCallback()
-    {
-        try
-        {
-            SentrySdk.InitFromNative();
-        }
-        catch (Exception ex)
-        {
-            GodotLog.Error($"Failed to initialize Sentry .NET layer: {ex}");
-        }
-    }
-
-    public static unsafe void RegisterDotnetInit()
-    {
-        csharp_interop_register_dotnet_init(&DotnetInitCallback);
-        GodotLog.Debug(".NET layer is ready for SDK init.");
-    }
-
-    [LibraryImport(Lib)]
-    private static unsafe partial void csharp_interop_register_logger_error_handler(
-            delegate* unmanaged[Cdecl]<char*, int, char*, int, void> fn);
-
-    private static Action<string, string>? _loggerErrorHandler;
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static unsafe void LoggerErrorCallback(char* code, int codeLen, char* file, int fileLen)
-    {
-        try
-        {
-            _loggerErrorHandler?.Invoke(
-                    new string(file, 0, fileLen),
-                    new string(code, 0, codeLen));
-        }
-        catch (Exception ex)
-        {
-            GodotLog.Error($"Failed to forward Godot logger error to Sentry .NET layer: {ex}");
-        }
-    }
-
-    public static unsafe void RegisterLoggerErrorHandler(Action<string, string> handler)
-    {
-        _loggerErrorHandler = handler;
-        csharp_interop_register_logger_error_handler(&LoggerErrorCallback);
-    }
-
-    public static unsafe void UnregisterLoggerErrorHandler()
-    {
-        csharp_interop_register_logger_error_handler(null);
-        _loggerErrorHandler = null;
     }
 
     [LibraryImport(Lib)]

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -321,11 +321,29 @@ func _cmd_dotnet_cross_layer_capture() -> int:
 	var native_event_id := SentrySDK.capture_message("Cross-layer capture - native side")
 	print("EVENT_CAPTURED: ", native_event_id)
 
+	_add_native_cross_layer_scope_sync_probes()
+
 	var managed_event_id: String = triggers.CaptureMessage("Cross-layer capture - .NET side")
 	print("EVENT_CAPTURED: ", managed_event_id)
 
 	_print_test_result("dotnet-cross-layer-capture", true, "Test complete")
 	return 0
+
+
+## Sets native-only scope items used by the cross-layer capture test to verify
+## that these items propagate to managed events (tags, breadcrumbs, user).
+func _add_native_cross_layer_scope_sync_probes() -> void:
+	SentrySDK.set_tag("native.scope.synced", "from-native")
+	SentrySDK.set_tag("native.scope.removed", "should-not-appear")
+	SentrySDK.remove_tag("native.scope.removed")
+	SentrySDK.add_breadcrumb(SentryBreadcrumb.create("Synced from native"))
+
+	var user := SentryUser.create_default()
+	user.id = "88888"
+	user.username = "NativeSyncedUser"
+	user.email = "native-synced@test.abc"
+	user.ip_address = "5.6.7.8"
+	SentrySDK.set_user(user)
 
 
 ## Runs a .NET exception trigger with the chosen init driver.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -91,7 +91,7 @@ void register_runtime_classes() {
 	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);
 	GDREGISTER_INTERNAL_CLASS(ViewHierarchyProcessor);
 	GDREGISTER_INTERNAL_CLASS(logging::SentryGodotLogger);
-	GDREGISTER_ABSTRACT_CLASS(SentryScopeObserver);
+	GDREGISTER_INTERNAL_CLASS(SentryScopeObserver);
 	GDREGISTER_INTERNAL_CLASS(sentry::dotnet::DotnetScopeObserver);
 
 #ifdef SDK_NATIVE

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,5 +1,6 @@
 #include "editor/sentry_editor_plugin.h"
 #include "sentry/disabled/disabled_event.h"
+#include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/logging/sentry_godot_logger.h"
 #include "sentry/processing/screenshot_processor.h"
 #include "sentry/processing/sentry_event_processor.h"
@@ -14,6 +15,7 @@
 #include "sentry/sentry_metric.h"
 #include "sentry/sentry_metrics.h"
 #include "sentry/sentry_options.h"
+#include "sentry/sentry_scope_observer.h"
 #include "sentry/sentry_sdk.h"
 #include "sentry/sentry_unit.h"
 #include "sentry/sentry_user.h"
@@ -89,6 +91,8 @@ void register_runtime_classes() {
 	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);
 	GDREGISTER_INTERNAL_CLASS(ViewHierarchyProcessor);
 	GDREGISTER_INTERNAL_CLASS(logging::SentryGodotLogger);
+	GDREGISTER_ABSTRACT_CLASS(SentryScopeObserver);
+	GDREGISTER_INTERNAL_CLASS(sentry::dotnet::DotnetScopeObserver);
 
 #ifdef SDK_NATIVE
 	GDREGISTER_INTERNAL_CLASS(native::NativeEvent);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -401,12 +401,12 @@ void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	if (s_managed_funcs.add_breadcrumb) {
 		Char16String message_utf16 = p_breadcrumb->get_message().utf16();
 		Char16String category_utf16 = p_breadcrumb->get_category().utf16();
-		Char16String type = p_breadcrumb->get_type().utf16();
+		Char16String type_utf16 = p_breadcrumb->get_type().utf16();
 		// TODO: SentryBreadcrumb::get_data() is not implemented
 		s_managed_funcs.add_breadcrumb(
 				message_utf16.get_data(), message_utf16.length(),
 				category_utf16.get_data(), category_utf16.length(),
-				type.get_data(), type.length(),
+				type_utf16.get_data(), type_utf16.length(),
 				static_cast<int32_t>(p_breadcrumb->get_level()));
 	}
 }

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -75,6 +75,8 @@ struct ManagedFunctions {
 	void (*add_breadcrumb)(const char16_t *message, int32_t message_len, const char16_t *category, int32_t category_len, const char16_t *type, int32_t type_len, int32_t level);
 	void (*set_tag)(const char16_t *name, int32_t name_len, const char16_t *value, int32_t value_len);
 	void (*remove_tag)(const char16_t *name, int32_t name_len);
+	void (*set_user)(const char16_t *id, int32_t id_len, const char16_t *username, int32_t username_len, const char16_t *email, int32_t email_len, const char16_t *ip, int32_t ip_len);
+	void (*remove_user)();
 };
 
 static ManagedFunctions s_managed_funcs = {};
@@ -340,15 +342,15 @@ CSHARP_EXPORT void csharp_interop_sdk_remove_tag(const char16_t *key, int32_t ke
 }
 
 CSHARP_EXPORT void csharp_interop_sdk_set_user(
+		const char16_t *id, int32_t id_len,
 		const char16_t *username, int32_t username_len,
 		const char16_t *email, int32_t email_len,
-		const char16_t *id, int32_t id_len,
 		const char16_t *ip_address, int32_t ip_address_len) {
 	Ref<SentryUser> user;
 	user.instantiate();
+	user->set_id(String::utf16(id, id_len));
 	user->set_username(String::utf16(username, username_len));
 	user->set_email(String::utf16(email, email_len));
-	user->set_id(String::utf16(id, id_len));
 	user->set_ip_address(String::utf16(ip_address, ip_address_len));
 	SentrySDK::get_singleton()->set_user(user);
 }
@@ -418,6 +420,27 @@ void remove_tag(const String &p_key) {
 		Char16String key_utf16 = p_key.utf16();
 		s_managed_funcs.remove_tag(
 				key_utf16.get_data(), key_utf16.length());
+	}
+}
+
+void set_user(const Ref<SentryUser> &p_user) {
+	if (s_managed_funcs.set_user) {
+		Char16String id_utf16 = p_user->get_id().utf16();
+		Char16String username_utf16 = p_user->get_username().utf16();
+		Char16String email_utf16 = p_user->get_email().utf16();
+		Char16String ip_utf16 = p_user->get_ip_address().utf16();
+
+		s_managed_funcs.set_user(
+				id_utf16.get_data(), id_utf16.length(),
+				username_utf16.get_data(), username_utf16.length(),
+				email_utf16.get_data(), email_utf16.length(),
+				ip_utf16.get_data(), ip_utf16.length());
+	}
+}
+
+void remove_user() {
+	if (s_managed_funcs.remove_user) {
+		s_managed_funcs.remove_user();
 	}
 }
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -1,4 +1,5 @@
 #include "gen/sdk_version.gen.h"
+#include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/environment.h"
 #include "sentry/logging/print.h"
 #include "sentry/sentry_breadcrumb.h"
@@ -322,6 +323,7 @@ CSHARP_EXPORT void csharp_interop_sdk_add_breadcrumb(
 		const char16_t *type, int32_t type_len,
 		int32_t level,
 		ManagedStringMap data) {
+	sentry::dotnet::DotnetScopeObserver::SyncGuard guard;
 	Ref<SentryBreadcrumb> crumb = SentryBreadcrumb::create(String::utf16(message, message_len));
 	crumb->set_category(String::utf16(category, category_len));
 	crumb->set_type(String::utf16(type, type_len));
@@ -331,12 +333,14 @@ CSHARP_EXPORT void csharp_interop_sdk_add_breadcrumb(
 }
 
 CSHARP_EXPORT void csharp_interop_sdk_set_tag(const char16_t *key, int32_t key_len, const char16_t *value, int32_t value_len) {
+	sentry::dotnet::DotnetScopeObserver::SyncGuard guard;
 	String k = String::utf16(key, key_len);
 	String v = String::utf16(value, value_len);
 	SentrySDK::get_singleton()->set_tag(k, v);
 }
 
 CSHARP_EXPORT void csharp_interop_sdk_remove_tag(const char16_t *key, int32_t key_len) {
+	sentry::dotnet::DotnetScopeObserver::SyncGuard guard;
 	String k = String::utf16(key, key_len);
 	SentrySDK::get_singleton()->remove_tag(k);
 }
@@ -346,6 +350,7 @@ CSHARP_EXPORT void csharp_interop_sdk_set_user(
 		const char16_t *username, int32_t username_len,
 		const char16_t *email, int32_t email_len,
 		const char16_t *ip_address, int32_t ip_address_len) {
+	sentry::dotnet::DotnetScopeObserver::SyncGuard guard;
 	Ref<SentryUser> user;
 	user.instantiate();
 	user->set_id(String::utf16(id, id_len));
@@ -356,6 +361,7 @@ CSHARP_EXPORT void csharp_interop_sdk_set_user(
 }
 
 CSHARP_EXPORT void csharp_interop_sdk_remove_user() {
+	sentry::dotnet::DotnetScopeObserver::SyncGuard guard;
 	SentrySDK::get_singleton()->remove_user();
 }
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -16,9 +16,6 @@
 
 using namespace sentry;
 
-static void (*s_dotnet_init_fn)() = nullptr;
-static void (*s_dotnet_logger_error_fn)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len) = nullptr;
-
 extern "C" {
 
 // Native-owned string handle for passing Godot Strings across the interop boundary.
@@ -69,6 +66,16 @@ static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map)
 	}
 	return dict;
 }
+
+// Managed functions that are called from native layer.
+// Must match ManagedFunctions struct in NativeBridge.cs.
+struct ManagedFunctions {
+	void (*init)();
+	void (*logger_error)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len);
+	void (*add_breadcrumb)(const char16_t *message, int32_t message_len, const char16_t *category, int32_t category_len, int32_t level, const char16_t *type, int32_t type_len);
+};
+
+static ManagedFunctions s_managed_funcs = {};
 
 // Must match layout of LoggerLimitsData in NativeBridge.cs.
 struct LoggerLimitsData {
@@ -235,6 +242,10 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 
 // *** Functions called from C#
 
+CSHARP_EXPORT void csharp_interop_register_managed_functions(ManagedFunctions p_functions) {
+	s_managed_funcs = p_functions;
+}
+
 CSHARP_EXPORT NativeOptions csharp_interop_get_options() {
 	NativeOptions data;
 	_populate_options_data(data, SentrySDK::get_singleton()->get_options());
@@ -245,15 +256,6 @@ CSHARP_EXPORT NativeOptions csharp_interop_get_options_defaults() {
 	NativeOptions data;
 	_populate_options_data(data, SentryOptions::create_from_project_settings());
 	return data;
-}
-
-CSHARP_EXPORT void csharp_interop_register_dotnet_init(void (*fn)()) {
-	s_dotnet_init_fn = fn;
-}
-
-CSHARP_EXPORT void csharp_interop_register_logger_error_handler(
-		void (*fn)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len)) {
-	s_dotnet_logger_error_fn = fn;
 }
 
 CSHARP_EXPORT NativeTraceContext csharp_interop_get_trace_context() {
@@ -370,18 +372,31 @@ CSHARP_EXPORT void csharp_interop_log(int32_t level, const char16_t *msg, int32_
 namespace sentry::dotnet {
 
 void init() {
-	if (s_dotnet_init_fn) {
-		s_dotnet_init_fn();
+	if (s_managed_funcs.init) {
+		s_managed_funcs.init();
 	}
 }
 
 void handle_logger_error(const String &p_file, const String &p_code) {
-	if (s_dotnet_logger_error_fn) {
+	if (s_managed_funcs.logger_error) {
 		Char16String code_utf16 = p_code.utf16();
 		Char16String file_utf16 = p_file.utf16();
-		s_dotnet_logger_error_fn(
-				(const char16_t *)code_utf16.get_data(), code_utf16.length(),
-				(const char16_t *)file_utf16.get_data(), file_utf16.length());
+		s_managed_funcs.logger_error(
+				code_utf16.get_data(), code_utf16.length(),
+				file_utf16.get_data(), file_utf16.length());
+	}
+}
+
+void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	if (s_managed_funcs.add_breadcrumb) {
+		Char16String message_utf16 = p_breadcrumb->get_message().utf16();
+		Char16String category_utf16 = p_breadcrumb->get_category().utf16();
+		Char16String type = p_breadcrumb->get_type().utf16();
+		s_managed_funcs.add_breadcrumb(
+				message_utf16.get_data(), message_utf16.length(),
+				category_utf16.get_data(), category_utf16.length(),
+				static_cast<int32_t>(p_breadcrumb->get_level()),
+				type.get_data(), type.length());
 	}
 }
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -72,7 +72,9 @@ static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map)
 struct ManagedFunctions {
 	void (*init)();
 	void (*logger_error)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len);
-	void (*add_breadcrumb)(const char16_t *message, int32_t message_len, const char16_t *category, int32_t category_len, int32_t level, const char16_t *type, int32_t type_len);
+	void (*add_breadcrumb)(const char16_t *message, int32_t message_len, const char16_t *category, int32_t category_len, const char16_t *type, int32_t type_len, int32_t level);
+	void (*set_tag)(const char16_t *name, int32_t name_len, const char16_t *value, int32_t value_len);
+	void (*remove_tag)(const char16_t *name, int32_t name_len);
 };
 
 static ManagedFunctions s_managed_funcs = {};
@@ -396,8 +398,26 @@ void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 		s_managed_funcs.add_breadcrumb(
 				message_utf16.get_data(), message_utf16.length(),
 				category_utf16.get_data(), category_utf16.length(),
-				static_cast<int32_t>(p_breadcrumb->get_level()),
-				type.get_data(), type.length());
+				type.get_data(), type.length(),
+				static_cast<int32_t>(p_breadcrumb->get_level()));
+	}
+}
+
+void set_tag(const String &p_key, const String &p_value) {
+	if (s_managed_funcs.set_tag) {
+		Char16String key_utf16 = p_key.utf16();
+		Char16String value_utf16 = p_value.utf16();
+		s_managed_funcs.set_tag(
+				key_utf16.get_data(), key_utf16.length(),
+				value_utf16.get_data(), value_utf16.length());
+	}
+}
+
+void remove_tag(const String &p_key) {
+	if (s_managed_funcs.remove_tag) {
+		Char16String key_utf16 = p_key.utf16();
+		s_managed_funcs.remove_tag(
+				key_utf16.get_data(), key_utf16.length());
 	}
 }
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -392,6 +392,7 @@ void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 		Char16String message_utf16 = p_breadcrumb->get_message().utf16();
 		Char16String category_utf16 = p_breadcrumb->get_category().utf16();
 		Char16String type = p_breadcrumb->get_type().utf16();
+		// TODO: SentryBreadcrumb::get_data() is not implemented
 		s_managed_funcs.add_breadcrumb(
 				message_utf16.get_data(), message_utf16.length(),
 				category_utf16.get_data(), category_utf16.length(),

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -16,4 +16,7 @@ void handle_logger_error(const String &p_file, const String &p_code);
 
 void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
 
+void set_tag(const String &p_key, const String &p_value);
+void remove_tag(const String &p_key);
+
 } // namespace sentry::dotnet

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sentry/sentry_breadcrumb.h"
+
 #include <godot_cpp/variant/string.hpp>
 
 using namespace godot;
@@ -11,5 +13,7 @@ void init();
 
 // Forwards a C# exception error to the .NET layer for capture.
 void handle_logger_error(const String &p_file, const String &p_code);
+
+void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
 
 } // namespace sentry::dotnet

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_user.h"
 
 #include <godot_cpp/variant/string.hpp>
 
@@ -18,5 +19,8 @@ void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
 
 void set_tag(const String &p_key, const String &p_value);
 void remove_tag(const String &p_key);
+
+void set_user(const Ref<SentryUser> &p_user);
+void remove_user();
 
 } // namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -4,23 +4,45 @@
 
 namespace sentry::dotnet {
 
+thread_local uint32_t DotnetScopeObserver::SyncGuard::_depth = 0;
+
 void DotnetScopeObserver::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
 	sentry::dotnet::add_breadcrumb(p_breadcrumb);
 }
 
 void DotnetScopeObserver::set_tag(const String &p_key, const String &p_value) {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
 	sentry::dotnet::set_tag(p_key, p_value);
 }
 
 void DotnetScopeObserver::remove_tag(const String &p_key) {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
 	sentry::dotnet::remove_tag(p_key);
 }
 
 void DotnetScopeObserver::set_user(const Ref<SentryUser> &p_user) {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
 	sentry::dotnet::set_user(p_user);
 }
 
 void DotnetScopeObserver::remove_user() {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
 	sentry::dotnet::remove_user();
 }
 

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -5,15 +5,15 @@
 namespace sentry::dotnet {
 
 void DotnetScopeObserver::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
-	if (p_breadcrumb.is_valid()) {
-		sentry::dotnet::add_breadcrumb(p_breadcrumb);
-	}
+	sentry::dotnet::add_breadcrumb(p_breadcrumb);
 }
 
 void DotnetScopeObserver::set_tag(const String &p_key, const String &p_value) {
+	sentry::dotnet::set_tag(p_key, p_value);
 }
 
 void DotnetScopeObserver::remove_tag(const String &p_key) {
+	sentry::dotnet::remove_tag(p_key);
 }
 
 void DotnetScopeObserver::set_user(const Ref<SentryUser> &p_user) {

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -34,6 +34,10 @@ void DotnetScopeObserver::set_user(const Ref<SentryUser> &p_user) {
 	if (SyncGuard::is_syncing()) {
 		return;
 	}
+	if (p_user.is_null()) {
+		remove_user();
+		return;
+	}
 	SyncGuard guard;
 	sentry::dotnet::set_user(p_user);
 }

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -1,0 +1,25 @@
+#include "dotnet_scope_observer.h"
+
+#include "sentry/dotnet/csharp_interop.h"
+
+namespace sentry::dotnet {
+
+void DotnetScopeObserver::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	if (p_breadcrumb.is_valid()) {
+		sentry::dotnet::add_breadcrumb(p_breadcrumb);
+	}
+}
+
+void DotnetScopeObserver::set_tag(const String &p_key, const String &p_value) {
+}
+
+void DotnetScopeObserver::remove_tag(const String &p_key) {
+}
+
+void DotnetScopeObserver::set_user(const Ref<SentryUser> &p_user) {
+}
+
+void DotnetScopeObserver::remove_user() {
+}
+
+} //namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -17,9 +17,11 @@ void DotnetScopeObserver::remove_tag(const String &p_key) {
 }
 
 void DotnetScopeObserver::set_user(const Ref<SentryUser> &p_user) {
+	sentry::dotnet::set_user(p_user);
 }
 
 void DotnetScopeObserver::remove_user() {
+	sentry::dotnet::remove_user();
 }
 
 } //namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_scope_observer.h
+++ b/src/sentry/dotnet/dotnet_scope_observer.h
@@ -2,6 +2,9 @@
 
 #include "sentry/sentry_scope_observer.h"
 
+#include <cstdint>
+#include <godot_cpp/core/defs.hpp>
+
 namespace sentry::dotnet {
 
 class DotnetScopeObserver : public SentryScopeObserver {
@@ -11,6 +14,24 @@ protected:
 	static void _bind_methods() {}
 
 public:
+	// Prevent feedback loops when syncing scope changes across layers.
+	// Incremented by DotnetScopeObserver for outbound updates and by managed callers in csharp_interop.cpp for inbound updates.
+	class SyncGuard {
+	private:
+		static thread_local uint32_t _depth;
+
+	public:
+		_FORCE_INLINE_ static bool is_syncing() { return _depth > 0; }
+
+		SyncGuard() { ++_depth; }
+		~SyncGuard() { --_depth; }
+
+		SyncGuard(const SyncGuard &) = delete;
+		SyncGuard &operator=(const SyncGuard &) = delete;
+		SyncGuard(SyncGuard &&) = delete;
+		SyncGuard &operator=(SyncGuard &&) = delete;
+	};
+
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 
 	virtual void set_tag(const String &p_key, const String &p_value) override;

--- a/src/sentry/dotnet/dotnet_scope_observer.h
+++ b/src/sentry/dotnet/dotnet_scope_observer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "sentry/sentry_scope_observer.h"
+
+namespace sentry::dotnet {
+
+class DotnetScopeObserver : public SentryScopeObserver {
+	GDCLASS(DotnetScopeObserver, SentryScopeObserver);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+
+	virtual void set_tag(const String &p_key, const String &p_value) override;
+	virtual void remove_tag(const String &p_key) override;
+
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+	virtual void remove_user() override;
+};
+
+} //namespace sentry::dotnet

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -278,6 +278,11 @@ void SentryOptions::add_event_processor(const Ref<SentryEventProcessor> &p_proce
 	event_processors.push_back(p_processor);
 }
 
+void SentryOptions::add_scope_observer(const Ref<SentryScopeObserver> &p_scope_observer) {
+	ERR_FAIL_COND(p_scope_observer.is_null());
+	scope_observers.push_back(p_scope_observer);
+}
+
 void SentryOptions::remove_event_processor(const Ref<SentryEventProcessor> &p_processor) {
 	ERR_FAIL_COND(p_processor.is_null());
 	event_processors.erase(p_processor);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -4,6 +4,7 @@
 #include "sentry/level.h"
 #include "sentry/processing/sentry_event_processor.h"
 #include "sentry/sentry_attachment.h"
+#include "sentry/sentry_scope_observer.h"
 #include "sentry/util/simple_bind.h"
 
 #include <godot_cpp/classes/ref_counted.hpp>
@@ -116,6 +117,7 @@ private:
 	Callable before_capture_screenshot;
 
 	Vector<Ref<SentryEventProcessor>> event_processors;
+	Vector<Ref<SentryScopeObserver>> scope_observers;
 	// Default attachments (log, screenshot, view hierarchy). Must be file-based. Survive clear_attachments().
 	Vector<Ref<SentryAttachment>> default_attachments;
 	// User attachments added during config callback, drained at init.
@@ -233,6 +235,9 @@ public:
 	void add_event_processor(const Ref<SentryEventProcessor> &p_processor);
 	void remove_event_processor(const Ref<SentryEventProcessor> &p_processor);
 	_FORCE_INLINE_ Vector<Ref<SentryEventProcessor>> get_event_processors() { return event_processors; }
+
+	void add_scope_observer(const Ref<SentryScopeObserver> &p_scope_observer);
+	_FORCE_INLINE_ Vector<Ref<SentryScopeObserver>> get_scope_observers() { return scope_observers; }
 
 	void add_default_attachment(const Ref<SentryAttachment> &p_attachment);
 	_FORCE_INLINE_ Vector<Ref<SentryAttachment>> get_default_attachments() const { return default_attachments; }

--- a/src/sentry/sentry_scope_observer.h
+++ b/src/sentry/sentry_scope_observer.h
@@ -16,13 +16,13 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {}
 
-	virtual void set_tag(const String &p_key, const String &p_value) = 0;
-	virtual void remove_tag(const String &p_key) = 0;
+	virtual void set_tag(const String &p_key, const String &p_value) {}
+	virtual void remove_tag(const String &p_key) {}
 
-	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
-	virtual void remove_user() = 0;
+	virtual void set_user(const Ref<SentryUser> &p_user) {}
+	virtual void remove_user() {}
 
 	virtual ~SentryScopeObserver() = default;
 };

--- a/src/sentry/sentry_scope_observer.h
+++ b/src/sentry/sentry_scope_observer.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_user.h"
+
+#include <godot_cpp/classes/ref_counted.hpp>
+
+using namespace godot;
+
+namespace sentry {
+
+class SentryScopeObserver : public RefCounted {
+	GDCLASS(SentryScopeObserver, RefCounted);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
+
+	virtual void set_tag(const String &p_key, const String &p_value) = 0;
+	virtual void remove_tag(const String &p_key) = 0;
+
+	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
+	virtual void remove_user() = 0;
+
+	virtual ~SentryScopeObserver() = default;
+};
+
+} //namespace sentry

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -160,7 +160,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 	}
 
 	// Add built-in scope observers.
-	if (OS::get_singleton()->has_feature("mono")) {
+	if (ClassDB::class_exists("CSharpScript")) {
 		options->add_scope_observer(memnew(sentry::dotnet::DotnetScopeObserver));
 	}
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -5,6 +5,7 @@
 #include "sentry/contexts.h"
 #include "sentry/disabled/disabled_sdk.h"
 #include "sentry/dotnet/csharp_interop.h"
+#include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/godot_singletons.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/screenshot_processor.h"
@@ -158,6 +159,11 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 		options->add_event_processor(memnew(ViewHierarchyProcessor));
 	}
 
+	// Add built-in scope observers.
+	if (OS::get_singleton()->has_feature("mono")) {
+		options->add_scope_observer(memnew(sentry::dotnet::DotnetScopeObserver));
+	}
+
 	// Add default attachments.
 	for (const Ref<SentryAttachment> &att : _get_default_attachments()) {
 		options->add_default_attachment(att);
@@ -216,6 +222,9 @@ String SentrySDK::capture_message(const String &p_message, Level p_level) {
 void SentrySDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	ERR_FAIL_COND_MSG(p_breadcrumb.is_null(), "Sentry: Can't add null breadcrumb.");
 	internal_sdk->add_breadcrumb(p_breadcrumb);
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->add_breadcrumb(p_breadcrumb);
+	}
 }
 
 String SentrySDK::get_last_event_id() const {
@@ -260,19 +269,31 @@ void SentrySDK::clear_attachments() {
 void SentrySDK::set_tag(const String &p_key, const String &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set tag with an empty key.");
 	internal_sdk->set_tag(p_key, p_value);
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->set_tag(p_key, p_value);
+	}
 }
 
 void SentrySDK::remove_tag(const String &p_key) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't remove tag with an empty key.");
 	internal_sdk->remove_tag(p_key);
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->remove_tag(p_key);
+	}
 }
 
 void SentrySDK::set_user(const Ref<SentryUser> &p_user) {
 	internal_sdk->set_user(p_user);
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->set_user(p_user);
+	}
 }
 
 void SentrySDK::remove_user() {
 	internal_sdk->remove_user();
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->remove_user();
+	}
 }
 
 void SentrySDK::set_context(const godot::String &p_key, const godot::Dictionary &p_value) {

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -389,8 +389,8 @@ options/debug_printing=0
             ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.scope.removed" }) | Should -BeNullOrEmpty
         }
 
-        It "Native event includes breadcrumb added from .NET" {
-            $nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from .NET" } | Should -Not -BeNullOrEmpty
+        It "Native event includes breadcrumb added from .NET exactly once" {
+            @($nativeEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from .NET" }) | Should -HaveCount 1
         }
 
         It "Native event contains user context set from .NET" {
@@ -426,8 +426,8 @@ options/debug_printing=0
             ($managedEvent.tags | Where-Object { $_.key -eq "native.scope.removed" }) | Should -BeNullOrEmpty
         }
 
-        It "Managed event includes breadcrumb added from native" {
-            $managedEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from native" } | Should -Not -BeNullOrEmpty
+        It "Managed event includes breadcrumb added from native exactly once" {
+            @($managedEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from native" }) | Should -HaveCount 1
         }
 
         # TODO: Test breadcrumb.data propagates native => managed once SentryBreadcrumb::get_data() lands;

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -418,6 +418,29 @@ options/debug_printing=0
             ($managedEvent.tags | Where-Object { $_.key -eq "dotnet.local_scope.tag" }) | Should -BeNullOrEmpty
         }
 
+        It "Managed event contains tag set from native" {
+            ($managedEvent.tags | Where-Object { $_.key -eq "native.scope.synced" }).value | Should -Be "from-native"
+        }
+
+        It "Managed event omits tag removed from native" {
+            ($managedEvent.tags | Where-Object { $_.key -eq "native.scope.removed" }) | Should -BeNullOrEmpty
+        }
+
+        It "Managed event includes breadcrumb added from native" {
+            $managedEvent.breadcrumbs.values | Where-Object { $_.message -eq "Synced from native" } | Should -Not -BeNullOrEmpty
+        }
+
+        # TODO: Test breadcrumb.data propagates native => managed once SentryBreadcrumb::get_data() lands;
+        #       currently, add_breadcrumb() forwarder in csharp_interop.cpp omits data field.
+
+        It "Managed event contains user context set from native" {
+            $managedEvent.user | Should -Not -BeNullOrEmpty
+            $managedEvent.user.id | Should -Be "88888"
+            $managedEvent.user.username | Should -Be "NativeSyncedUser"
+            $managedEvent.user.email | Should -Be "native-synced@test.abc"
+            $managedEvent.user.ip_address | Should -Be "5.6.7.8"
+        }
+
         It "Native event omits tag set in local scope callback" {
             ($nativeEvent.tags | Where-Object { $_.key -eq "dotnet.local_scope.tag" }) | Should -BeNullOrEmpty
         }


### PR DESCRIPTION
Adds `SentryScopeObserver` interface and `DotnetScopeObserver` that forwards tag, breadcrumb, and user changes from the native layer to the managed layer, completing bidirectional scope sync. Also, adds thread-local sync guards to prevent double-record problem. Attachments, attributes and such will be tackled later. The `SentryScopeObserver` interface is not currently exposed in the public API, but doing so remains a possibility in the future.

- Follow-up on #701  
- Refs #650
