### PR TITLE
fix(dotnet): Probe symbol instead of env-var hint in auto-init hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Fix .NET layer not closed when request comes from native layer ([#715](https://github.com/getsentry/sentry-godot/pull/715))
   - Propagate default attachments (log, screenshot, and view hierarchy) to the .NET layer so .NET events include the same attachments as native events ([#713](https://github.com/getsentry/sentry-godot/pull/713))
   - Switch to distributing .NET libs as precompiled DLLs ([#719](https://github.com/getsentry/sentry-godot/pull/719))
+  - Fix occasional `EntryPointNotFoundException` during project export ([#721](https://github.com/getsentry/sentry-godot/pull/721))
 
 ### Fixes
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/SentryGodotInitializer.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/SentryGodotInitializer.cs
@@ -11,10 +11,11 @@ public static class SentryGodotInitializer
 {
     public static void AutoInit()
     {
-        if (Environment.GetEnvironmentVariable("SENTRY_GODOT_EDITOR_HINT") == "1")
+        // Module initializers run whenever the user assembly is loaded, including by tooling such as project export
+        // or IDE script analysis, where the Sentry GDExtension may not be loaded.
+        if (!NativeBridge.IsNativeAvailable())
         {
-            // Skip in the Godot editor process.
-            Console.WriteLine("SentryGodotInitializer: Skipping initialization in Godot editor process.");
+            Console.WriteLine("SentryGodotInitializer: Sentry GDExtension not loaded in this process; skipping. If you see this in a running game (not during project export or IDE script analysis), check Godot's log for extension load failures.");
             return;
         }
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -244,6 +244,23 @@ internal static partial class NativeBridge
         ManagedFunctions functions);
 
     /// <summary>
+    /// Checks whether the native interop library is loaded and exposes the expected symbol.
+    /// Returns false when running outside the Godot/GDExtension host, so initialization can be skipped.
+    /// </summary>
+    public static bool IsNativeAvailable()
+    {
+        try
+        {
+            return NativeLibrary.TryGetExport(NativeLibResolver.Resolve(),
+                nameof(csharp_interop_register_managed_functions), out _);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Registers managed functions that are called from native layer.
     /// </summary>
     public static unsafe void RegisterManagedFunctions()

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeLibResolver.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeLibResolver.cs
@@ -9,33 +9,25 @@ namespace Sentry.Godot.Interop;
 /// </summary>
 internal static class NativeLibResolver
 {
-    private static bool _initialized;
-
     [ModuleInitializer]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2255")]
     internal static void Init()
     {
-        if (_initialized)
-        {
-            return;
-        }
-        _initialized = true;
-
-        var libPath = Environment.GetEnvironmentVariable("SENTRY_GODOT_LIB_PATH");
-
         NativeLibrary.SetDllImportResolver(typeof(NativeLibResolver).Assembly, (name, asm, path) =>
-        {
-            if (name != NativeBridge.Lib)
-            {
-                return IntPtr.Zero;
-            }
-            if (!string.IsNullOrEmpty(libPath) && NativeLibrary.TryLoad(libPath, out var handle))
-            {
-                return handle;
-            }
+            name == NativeBridge.Lib ? Resolve() : IntPtr.Zero);
+    }
 
-            // Fallback to RTLD_DEFAULT: takes effect on iOS where env var approach doesn't work.
-            return NativeLibrary.GetMainProgramHandle();
-        });
+    /// <summary>
+    /// Returns the GDExtension library handle for P/Invokes and the availability probe.
+    /// </summary>
+    internal static IntPtr Resolve()
+    {
+        var libPath = Environment.GetEnvironmentVariable("SENTRY_GODOT_LIB_PATH");
+        if (!string.IsNullOrEmpty(libPath) && NativeLibrary.TryLoad(libPath, out var handle))
+        {
+            return handle;
+        }
+        // Fallback to RTLD_DEFAULT: takes effect on iOS where env var approach doesn't work.
+        return NativeLibrary.GetMainProgramHandle();
     }
 }

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -437,12 +437,6 @@ void SentrySDK::prepare_and_auto_initialize() {
 	OS::get_singleton()->set_environment("SENTRY_GODOT_LIB_PATH",
 			sentry::util::get_gdextension_library_path());
 
-	// Signal editor vs. game context to the managed [ModuleInitializer] via environment variable.
-	// This is used by the managed code to skip initialization in the Godot editor process.
-	// Always write, even "0", because F5-play child process inherits this from the editor.
-	OS::get_singleton()->set_environment("SENTRY_GODOT_EDITOR_HINT",
-			Engine::get_singleton()->is_editor_hint() ? "1" : "0");
-
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
 		editor::prepare_csharp_project();


### PR DESCRIPTION
Replaces environment variable hint with direct symbol probe when detecting if the native layer is available. Previously, we used environment variable hint for the initializer, but it proved to be unreliable for detecting editor/tooling context.

- Refs #647 
- Depends on #719 

The .NET layer's auto-init runs from a `[ModuleInitializer]`, which fires whenever the project assembly is loaded. Godot can do this in tooling contexts like project export, before the Sentry GDExtension is loaded in the same process. Auto-init hook tried to call into native and threw `EntryPointNotFoundException`. The export itself still produced output, so it's a loud error in the log rather than a hard failure. 

**This was printed to Godot console**:
```
  ERROR: /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs:113 - System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
  ERROR:  ---> System.TypeInitializationException: The type initializer for '<Module>' threw an exception.
  ERROR:  ---> System.EntryPointNotFoundException: Unable to find an entry point named 'csharp_interop_register_managed_functions' in shared library 'sentry-godot'.
  ERROR:    at Sentry.Godot.Interop.NativeBridge.csharp_interop_register_managed_functions(ManagedFunctions functions)
  ERROR:    at Sentry.Godot.Interop.NativeBridge.csharp_interop_register_managed_functions(ManagedFunctions functions)
  ERROR:    at Sentry.Godot.Interop.NativeBridge.RegisterManagedFunctions() in /home/runner/work/sentry-godot/sentry-godot/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs:line 251
  ERROR:    at Sentry.Godot.Internal.SentryGodotInitializer.AutoInit() in /home/runner/work/sentry-godot/sentry-godot/src/sentry/dotnet/managed/Sentry.Godot/Internal/SentryGodotInitializer.cs:line 21
  ERROR:    at SentryAutoInit.Init() in /home/limbo/Downloads/81ad35071d25de6971e49f1f4a3281711b5830b8/sentry-godot-demo-project-2.0.0-beta.0+81ad350/addons/sentry/dotnet/SentryAutoInit.cs:line 9
  ERROR:    at .cctor()
  ERROR:    --- End of inner exception stack trace ---
  ERROR:    at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
  ERROR:    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
  ERROR:    --- End of inner exception stack trace ---
  ERROR:    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
  ERROR:    at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
  ERROR:    at Godot.Bridge.ScriptManagerBridge.GetMethodListForType(Type type) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs:line 969
  ERROR:    at Godot.Bridge.ScriptManagerBridge.UpdateScriptClassInfo(IntPtr scriptPtr, godot_csharp_type_info* outTypeInfo, godot_array* outMethodsDest, godot_dictionary* outRpcFunctionsDest, godot_dictionary* outEventSignalsDest, godot_ref* outBaseScript) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs:line 779
```