### PR TITLE
fix(dotnet): .NET layer not closed when request comes from native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
   - Sync trace context with .NET layer ([#696](https://github.com/getsentry/sentry-godot/pull/696))
   - Sync breadcrumbs, tags and user changes between .NET and native layers ([#701](https://github.com/getsentry/sentry-godot/pull/701), [#710](https://github.com/getsentry/sentry-godot/pull/710))
+  - Fix .NET layer not closed when request comes from native layer ([#715](https://github.com/getsentry/sentry-godot/pull/715))
 
 ### Fixes
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/Interop/NativeBridge.cs
@@ -199,6 +199,7 @@ internal static partial class NativeBridge
     private unsafe struct ManagedFunctions
     {
         public delegate* unmanaged[Cdecl]<void> init;
+        public delegate* unmanaged[Cdecl]<void> close;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> logger_error;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, int, void> add_breadcrumb;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> set_tag;
@@ -218,7 +219,8 @@ internal static partial class NativeBridge
     {
         csharp_interop_register_managed_functions(new ManagedFunctions
         {
-            init = &DotnetInitCallback,
+            init = &InitCallback,
+            close = &CloseCallback,
             logger_error = &LoggerErrorCallback,
             add_breadcrumb = &AddBreadcrumbCallback,
             set_tag = &SetTagCallback,
@@ -229,7 +231,7 @@ internal static partial class NativeBridge
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-    private static void DotnetInitCallback()
+    private static void InitCallback()
     {
         try
         {
@@ -238,6 +240,19 @@ internal static partial class NativeBridge
         catch (Exception ex)
         {
             GodotLog.Error($"Failed to initialize Sentry .NET layer: {ex}");
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static void CloseCallback()
+    {
+        try
+        {
+            SentrySdk.CloseFromNative();
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to close Sentry .NET layer: {ex}");
         }
     }
 

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -18,6 +18,13 @@ public static partial class SentrySdk
     // Doesn't need locking, because the whole call chain runs on the same thread.
     static bool _initializing;
 
+    // Re-entry guard for the Close() -> native close() -> CloseFromNative() chain:
+    // Close() triggers native shutdown, which signals back into the .NET layer
+    // via CloseFromNative() and would otherwise run CloseDotnetSdk() a second
+    // time.
+    // Doesn't need locking, because the whole call chain runs on the same thread.
+    static bool _closing;
+
     [ThreadStatic] private static bool _inLocalScope;
     internal static bool InLocalScope => _inLocalScope;
 
@@ -115,11 +122,37 @@ public static partial class SentrySdk
     /// </summary>
     public static void Close()
     {
+        if (_closing)
+        {
+            return;
+        }
+        _closing = true;
+        try
+        {
+            CloseDotnetSdk();
+            NativeBridge.CloseNativeSdk();
+        }
+        finally
+        {
+            _closing = false;
+        }
+    }
+
+    internal static void CloseFromNative()
+    {
+        if (_closing)
+        {
+            return;
+        }
+        CloseDotnetSdk();
+    }
+
+    private static void CloseDotnetSdk()
+    {
         _exceptionHandler?.Dispose();
         _exceptionHandler = null;
         CurrentOptions = null;
         Sentry.SentrySdk.Close();
-        NativeBridge.CloseNativeSdk();
     }
 
     private static void InitFirstChanceExceptionHandler()

--- a/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
+++ b/project/addons/sentry/dotnet/Sentry.Godot/SentrySdk.cs
@@ -144,7 +144,15 @@ public static partial class SentrySdk
         {
             return;
         }
-        CloseDotnetSdk();
+        _closing = true;
+        try
+        {
+            CloseDotnetSdk();
+        }
+        finally
+        {
+            _closing = false;
+        }
     }
 
     private static void CloseDotnetSdk()

--- a/project/cli/DotnetCliTriggers.cs
+++ b/project/cli/DotnetCliTriggers.cs
@@ -20,6 +20,11 @@ public partial class DotnetCliTriggers : RefCounted
         });
     }
 
+    public void CloseSentryFromDotnet()
+    {
+        Sentry.Godot.SentrySdk.Close();
+    }
+
     public void AddIntegrationTestContext(string testType)
     {
         Sentry.Godot.SentrySdk.AddBreadcrumb("Integration test started");

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -44,6 +44,7 @@ func _register_commands() -> void:
 	_parser.add_command("pii-capture", _cmd_pii_capture, "Capture a message with send_default_pii enabled")
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
+	_parser.add_command("dotnet-capture-via-dotnet-init", _cmd_dotnet_capture_via_dotnet_init, "Capture a .NET exception with .NET driving init")
 	_parser.add_command("dotnet-capture-via-gdscript-init", _cmd_dotnet_capture_via_gdscript_init, "Capture a .NET exception with GDScript driving init")
 	_parser.add_command("dotnet-capture-via-auto-init", _cmd_dotnet_capture_via_auto_init, "Capture a .NET exception with native auto-init driving init")
 	_parser.add_command("dotnet-cross-layer-capture", _cmd_dotnet_cross_layer_capture, "Capture a native and a .NET event to verify cross-layer synchronization")
@@ -296,6 +297,12 @@ func _cmd_dotnet_exception_capture(p_scenario: String) -> int:
 	return await _run_dotnet_trigger("dotnet-exception-capture-" + p_scenario, trigger_method, DotnetInitDriver.DOTNET)
 
 
+func _cmd_dotnet_capture_via_dotnet_init() -> int:
+	var result := await _run_dotnet_trigger("dotnet-capture-via-dotnet-init", "TriggerException", DotnetInitDriver.DOTNET)
+	await _verify_dotnet_initiated_close()
+	return result
+
+
 func _cmd_dotnet_capture_via_gdscript_init() -> int:
 	var result := await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
 	await _verify_native_initiated_close()
@@ -311,6 +318,20 @@ func _verify_native_initiated_close() -> void:
 	var triggers: Object = script.new()
 
 	SentrySDK.close()
+	await get_tree().create_timer(2.0).timeout
+	print("AFTER_CLOSE_NATIVE_ENABLED: ", SentrySDK.is_enabled())
+	print("AFTER_CLOSE_DOTNET_ENABLED: ", triggers.IsSdkEnabled())
+
+
+## Closes the SDK via the .NET API and prints test markers to verify the native and .NET layers were shut down.
+func _verify_dotnet_initiated_close() -> void:
+	var script: Script = load("res://cli/DotnetCliTriggers.cs")
+	if script == null:
+		printerr("Error: DotnetCliTriggers.cs is not available")
+		return
+	var triggers: Object = script.new()
+
+	triggers.CloseSentryFromDotnet()
 	await get_tree().create_timer(2.0).timeout
 	print("AFTER_CLOSE_NATIVE_ENABLED: ", SentrySDK.is_enabled())
 	print("AFTER_CLOSE_DOTNET_ENABLED: ", triggers.IsSdkEnabled())

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -297,7 +297,23 @@ func _cmd_dotnet_exception_capture(p_scenario: String) -> int:
 
 
 func _cmd_dotnet_capture_via_gdscript_init() -> int:
-	return await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
+	var result := await _run_dotnet_trigger("dotnet-capture-via-gdscript-init", "TriggerException", DotnetInitDriver.GDSCRIPT)
+	await _verify_native_initiated_close()
+	return result
+
+
+## Closes the SDK via the native API and prints test markers to verify the native and .NET layers were shut down.
+func _verify_native_initiated_close() -> void:
+	var script: Script = load("res://cli/DotnetCliTriggers.cs")
+	if script == null:
+		printerr("Error: DotnetCliTriggers.cs is not available")
+		return
+	var triggers: Object = script.new()
+
+	SentrySDK.close()
+	await get_tree().create_timer(2.0).timeout
+	print("AFTER_CLOSE_NATIVE_ENABLED: ", SentrySDK.is_enabled())
+	print("AFTER_CLOSE_DOTNET_ENABLED: ", triggers.IsSdkEnabled())
 
 
 func _cmd_dotnet_capture_via_auto_init() -> int:

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -72,6 +72,7 @@ static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map)
 // Must match ManagedFunctions struct in NativeBridge.cs.
 struct ManagedFunctions {
 	void (*init)();
+	void (*close)();
 	void (*logger_error)(const char16_t *code, int32_t code_len, const char16_t *file, int32_t file_len);
 	void (*add_breadcrumb)(const char16_t *message, int32_t message_len, const char16_t *category, int32_t category_len, const char16_t *type, int32_t type_len, int32_t level);
 	void (*set_tag)(const char16_t *name, int32_t name_len, const char16_t *value, int32_t value_len);
@@ -384,6 +385,12 @@ namespace sentry::dotnet {
 void init() {
 	if (s_managed_funcs.init) {
 		s_managed_funcs.init();
+	}
+}
+
+void close() {
+	if (s_managed_funcs.close) {
+		s_managed_funcs.close();
 	}
 }
 

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -9,8 +9,11 @@ using namespace godot;
 
 namespace sentry::dotnet {
 
-// Calls the .NET init, if available.
+// Calls the .NET init, if available. No-op in standard non-.NET Godot builds.
 void init();
+
+// Calls the .NET close, if available. No-op in standard non-.NET Godot builds.
+void close();
 
 // Forwards a C# exception error to the .NET layer for capture.
 void handle_logger_error(const String &p_file, const String &p_code);

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -207,6 +207,9 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 void SentrySDK::close() {
 	if (internal_sdk->is_enabled()) {
 		sentry::logging::print_debug("Shutting down Sentry SDK");
+
+		sentry::dotnet::close();
+
 		if (godot_logger.is_valid()) {
 			OS::get_singleton()->remove_logger(godot_logger);
 			godot_logger.unref();

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -172,7 +172,7 @@ Describe ".NET Integration Tests" {
             Connect-Device -Platform $script:TestSetup.Platform
             Install-DeviceApp -Path $script:TestSetup.Executable
 
-            $script:dotnetInitRunResult      = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("plain")
+            $script:dotnetInitRunResult      = Invoke-TestAction -Action "dotnet-capture-via-dotnet-init"
             $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")
             $script:wrappedRethrowRunResult = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("wrapped-rethrow")
             $script:gdscriptInitRunResult   = Invoke-TestAction -Action "dotnet-capture-via-gdscript-init"
@@ -298,11 +298,25 @@ options/debug_printing=0
         }
 
         It "<Name>" -ForEach $CommonTestCases {
-            & $testBlock -SentryEvent $runEvent -TestType "dotnet-exception-capture-plain" -RunResult $runResult -TestSetup $script:TestSetup
+            & $testBlock -SentryEvent $runEvent -TestType "dotnet-capture-via-dotnet-init" -RunResult $runResult -TestSetup $script:TestSetup
         }
 
         It "<Name>" -ForEach $DotnetCommonTestCases {
             & $TestBlock -SentryEvent $runEvent -RunResult $runResult -TestSetup $script:TestSetup
+        }
+
+        It "Disables native layer after .NET-initiated close" {
+            $line = $runResult.Output | Where-Object {
+                $_ -match "AFTER_CLOSE_NATIVE_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "AFTER_CLOSE_NATIVE_ENABLED: false"
+        }
+
+        It "Disables .NET layer after .NET-initiated close" {
+            $line = $runResult.Output | Where-Object {
+                $_ -match "AFTER_CLOSE_DOTNET_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "AFTER_CLOSE_DOTNET_ENABLED: false"
         }
     }
 

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -325,6 +325,20 @@ options/debug_printing=0
         It "<Name>" -ForEach $DotnetCommonTestCases {
             & $TestBlock -SentryEvent $runEvent -RunResult $runResult -TestSetup $script:TestSetup
         }
+
+        It "Disables native layer after GDScript-initiated close" {
+            $line = $runResult.Output | Where-Object {
+                $_ -match "AFTER_CLOSE_NATIVE_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "AFTER_CLOSE_NATIVE_ENABLED: false"
+        }
+
+        It "Disables .NET layer after GDScript-initiated close" {
+            $line = $runResult.Output | Where-Object {
+                $_ -match "AFTER_CLOSE_DOTNET_ENABLED: (true|false)"
+            } | Select-Object -First 1
+            $line | Should -Match "AFTER_CLOSE_DOTNET_ENABLED: false"
+        }
     }
 
     Context "Dotnet with native auto-init driving init" -Skip:($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs", "iOSSauceLabs")) {


### PR DESCRIPTION
When the `close()` request originated from the native layer (e.g. from a GDScript `SentrySDK.close()` call), the .NET layer's cleanup never ran, leaving the upstream Sentry .NET SDK running. The native layer now signals the .NET layer during shutdown so the proper cleanup can take place. A re-entry guard on the .NET side prevents the cleanup from running twice, mirroring the existing `Init()` setup. The integration tests now also assert that both layers are disabled after close, covering both native-initiated and .NET-initiated paths.