### PR TITLE
fix(dotnet): Symbolicate managed stack frames on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
+  - Symbolicate managed stack frames on Android ([#724](https://github.com/getsentry/sentry-godot/pull/724))
+
 ## 2.0.0-beta.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
-  - Symbolicate managed stack frames on Android ([#724](https://github.com/getsentry/sentry-godot/pull/724))
+  - Symbolicate managed stack frames on Android server-side ([#724](https://github.com/getsentry/sentry-godot/pull/724))
 
 ## 2.0.0-beta.1
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -367,6 +367,7 @@ CSHARP_EXPORT AssemblyHandle csharp_interop_open_managed_assembly(const char16_t
 	AssemblyHandle result = {};
 
 	String name = String::utf16(p_name, p_name_len);
+	name = name.get_file();
 	if (!name.ends_with(".dll")) {
 		name += ".dll";
 	}

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -7,8 +7,12 @@
 #include "sentry/sentry_sdk.h"
 #include "sentry/sentry_user.h"
 
+#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/engine_debugger.hpp>
+#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+
+#include <cstring>
 
 #ifdef _WIN32
 #define CSHARP_EXPORT __declspec(dllexport)
@@ -341,6 +345,85 @@ CSHARP_EXPORT bool csharp_interop_is_android() {
 #else
 	return false;
 #endif
+}
+
+// Remarks:
+// Managed side needs to access assemblies for .NET stack-trace symbolication. On Android, these assemblies live inside
+// the application archive, potentially inside a .pck container, so direct file access is not viable. Routing through
+// FileAccess lets the engine's virtual filesystem handle packing and decompression. The Sentry SDK needs each
+// assembly's PE bytes to build a debug image, but only reads two small segments: the headers at the start and the debug
+// directory near the end. The assembly is exposed as a seekable handle so the managed side reads just those segments,
+// without marshalling the whole file content.
+
+// Opaque handle for an open managed assembly file.
+// Must match layout of AssemblyHandle in NativeBridge.cs.
+// Must be closed with csharp_interop_close_managed_assembly().
+struct AssemblyHandle {
+	void *handle; // Ref<FileAccess>* or nullptr if the assembly was not found
+	int64_t length;
+};
+
+CSHARP_EXPORT AssemblyHandle csharp_interop_open_managed_assembly(const char16_t *p_name, int32_t p_name_len) {
+	AssemblyHandle result = {};
+
+	String name = String::utf16(p_name, p_name_len);
+	if (!name.ends_with(".dll")) {
+		name += ".dll";
+	}
+
+	String arch = Engine::get_singleton()->get_architecture_name();
+	String path = String("res://.godot/mono/publish/").path_join(arch).path_join(name);
+
+	bool exists = FileAccess::file_exists(path);
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::READ);
+	sentry::logging::print_debug("[AssemblyReader/native] open: path=", path, ", file_exists=", exists, ", opened=", file.is_valid());
+	if (file.is_null()) {
+		return result;
+	}
+
+	result.handle = memnew(Ref<FileAccess>(file));
+	result.length = file->get_length();
+	sentry::logging::print_debug("[AssemblyReader/native]   length=", result.length);
+	return result;
+}
+
+CSHARP_EXPORT int64_t csharp_interop_read_managed_assembly(void *p_handle, int64_t p_offset, int64_t p_count, uint8_t *r_dst) {
+	if (p_handle == nullptr || r_dst == nullptr || p_count <= 0) {
+		sentry::logging::print_debug("[AssemblyReader/native] read: bail (handle/dst null or count<=0), p_count=", p_count);
+		return 0;
+	}
+
+	const Ref<FileAccess> &file = *static_cast<Ref<FileAccess> *>(p_handle);
+	if (file.is_null()) {
+		sentry::logging::print_debug("[AssemblyReader/native] read: file Ref is null");
+		return 0;
+	}
+
+	file->seek(p_offset);
+	PackedByteArray data = file->get_buffer(p_count);
+	int64_t num_read = data.size();
+	String first_bytes;
+	if (num_read > 0) {
+		int preview = MIN((int64_t)4, num_read);
+		for (int i = 0; i < preview; i++) {
+			first_bytes += vformat("%02X", data.ptr()[i]);
+		}
+		if (num_read > preview) {
+			first_bytes += "(...)";
+		}
+	}
+	sentry::logging::print_debug("[AssemblyReader/native] read: offset=", p_offset, ", requested=", p_count, ", got=", num_read, ", bytes=", first_bytes);
+	if (num_read > 0) {
+		memcpy(r_dst, data.ptr(), num_read);
+	}
+	return num_read;
+}
+
+CSHARP_EXPORT void csharp_interop_close_managed_assembly(void *p_handle) {
+	sentry::logging::print_debug("[AssemblyReader/native] close");
+	if (p_handle != nullptr) {
+		memdelete(static_cast<Ref<FileAccess> *>(p_handle));
+	}
 }
 
 static ManagedOptions s_pending_managed_opts;

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -374,45 +374,29 @@ CSHARP_EXPORT AssemblyHandle csharp_interop_open_managed_assembly(const char16_t
 	String arch = Engine::get_singleton()->get_architecture_name();
 	String path = String("res://.godot/mono/publish/").path_join(arch).path_join(name);
 
-	bool exists = FileAccess::file_exists(path);
 	Ref<FileAccess> file = FileAccess::open(path, FileAccess::READ);
-	sentry::logging::print_debug("[AssemblyReader/native] open: path=", path, ", file_exists=", exists, ", opened=", file.is_valid());
 	if (file.is_null()) {
 		return result;
 	}
 
 	result.handle = memnew(Ref<FileAccess>(file));
 	result.length = file->get_length();
-	sentry::logging::print_debug("[AssemblyReader/native]   length=", result.length);
 	return result;
 }
 
 CSHARP_EXPORT int64_t csharp_interop_read_managed_assembly(void *p_handle, int64_t p_offset, int64_t p_count, uint8_t *r_dst) {
 	if (p_handle == nullptr || r_dst == nullptr || p_count <= 0) {
-		sentry::logging::print_debug("[AssemblyReader/native] read: bail (handle/dst null or count<=0), p_count=", p_count);
 		return 0;
 	}
 
 	const Ref<FileAccess> &file = *static_cast<Ref<FileAccess> *>(p_handle);
 	if (file.is_null()) {
-		sentry::logging::print_debug("[AssemblyReader/native] read: file Ref is null");
 		return 0;
 	}
 
 	file->seek(p_offset);
 	PackedByteArray data = file->get_buffer(p_count);
 	int64_t num_read = data.size();
-	String first_bytes;
-	if (num_read > 0) {
-		int preview = MIN((int64_t)4, num_read);
-		for (int i = 0; i < preview; i++) {
-			first_bytes += vformat("%02X", data.ptr()[i]);
-		}
-		if (num_read > preview) {
-			first_bytes += "(...)";
-		}
-	}
-	sentry::logging::print_debug("[AssemblyReader/native] read: offset=", p_offset, ", requested=", p_count, ", got=", num_read, ", bytes=", first_bytes);
 	if (num_read > 0) {
 		memcpy(r_dst, data.ptr(), num_read);
 	}
@@ -420,7 +404,6 @@ CSHARP_EXPORT int64_t csharp_interop_read_managed_assembly(void *p_handle, int64
 }
 
 CSHARP_EXPORT void csharp_interop_close_managed_assembly(void *p_handle) {
-	sentry::logging::print_debug("[AssemblyReader/native] close");
 	if (p_handle != nullptr) {
 		memdelete(static_cast<Ref<FileAccess> *>(p_handle));
 	}

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
@@ -30,7 +30,6 @@ internal sealed class GodotAssemblyReader
     /// </summary>
     public PEReader? TryReadAssembly(string assemblyName)
     {
-        GodotLog.Debug($"[AssemblyReader] TryReadAssembly: name={assemblyName}");
         AssemblyReadState state;
         IntPtr openHandle = IntPtr.Zero;
         lock (_lock)
@@ -39,21 +38,19 @@ internal sealed class GodotAssemblyReader
             {
                 if (cached is null)
                 {
-                    GodotLog.Debug($"[AssemblyReader]   cache: known miss");
+                    // Known miss: Failed to find this assembly previously.
                     return null;
                 }
-                GodotLog.Debug($"[AssemblyReader]   cache: hit, state.Length={cached.Length}, segments={cached.Segments.Count}");
                 state = cached;
             }
             else
             {
+                // First request: Open assembly and learn its length, and keep the handle for later reads.
                 var opened = NativeBridge.OpenManagedAssembly(assemblyName);
                 openHandle = opened.Handle;
-                GodotLog.Debug($"[AssemblyReader]   open: handle={openHandle.ToInt64():X}, length={opened.Length}");
                 if (openHandle == IntPtr.Zero)
                 {
-                    _cache[assemblyName] = null;
-                    GodotLog.Debug($"[AssemblyReader]   open FAILED, recording miss");
+                    _cache[assemblyName] = null; // record miss
                     return null;
                 }
                 state = new AssemblyReadState(opened.Length);
@@ -64,13 +61,10 @@ internal sealed class GodotAssemblyReader
         var stream = new AssemblyReadStream(assemblyName, state, openHandle);
         try
         {
-            var reader = new PEReader(stream);
-            GodotLog.Debug($"[AssemblyReader]   PEReader constructed OK");
-            return reader;
+            return new PEReader(stream);
         }
-        catch (Exception ex)
+        catch
         {
-            GodotLog.Debug($"[AssemblyReader]   PEReader THREW: {ex.GetType().Name}: {ex.Message}");
             stream.Dispose();
             return null;
         }
@@ -128,11 +122,8 @@ internal sealed class GodotAssemblyReader
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            GodotLog.Debug($"[AssemblyReader] Read {_assemblyName}: position={_position}, count={count}");
-
             if (count <= 0 || _position >= _state.Length)
             {
-                GodotLog.Debug($"[AssemblyReader]   -> 0 (count<=0 or past EOF)");
                 return 0;
             }
 
@@ -149,7 +140,6 @@ internal sealed class GodotAssemblyReader
                         segment.Data.AsSpan(offsetInSegment, count)
                             .CopyTo(buffer.AsSpan(offset));
                         _position += count;
-                        GodotLog.Debug($"[AssemblyReader]   -> {count} (cache hit, segment[{segment.Start}, {segment.End}), bytes={HexPreview(buffer, offset, count)})");
                         return count;
                     }
                 }
@@ -162,14 +152,10 @@ internal sealed class GodotAssemblyReader
             long blockAlignedEnd = (requestedEnd + BlockSize - 1) & ~(BlockSize - 1);
             long segmentEnd = Math.Min(blockAlignedEnd, _state.Length);
 
-            GodotLog.Debug($"[AssemblyReader]   cache MISS, reading [{segmentStart}, {segmentEnd}) = {segmentEnd - segmentStart} bytes");
-
             var segmentData = new byte[segmentEnd - segmentStart];
             int read = ReadFromFile(segmentStart, segmentData);
-            GodotLog.Debug($"[AssemblyReader]   ReadFromFile: read={read}, bytes={HexPreview(segmentData, 0, read)}");
             if (read <= 0)
             {
-                GodotLog.Debug($"[AssemblyReader]   -> 0 (ReadFromFile returned {read})");
                 return 0;
             }
             if (read < segmentData.Length)
@@ -186,7 +172,7 @@ internal sealed class GodotAssemblyReader
             var segmentActualEnd = segmentStart + segmentData.Length;
             if (segmentActualEnd <= _position)
             {
-                GodotLog.Debug($"[AssemblyReader]   -> 0 (severe truncation: segmentActualEnd={segmentActualEnd} <= position={_position})");
+                // Reading truncated at EOF before reaching our position - nothing to return.
                 return 0;
             }
 
@@ -195,7 +181,6 @@ internal sealed class GodotAssemblyReader
             segmentData.AsSpan(offsetInSegmentData, bytesToCopy)
                 .CopyTo(buffer.AsSpan(offset));
             _position += bytesToCopy;
-            GodotLog.Debug($"[AssemblyReader]   -> {bytesToCopy} (miss path served), bytes={HexPreview(buffer, offset, bytesToCopy)}");
             return bytesToCopy;
         }
 
@@ -203,27 +188,17 @@ internal sealed class GodotAssemblyReader
         {
             if (_handle == IntPtr.Zero)
             {
-                GodotLog.Debug($"[AssemblyReader]   ReadFromFile: handle was Zero, reopening {_assemblyName}");
                 _handle = NativeBridge.OpenManagedAssembly(_assemblyName).Handle;
                 if (_handle == IntPtr.Zero)
                 {
-                    GodotLog.Debug($"[AssemblyReader]   ReadFromFile: reopen FAILED");
                     return 0;
                 }
             }
             return NativeBridge.ReadManagedAssembly(_handle, offset, destination);
         }
 
-        private static string HexPreview(byte[] buffer, int offset, int count)
-        {
-            int n = Math.Min(count, 4);
-            if (n <= 0) return "(none)";
-            return Convert.ToHexString(buffer, offset, n) + (count > n ? "(...)" : "");
-        }
-
         public override long Seek(long offset, SeekOrigin origin)
         {
-            long prev = _position;
             _position = origin switch
             {
                 SeekOrigin.Begin => offset,
@@ -231,7 +206,6 @@ internal sealed class GodotAssemblyReader
                 SeekOrigin.End => _state.Length + offset,
                 _ => _position,
             };
-            GodotLog.Debug($"[AssemblyReader] Seek {_assemblyName}: origin={origin}, offset={offset}, {prev} -> {_position}");
             return _position;
         }
 
@@ -243,7 +217,6 @@ internal sealed class GodotAssemblyReader
 
         protected override void Dispose(bool disposing)
         {
-            GodotLog.Debug($"[AssemblyReader] Dispose {_assemblyName}: handle={(_handle == IntPtr.Zero ? "null" : "open")}, position={_position}");
             if (_handle != IntPtr.Zero)
             {
                 NativeBridge.CloseManagedAssembly(_handle);

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
@@ -111,7 +111,11 @@ internal sealed class GodotAssemblyReader
         public override long Position
         {
             get => _position;
-            set => _position = value;
+            set
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(value);
+                _position = value;
+            }
         }
 
         public override bool CanRead => true;
@@ -198,13 +202,18 @@ internal sealed class GodotAssemblyReader
 
         public override long Seek(long offset, SeekOrigin origin)
         {
-            _position = origin switch
+            long newPosition = origin switch
             {
                 SeekOrigin.Begin => offset,
                 SeekOrigin.Current => _position + offset,
                 SeekOrigin.End => _state.Length + offset,
-                _ => _position,
+                _ => throw new ArgumentException("Invalid SeekOrigin value.", nameof(origin)),
             };
+            if (newPosition < 0)
+            {
+                throw new IOException("Cannot seek before the beginning of the stream.");
+            }
+            _position = newPosition;
             return _position;
         }
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
@@ -114,7 +114,6 @@ internal sealed class GodotAssemblyReader
             set => _position = value;
         }
 
-
         public override bool CanRead => true;
         public override bool CanSeek => true;
         public override bool CanWrite => false;

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotAssemblyReader.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.PortableExecutable;
+using Sentry.Godot.Interop;
+
+namespace Sentry.Godot.Internal;
+
+/// <summary>
+/// Provides assembly bytes to the Sentry .NET SDK for managed stack-trace symbolication.
+/// </summary>
+/// <remarks>
+/// On Android, .NET assemblies live inside the application archive (possibly nested in a .pck) and have no on-disk path
+/// the SDK can open. Without their bytes the SDK cannot build debug images, so the server reports every managed frame
+/// as unknown_image. This reader is designed to fetch bytes via the native bridge, routed through Godot's FileAccess
+/// so the engine's virtual FS handles packing and decompression.
+///
+/// The SDK only reads two small segments per assembly (PE headers at the start and the debug directory near the end), so
+/// each assembly is exposed as a seekable Stream rather than whole. Touched segments are cached per assembly, and repeat
+/// captures are served from cache and do no further I/O.
+/// </remarks>
+internal sealed class GodotAssemblyReader
+{
+    // Per-assembly read cache, keyed by the assembly name. A null value records a failed lookup (no such assembly found).
+    private readonly Dictionary<string, AssemblyReadState?> _cache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Returns a PEReader over the named assembly, or null if it cannot be resolved.
+    /// </summary>
+    public PEReader? TryReadAssembly(string assemblyName)
+    {
+        GodotLog.Debug($"[AssemblyReader] TryReadAssembly: name={assemblyName}");
+        AssemblyReadState state;
+        IntPtr openHandle = IntPtr.Zero;
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(assemblyName, out var cached))
+            {
+                if (cached is null)
+                {
+                    GodotLog.Debug($"[AssemblyReader]   cache: known miss");
+                    return null;
+                }
+                GodotLog.Debug($"[AssemblyReader]   cache: hit, state.Length={cached.Length}, segments={cached.Segments.Count}");
+                state = cached;
+            }
+            else
+            {
+                var opened = NativeBridge.OpenManagedAssembly(assemblyName);
+                openHandle = opened.Handle;
+                GodotLog.Debug($"[AssemblyReader]   open: handle={openHandle.ToInt64():X}, length={opened.Length}");
+                if (openHandle == IntPtr.Zero)
+                {
+                    _cache[assemblyName] = null;
+                    GodotLog.Debug($"[AssemblyReader]   open FAILED, recording miss");
+                    return null;
+                }
+                state = new AssemblyReadState(opened.Length);
+                _cache[assemblyName] = state;
+            }
+        }
+
+        var stream = new AssemblyReadStream(assemblyName, state, openHandle);
+        try
+        {
+            var reader = new PEReader(stream);
+            GodotLog.Debug($"[AssemblyReader]   PEReader constructed OK");
+            return reader;
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Debug($"[AssemblyReader]   PEReader THREW: {ex.GetType().Name}: {ex.Message}");
+            stream.Dispose();
+            return null;
+        }
+    }
+
+    private sealed class AssemblyReadState(long length)
+    {
+        public readonly long Length = length;
+
+        // Byte ranges read from the file so far.
+        public readonly List<Segment> Segments = [];
+    }
+
+    private readonly struct Segment(long start, byte[] data)
+    {
+        public readonly long Start = start;
+        public readonly byte[] Data = data;
+
+        public long End => Start + Data.Length;
+    }
+
+    /// <summary>
+    /// Seekable stream over a managed assembly in Godot's virtual FS.
+    /// </summary>
+    /// <remarks>
+    /// Reads hit cached segments when possible, and misses go to the native file handle and the segment is stored so
+    /// later captures hit our cache.
+    /// The handle is opened lazily and closed on dispose.
+    /// </remarks>
+    private sealed class AssemblyReadStream(string assemblyName, AssemblyReadState state, IntPtr handle) : Stream
+    {
+        // The SDK parses the PE headers a few bytes at a time, then reads the debug directory.
+        // Reading larger blocks on a miss collapses that into a handful of native reads instead of one per field.
+        // The value was derived empirically, resulting in 2 native reads per assembly.
+        private const long BlockSize = 4096; // matches Godot's compressed FS block size
+
+        private readonly string _assemblyName = assemblyName;
+        private readonly AssemblyReadState _state = state;
+
+        // Contains IntPtr.Zero until a read misses the cached segments and needs the file.
+        private IntPtr _handle = handle;
+
+        private long _position;
+        public override long Position
+        {
+            get => _position;
+            set => _position = value;
+        }
+
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _state.Length;
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            GodotLog.Debug($"[AssemblyReader] Read {_assemblyName}: position={_position}, count={count}");
+
+            if (count <= 0 || _position >= _state.Length)
+            {
+                GodotLog.Debug($"[AssemblyReader]   -> 0 (count<=0 or past EOF)");
+                return 0;
+            }
+
+            count = (int)Math.Min(count, _state.Length - _position);
+
+            // Serve from a cached segment if one fully covers the request.
+            lock (_state)
+            {
+                foreach (var segment in _state.Segments)
+                {
+                    if (segment.Start <= _position && segment.End >= _position + count)
+                    {
+                        var offsetInSegment = (int)(_position - segment.Start);
+                        segment.Data.AsSpan(offsetInSegment, count)
+                            .CopyTo(buffer.AsSpan(offset));
+                        _position += count;
+                        GodotLog.Debug($"[AssemblyReader]   -> {count} (cache hit, segment[{segment.Start}, {segment.End}), bytes={HexPreview(buffer, offset, count)})");
+                        return count;
+                    }
+                }
+            }
+
+            // Miss: Read the block-aligned byte segment covering the request and cache it for later reads.
+
+            long segmentStart = _position & ~(BlockSize - 1); // round down to a multiple of BlockSize
+            long requestedEnd = _position + count;
+            long blockAlignedEnd = (requestedEnd + BlockSize - 1) & ~(BlockSize - 1);
+            long segmentEnd = Math.Min(blockAlignedEnd, _state.Length);
+
+            GodotLog.Debug($"[AssemblyReader]   cache MISS, reading [{segmentStart}, {segmentEnd}) = {segmentEnd - segmentStart} bytes");
+
+            var segmentData = new byte[segmentEnd - segmentStart];
+            int read = ReadFromFile(segmentStart, segmentData);
+            GodotLog.Debug($"[AssemblyReader]   ReadFromFile: read={read}, bytes={HexPreview(segmentData, 0, read)}");
+            if (read <= 0)
+            {
+                GodotLog.Debug($"[AssemblyReader]   -> 0 (ReadFromFile returned {read})");
+                return 0;
+            }
+            if (read < segmentData.Length)
+            {
+                Array.Resize(ref segmentData, read);
+            }
+
+            lock (_state)
+            {
+                _state.Segments.Add(new Segment(segmentStart, segmentData));
+            }
+
+            // ReadFromFile() can return less than requested at EOF.
+            var segmentActualEnd = segmentStart + segmentData.Length;
+            if (segmentActualEnd <= _position)
+            {
+                GodotLog.Debug($"[AssemblyReader]   -> 0 (severe truncation: segmentActualEnd={segmentActualEnd} <= position={_position})");
+                return 0;
+            }
+
+            int bytesToCopy = (int)Math.Min(count, segmentActualEnd - _position);
+            int offsetInSegmentData = (int)(_position - segmentStart);
+            segmentData.AsSpan(offsetInSegmentData, bytesToCopy)
+                .CopyTo(buffer.AsSpan(offset));
+            _position += bytesToCopy;
+            GodotLog.Debug($"[AssemblyReader]   -> {bytesToCopy} (miss path served), bytes={HexPreview(buffer, offset, bytesToCopy)}");
+            return bytesToCopy;
+        }
+
+        private int ReadFromFile(long offset, Span<byte> destination)
+        {
+            if (_handle == IntPtr.Zero)
+            {
+                GodotLog.Debug($"[AssemblyReader]   ReadFromFile: handle was Zero, reopening {_assemblyName}");
+                _handle = NativeBridge.OpenManagedAssembly(_assemblyName).Handle;
+                if (_handle == IntPtr.Zero)
+                {
+                    GodotLog.Debug($"[AssemblyReader]   ReadFromFile: reopen FAILED");
+                    return 0;
+                }
+            }
+            return NativeBridge.ReadManagedAssembly(_handle, offset, destination);
+        }
+
+        private static string HexPreview(byte[] buffer, int offset, int count)
+        {
+            int n = Math.Min(count, 4);
+            if (n <= 0) return "(none)";
+            return Convert.ToHexString(buffer, offset, n) + (count > n ? "(...)" : "");
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long prev = _position;
+            _position = origin switch
+            {
+                SeekOrigin.Begin => offset,
+                SeekOrigin.Current => _position + offset,
+                SeekOrigin.End => _state.Length + offset,
+                _ => _position,
+            };
+            GodotLog.Debug($"[AssemblyReader] Seek {_assemblyName}: origin={origin}, offset={offset}, {prev} -> {_position}");
+            return _position;
+        }
+
+        public override void Flush() { }
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            GodotLog.Debug($"[AssemblyReader] Dispose {_assemblyName}: handle={(_handle == IntPtr.Zero ? "null" : "open")}, position={_position}");
+            if (_handle != IntPtr.Zero)
+            {
+                NativeBridge.CloseManagedAssembly(_handle);
+                _handle = IntPtr.Zero;
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -572,6 +572,62 @@ internal static partial class NativeBridge
         return csharp_interop_is_android() != 0;
     }
 
+    // Must match layout of AssemblyHandle in csharp_interop.cpp.
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct AssemblyHandle
+    {
+        public IntPtr Handle;
+        public long Length;
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial AssemblyHandle csharp_interop_open_managed_assembly(char* name, int nameLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial long csharp_interop_read_managed_assembly(IntPtr handle, long offset, long count, byte* dst);
+
+    [LibraryImport(Lib)]
+    private static partial void csharp_interop_close_managed_assembly(IntPtr handle);
+
+    /// <summary>
+    /// Opens managed assembly by name from Godot's virtual filesystem as a seekable handle.
+    /// Returns null handle with zero length if the assembly was not found.
+    /// </summary>
+    public static unsafe AssemblyHandle OpenManagedAssembly(string assemblyName)
+    {
+        fixed (char* namePtr = assemblyName)
+        {
+            return csharp_interop_open_managed_assembly(namePtr, assemblyName.Length);
+        }
+    }
+
+    /// <summary>
+    /// Reads bytes from an open assembly handle at specified offset into destination.
+    /// Returns the number of bytes read, which may be less than requested at EOF.
+    /// </summary>
+    public static unsafe int ReadManagedAssembly(IntPtr handle, long offset, Span<byte> destination)
+    {
+        if (handle == IntPtr.Zero || destination.IsEmpty)
+        {
+            return 0;
+        }
+        fixed (byte* dstPtr = destination)
+        {
+            return (int)csharp_interop_read_managed_assembly(handle, offset, destination.Length, dstPtr);
+        }
+    }
+
+    /// <summary>
+    /// Closes a managed assembly handle opened by <see cref="OpenManagedAssembly"/>.
+    /// </summary>
+    public static void CloseManagedAssembly(IntPtr handle)
+    {
+        if (handle != IntPtr.Zero)
+        {
+            csharp_interop_close_managed_assembly(handle);
+        }
+    }
+
     [LibraryImport(Lib)]
     private static unsafe partial void csharp_interop_sdk_init(ManagedOptions opts);
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -11,6 +11,8 @@ public static partial class SentrySdk
 {
     static IDisposable? _exceptionHandler;
 
+    static GodotAssemblyReader? _assemblyReader;
+
     // Re-entry guard for the Init() -> native init() -> InitFromNative() chain:
     // Init() triggers native initialization, which signals back into the .NET
     // layer via InitFromNative() and would otherwise run InitDotnet() a second
@@ -103,8 +105,31 @@ public static partial class SentrySdk
     {
         CurrentOptions = godotOptions;
         GodotLog.Debug("Initializing Sentry in .NET...");
+        ConfigureAssemblyReader(godotOptions);
         Sentry.SentrySdk.Init(godotOptions);
         InitFirstChanceExceptionHandler();
+    }
+
+    /// <summary>
+    /// On Android, lets the SDK read managed assembly bytes from the packed project data.
+    /// </summary>
+    /// <remarks>
+    /// Godot's Mono runtime on Android loads managed assemblies from the packed
+    /// project data, so they have no on-disk path and the SDK cannot build debug
+    /// images for managed stack frames. The reader resolves the bytes through the
+    /// native layer instead. Desktop builds keep the SDK's default disk reader,
+    /// which finds the assemblies as loose files next to the executable.
+    /// </remarks>
+    private static void ConfigureAssemblyReader(SentryGodotOptions godotOptions)
+    {
+        if (!NativeBridge.IsAndroid() || godotOptions.AssemblyReader is not null)
+        {
+            return;
+        }
+
+        _assemblyReader = new GodotAssemblyReader();
+        godotOptions.AssemblyReader = _assemblyReader.TryReadAssembly;
+        GodotLog.Debug("Assembly reader registered for .NET stack symbolication.");
     }
 
     /// <summary>
@@ -162,6 +187,7 @@ public static partial class SentrySdk
     {
         _exceptionHandler?.Dispose();
         _exceptionHandler = null;
+        _assemblyReader = null;
         Sentry.SentrySdk.Close();
         CurrentOptions = null;
     }

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -90,6 +90,48 @@ $DotnetCommonTestCases = @(
             $viewHierarchy.size | Should -BeGreaterThan 0
         }
     }
+    @{ Name = "Has pe_dotnet debug images"; TestBlock = {
+            param($SentryEvent)
+            $SentryEvent.debugmeta | Should -Not -BeNullOrEmpty
+            $peImages = @($SentryEvent.debugmeta.images | Where-Object { $_.type -eq "pe_dotnet" })
+            $peImages.Count | Should -BeGreaterThan 0
+        }
+    }
+    @{ Name = "GodotSharp assembly debug image has debug_id and code_id"; TestBlock = {
+            param($SentryEvent)
+            $godotSharpImage = $SentryEvent.debugmeta.images | Where-Object {
+                $_.type -eq "pe_dotnet" -and ($_.code_file -eq "GodotSharp.dll" -or $_.code_file -like "*/GodotSharp.dll")
+            } | Select-Object -First 1
+            $godotSharpImage | Should -Not -BeNullOrEmpty
+            $godotSharpImage.debug_id | Should -Not -BeNullOrEmpty
+            $godotSharpImage.code_id | Should -Not -BeNullOrEmpty
+        }
+    }
+    @{ Name = "Android: Project assembly debug image has debug_id and code_id"; TestBlock = {
+            param($SentryEvent, $TestSetup)
+            if (-not $TestSetup.IsAndroid) {
+                # Android-only: desktop resolves managed frames locally.
+                return
+            }
+            $projectImage = $SentryEvent.debugmeta.images | Where-Object {
+                $_.type -eq "pe_dotnet" -and $_.code_file -eq "Sentry demo project.dll"
+            } | Select-Object -First 1
+            $projectImage | Should -Not -BeNullOrEmpty
+            $projectImage.debug_id | Should -Not -BeNullOrEmpty
+            $projectImage.code_id | Should -Not -BeNullOrEmpty
+        }
+    }
+    @{ Name = "Android: No frames have unknown_image symbolicator status"; TestBlock = {
+            param($SentryEvent, $TestSetup)
+            if (-not $TestSetup.IsAndroid) {
+                # Android-only: desktop resolves managed frames locally.
+                return
+            }
+            $frames = $SentryEvent.exception.values[0].stacktrace.frames
+            $unknown = @($frames | Where-Object { $_.data.symbolicator_status -eq "unknown_image" })
+            $unknown.Count | Should -Be 0
+        }
+    }
 )
 
 BeforeAll {

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -100,7 +100,7 @@ $DotnetCommonTestCases = @(
     @{ Name = "GodotSharp assembly debug image has debug_id and code_id"; TestBlock = {
             param($SentryEvent)
             $godotSharpImage = $SentryEvent.debugmeta.images | Where-Object {
-                $_.type -eq "pe_dotnet" -and ($_.code_file -eq "GodotSharp.dll" -or $_.code_file -like "*/GodotSharp.dll")
+                $_.type -eq "pe_dotnet" -and $_.code_file -match "(^|[\\/])GodotSharp\.dll$"
             } | Select-Object -First 1
             $godotSharpImage | Should -Not -BeNullOrEmpty
             $godotSharpImage.debug_id | Should -Not -BeNullOrEmpty

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -91,14 +91,22 @@ $DotnetCommonTestCases = @(
         }
     }
     @{ Name = "Has pe_dotnet debug images"; TestBlock = {
-            param($SentryEvent)
+            param($SentryEvent, $TestSetup)
+            if ($TestSetup.Platform -match "iOS") {
+                # iOS uses NativeAOT, no PE assemblies.
+                return
+            }
             $SentryEvent.debugmeta | Should -Not -BeNullOrEmpty
             $peImages = @($SentryEvent.debugmeta.images | Where-Object { $_.type -eq "pe_dotnet" })
             $peImages.Count | Should -BeGreaterThan 0
         }
     }
     @{ Name = "GodotSharp assembly debug image has debug_id and code_id"; TestBlock = {
-            param($SentryEvent)
+            param($SentryEvent, $TestSetup)
+            if ($TestSetup.Platform -match "iOS") {
+                # iOS uses NativeAOT, no PE assemblies.
+                return
+            }
             $godotSharpImage = $SentryEvent.debugmeta.images | Where-Object {
                 $_.type -eq "pe_dotnet" -and $_.code_file -match "(^|[\\/])GodotSharp\.dll$"
             } | Select-Object -First 1


### PR DESCRIPTION
C# stack traces captured on Android now symbolicate to file and line numbers in the Sentry issue UI (enabling source context too). Previously, every managed frame was reported as `unknown_image`, even with debug symbols uploaded. On Android, .NET assemblies live inside the application archive (possibly nested in a `.pck` container) and have no on-disk path the SDK can open, so it had no way to read the PE bytes needed to build debug images. This PR wires assembly file access through Godot's virtual filesystem that handles packing and decompression, so the SDK can read each assembly's headers and debug directory and produce the same symbolicated frames users already see on desktop (uploading debug files with `sentry-cli` is required for this to work).

- Closes #709

## For reviewers

The Sentry SDK needs each ssembly's PE bytes to build a debug image, but only reads two small segments: the headers at the start and the debug directory near the end. The assembly is exposed as a seekable handle so the managed side reads just those segments, without marshaling the whole file content. Reads are 4096-byte block-aligned and cached per assembly, which collapses ~120 small PE field reads into 2 native reads of 4096 bytes each (one block for headers, one for the debug directory).

### Caching strategy in action

<details>

<summary>Logcat (click me)</summary>

```
--------- beginning of main
Godot Engine v4.5.1.stable.mono.official.f62fdbde1 - https://godotengine.org
OpenGL API OpenGL ES 3.2 V@0502.43 (GIT@b213cd5627, I42f35bf1e0, 1686547189) (Date:06/11/23) - Compatibility - Using Device: Qualcomm - Adreno (TM) 650

Sentry: DEBUG: starting Sentry SDK version 2.0.0-beta.0+604ce1e8
Sentry: DEBUG: Automatic initialization is disabled in the project settings.
Sentry: INFO: Automatic initialization is disabled! Operations with Sentry SDK will result in no-ops.
INFO: [ProjectMainLoop] Initializing SDK from GDScript
Sentry: DEBUG: Initializing Sentry SDK
Sentry: DEBUG: initializing contexts
Sentry: DEBUG: Initializing Sentry in .NET...
Sentry: DEBUG: Assembly reader registered for .NET stack symbolication.
Sentry: DEBUG: Using Logger-based exception handler.
Sentry: DEBUG: Registered Logger-based exception handler.
Sentry: DEBUG: .NET first chance exception handler initialized.
Triggering exception...
ERROR: System.Exception: Exception (should be captured)
   at DotnetActions.TriggerException()
   at DotnetActions.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret)
   at Godot.Bridge.CSharpInstanceBridge.Call(IntPtr godotObjectGCHandle, godot_string_name* method, godot_variant** args, Int32 argCount, godot_variant_call_error* refCallError, godot_variant* ret)
   at: void Godot.NativeInterop.ExceptionUtils.LogException(System.Exception) (:0)
   C# backtrace (most recent call first):
       [0] void Godot.GD.PushError(string)
       [1] void Godot.NativeInterop.ExceptionUtils.LogException(System.Exception)
       [2] Godot.NativeInterop.godot_bool Godot.Bridge.CSharpInstanceBridge.Call(nint, Godot.NativeInterop.godot_string_name*, Godot.NativeInterop.godot_variant**, int, Godot.NativeInterop.godot_variant_call_error*, Godot.NativeInterop.godot_variant*)
Sentry: DEBUG: Capturing .NET exception caught by Godot bridge:
  System.Exception: "Exception (should be captured)"
Sentry: DEBUG: [AssemblyReader] TryReadAssembly: name=Sentry demo project.dll
Sentry: DEBUG: [AssemblyReader/native] open: path=res://.godot/mono/publish/arm64/Sentry demo project.dll, file_exists=true, opened=true
Sentry: DEBUG: [AssemblyReader/native]   length=16896
Sentry: DEBUG: [AssemblyReader]   open: handle=B4000078B56192F0, length=16896
Sentry: DEBUG: [AssemblyReader]   PEReader constructed OK
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=0, 0 -> 0
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=0, count=2
Sentry: DEBUG: [AssemblyReader]   cache MISS, reading [0, 4096) = 4096 bytes
Sentry: DEBUG: [AssemblyReader/native] read: offset=0, requested=4096, got=4096, bytes=4D5A9000(...)
Sentry: DEBUG: [AssemblyReader]   ReadFromFile: read=4096, bytes=4D5A9000(...)
Sentry: DEBUG: [AssemblyReader]   -> 2 (miss path served), bytes=4D5A
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=60, 2 -> 60
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=60, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=80000000)
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=128, 64 -> 128
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=128, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=50450000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=132, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=64AA)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=134, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0200)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=136, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=13E09CA8)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=140, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=144, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=148, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=F000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=150, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=2220)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=152, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0B02)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=154, count=1
Sentry: DEBUG: [AssemblyReader]   -> 1 (cache hit, segment[0, 4096), bytes=30)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=155, count=1
Sentry: DEBUG: [AssemblyReader]   -> 1 (cache hit, segment[0, 4096), bytes=00)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=156, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=003C0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=160, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00040000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=164, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=168, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=172, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=176, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=00000080(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=184, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=188, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=192, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0400)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=194, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=196, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=198, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=200, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0400)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=202, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=204, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=208, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00800000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=212, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=216, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=220, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0300)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=222, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=6085)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=224, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=00004000(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=232, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=00400000(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=240, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=00001000(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=248, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=00200000(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=256, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=260, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=10000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=264, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=268, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=272, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=276, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=280, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00600000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=284, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=D4030000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=288, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=292, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=296, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=300, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=304, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=308, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=312, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=B8590000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=316, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=54000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=320, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=324, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=328, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=332, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=336, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=340, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=344, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=348, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=352, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=356, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=360, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=364, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=368, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=372, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=376, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=380, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=48000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=384, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=388, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=392, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=2E746578(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=400, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=C43A0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=404, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=408, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=003C0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=412, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=416, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=420, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=424, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=426, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=428, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=20000060)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=432, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=2E727372(...))
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=440, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=D4030000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=444, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00600000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=448, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00040000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=452, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=003E0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=456, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=460, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=464, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=466, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=468, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=40000040)
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=512, 472 -> 512
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=512, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=48000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=516, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0200)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=518, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0500)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=520, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=8C310000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=524, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=2C280000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=528, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=01000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=532, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=536, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=540, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=544, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=548, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=552, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=556, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=560, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=564, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=568, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=572, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=576, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=580, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=15288, 584 -> 15288
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=15288, count=84
Sentry: DEBUG: [AssemblyReader]   cache MISS, reading [12288, 16384) = 4096 bytes
Sentry: DEBUG: [AssemblyReader/native] read: offset=12288, requested=4096, got=4096, bytes=72002D00(...)
Sentry: DEBUG: [AssemblyReader]   ReadFromFile: read=4096, bytes=72002D00(...)
Sentry: DEBUG: [AssemblyReader]   -> 84 (miss path served), bytes=00000000(...)
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=15372, 15372 -> 15372
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=15372, count=145
Sentry: DEBUG: [AssemblyReader]   -> 145 (cache hit, segment[12288, 16384), bytes=52534453(...))
Sentry: DEBUG: [AssemblyReader] Seek Sentry demo project.dll: origin=Begin, offset=15517, 15517 -> 15517
Sentry: DEBUG: [AssemblyReader] Read Sentry demo project.dll: position=15517, count=39
Sentry: DEBUG: [AssemblyReader]   -> 39 (cache hit, segment[12288, 16384), bytes=53484132(...))
Sentry: DEBUG: [AssemblyReader] Dispose Sentry demo project.dll: handle=open, position=15556
Sentry: DEBUG: [AssemblyReader/native] close
Sentry: DEBUG: [AssemblyReader] TryReadAssembly: name=GodotSharp.dll
Sentry: DEBUG: [AssemblyReader/native] open: path=res://.godot/mono/publish/arm64/GodotSharp.dll, file_exists=true, opened=true
Sentry: DEBUG: [AssemblyReader/native]   length=5613568
Sentry: DEBUG: [AssemblyReader]   open: handle=B4000078B5652070, length=5613568
Sentry: DEBUG: [AssemblyReader]   PEReader constructed OK
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=0, 0 -> 0
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=0, count=2
Sentry: DEBUG: [AssemblyReader]   cache MISS, reading [0, 4096) = 4096 bytes
Sentry: DEBUG: [AssemblyReader/native] read: offset=0, requested=4096, got=4096, bytes=4D5A9000(...)
Sentry: DEBUG: [AssemblyReader]   ReadFromFile: read=4096, bytes=4D5A9000(...)
Sentry: DEBUG: [AssemblyReader]   -> 2 (miss path served), bytes=4D5A
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=60, 2 -> 60
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=60, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=80000000)
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=128, 64 -> 128
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=128, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=50450000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=132, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=4C01)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=134, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0300)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=136, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=8C5E7A90)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=140, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=144, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=148, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=E000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=150, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=2220)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=152, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0B01)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=154, count=1
Sentry: DEBUG: [AssemblyReader]   -> 1 (cache hit, segment[0, 4096), bytes=30)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=155, count=1
Sentry: DEBUG: [AssemblyReader]   -> 1 (cache hit, segment[0, 4096), bytes=00)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=156, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=009E5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=160, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00080000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=164, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=168, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=76BB5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=172, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=176, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00C05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=180, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000010)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=184, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=188, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=192, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0400)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=194, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=196, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=198, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=200, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0400)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=202, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=204, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=208, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00005600)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=212, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=216, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=220, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0300)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=222, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=6085)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=224, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00001000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=228, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00100000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=232, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00001000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=236, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00100000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=240, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=244, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=10000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=248, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=252, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=256, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=22BB5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=260, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=4F000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=264, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00C05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=268, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=2C040000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=272, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=276, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=280, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=284, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=288, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00E05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=292, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=0C000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=296, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=40BA5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=300, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=54000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=304, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=308, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=312, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=316, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=320, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=324, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=328, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=332, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=336, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=340, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=344, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=348, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=08000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=352, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=356, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=360, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=08200000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=364, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=48000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=368, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=372, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=376, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=2E746578(...))
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=384, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=289C5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=388, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00200000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=392, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=009E5500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=396, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=400, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=404, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=408, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=410, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=412, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=20000060)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=416, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=2E727372(...))
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=424, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=2C040000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=428, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00C05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=432, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00060000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=436, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00A05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=440, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=444, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=448, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=450, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=452, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=40000040)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=456, count=8
Sentry: DEBUG: [AssemblyReader]   -> 8 (cache hit, segment[0, 4096), bytes=2E72656C(...))
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=464, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=0C000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=468, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00E05500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=472, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00020000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=476, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00A65500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=480, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=484, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=488, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=490, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=492, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=40000042)
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=520, 496 -> 520
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=520, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=48000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=524, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0200)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=526, count=2
Sentry: DEBUG: [AssemblyReader]   -> 2 (cache hit, segment[0, 4096), bytes=0500)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=528, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=E89F1E00)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=532, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=581A3700)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=536, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=01000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=540, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=544, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=548, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=552, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=556, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=560, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=564, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=568, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=572, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=576, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=580, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=584, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=588, count=4
Sentry: DEBUG: [AssemblyReader]   -> 4 (cache hit, segment[0, 4096), bytes=00000000)
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=5610560, 592 -> 5610560
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=5610560, count=84
Sentry: DEBUG: [AssemblyReader]   cache MISS, reading [5607424, 5611520) = 4096 bytes
Sentry: DEBUG: [AssemblyReader/native] read: offset=5607424, requested=4096, got=4096, bytes=74657327(...)
Sentry: DEBUG: [AssemblyReader]   ReadFromFile: read=4096, bytes=74657327(...)
Sentry: DEBUG: [AssemblyReader]   -> 84 (miss path served), bytes=00000000(...)
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=5610644, 5610644 -> 5610644
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=5610644, count=103
Sentry: DEBUG: [AssemblyReader]   -> 103 (cache hit, segment[5607424, 5611520), bytes=52534453(...))
Sentry: DEBUG: [AssemblyReader] Seek GodotSharp.dll: origin=Begin, offset=5610747, 5610747 -> 5610747
Sentry: DEBUG: [AssemblyReader] Read GodotSharp.dll: position=5610747, count=39
Sentry: DEBUG: [AssemblyReader]   -> 39 (cache hit, segment[5607424, 5611520), bytes=53484132(...))
Sentry: DEBUG: [AssemblyReader] Dispose GodotSharp.dll: handle=open, position=5610786
Sentry: DEBUG: [AssemblyReader/native] close
Sentry: DEBUG: Processing default attachments...
Sentry: DEBUG: Taking screenshot
Sentry: DEBUG: Capturing scene tree data took 334 usec
```
</details>

**TLDR**: Over a hundred of small reads per assembly folded into 2 actual native reads of 4096 bytes each. The rest is served from cache.

### Issue example

- After this PR: https://sentry-sdks.sentry.io/issues/7384782490/events/72ee343275c14db08ab703cb8458ed2a/