### PR TITLE
feat(dotnet): Symbolicate iOS NativeAOT stack frames server-side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
   - Symbolicate managed stack frames on Android server-side ([#724](https://github.com/getsentry/sentry-godot/pull/724))
-	- Symbolicate iOS NativeAOT stack frames server-side ([#727](https://github.com/getsentry/sentry-godot/pull/727))
+  - Symbolicate iOS NativeAOT stack frames server-side ([#727](https://github.com/getsentry/sentry-godot/pull/727))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
   - Symbolicate managed stack frames on Android server-side ([#724](https://github.com/getsentry/sentry-godot/pull/724))
+	- Symbolicate iOS NativeAOT stack frames server-side ([#727](https://github.com/getsentry/sentry-godot/pull/727))
 
 ### Dependencies
 

--- a/src/sentry/cocoa/cocoa_debug_images.h
+++ b/src/sentry/cocoa/cocoa_debug_images.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sentry::cocoa {
+
+// Mach-O debug image data.
+// Strings are owned by cocoa, UTF-8, and valid only inside the callback.
+struct MachOImage {
+	const char *code_file; // never null
+	const char *debug_id; // never null
+	int64_t image_address; // load address in the process
+	int64_t image_size; // 0 if unknown
+};
+
+typedef void (*VisitImageFunc)(const MachOImage *p_image, void *p_userdata);
+
+// Finds Mach-O images by base address in sentry-cocoa's in-process cache and
+// invokes the callback once per match. Returns the number of emitted images.
+// User data is passed through to the callback.
+int32_t get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count, VisitImageFunc p_callback, void *p_userdata);
+
+} // namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_debug_images.h
+++ b/src/sentry/cocoa/cocoa_debug_images.h
@@ -1,23 +1,24 @@
 #pragma once
 
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/string.hpp>
+
 #include <cstdint>
+
+using namespace godot;
 
 namespace sentry::cocoa {
 
-// Mach-O debug image data.
-// Strings are owned by cocoa, UTF-8, and valid only inside the callback.
-struct MachOImage {
-	const char *code_file; // never null
-	const char *debug_id; // never null
-	int64_t image_address; // load address in the process
-	int64_t image_size; // 0 if unknown
+// Mach-O debug image resolved from sentry-cocoa's in-process binary image cache.
+struct DebugImage {
+	String code_file;
+	String debug_id;
+	int64_t image_address = 0; // load address in the process
+	int64_t image_size = 0; // 0 if unknown
 };
 
-typedef void (*VisitImageFunc)(const MachOImage *p_image, void *p_userdata);
-
-// Finds Mach-O images by base address in sentry-cocoa's in-process cache and
-// invokes the callback once per match. Returns the number of emitted images.
-// User data is passed through to the callback.
-int32_t get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count, VisitImageFunc p_callback, void *p_userdata);
+// Finds Mach-O images by base address in sentry-cocoa's in-process cache.
+// Returns one entry per matched address; unmatched addresses are skipped.
+Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count);
 
 } // namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -22,7 +22,7 @@ Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addres
 		}
 
 		DebugImage image;
-		image.code_file = info.name ? String::utf8([info.name UTF8String]) : String();
+		image.code_file = String::utf8([info.name UTF8String]);
 		image.debug_id = info.uuid ? String::utf8([info.uuid UTF8String]) : String();
 		image.image_address = static_cast<int64_t>(info.address);
 		image.image_size = static_cast<int64_t>(info.size);

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -1,0 +1,36 @@
+#include "cocoa_debug_images.h"
+
+#include "cocoa_includes.h"
+
+namespace sentry::cocoa {
+
+int32_t get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count, VisitImageFunc p_callback, void *p_userdata) {
+	if (p_callback == nullptr || p_addresses == nullptr || p_addresses_count <= 0) {
+		return 0;
+	}
+
+	SentryBinaryImageCache *cache = SentryDependencies.binaryImageCache;
+	if (cache == nil) {
+		return 0;
+	}
+
+	int32_t emitted = 0;
+	for (int32_t i = 0; i < p_addresses_count; ++i) {
+		SentryBinaryImageInfo *info = [cache imageByAddress:(uint64_t)p_addresses[i]];
+		if (info == nil) {
+			continue;
+		}
+
+		MachOImage image = {
+			info.name ? [info.name UTF8String] : "",
+			info.uuid ? [info.uuid UTF8String] : "",
+			static_cast<int64_t>(info.address),
+			static_cast<int64_t>(info.size),
+		};
+		p_callback(&image, p_userdata);
+		++emitted;
+	}
+	return emitted;
+}
+
+} // namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -4,33 +4,31 @@
 
 namespace sentry::cocoa {
 
-int32_t get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count, VisitImageFunc p_callback, void *p_userdata) {
-	if (p_callback == nullptr || p_addresses == nullptr || p_addresses_count <= 0) {
-		return 0;
+Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addresses_count) {
+	Vector<DebugImage> images;
+	if (p_addresses == nullptr || p_addresses_count <= 0) {
+		return images;
 	}
 
 	SentryBinaryImageCache *cache = SentryDependencies.binaryImageCache;
 	if (cache == nil) {
-		return 0;
+		return images;
 	}
 
-	int32_t emitted = 0;
 	for (int32_t i = 0; i < p_addresses_count; ++i) {
 		SentryBinaryImageInfo *info = [cache imageByAddress:(uint64_t)p_addresses[i]];
 		if (info == nil) {
 			continue;
 		}
 
-		MachOImage image = {
-			info.name ? [info.name UTF8String] : "",
-			info.uuid ? [info.uuid UTF8String] : "",
-			static_cast<int64_t>(info.address),
-			static_cast<int64_t>(info.size),
-		};
-		p_callback(&image, p_userdata);
-		++emitted;
+		DebugImage image;
+		image.code_file = info.name ? String::utf8([info.name UTF8String]) : String();
+		image.debug_id = info.uuid ? String::utf8([info.uuid UTF8String]) : String();
+		image.image_address = static_cast<int64_t>(info.address);
+		image.image_size = static_cast<int64_t>(info.size);
+		images.push_back(image);
 	}
-	return emitted;
+	return images;
 }
 
 } // namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -22,7 +22,7 @@ Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addres
 		}
 
 		DebugImage image;
-		image.code_file = String::utf8([info.name UTF8String]);
+		image.code_file = String::utf8([info.name UTF8String]); // info.name is nonnull
 		image.debug_id = info.uuid ? String::utf8([info.uuid UTF8String]) : String();
 		image.image_address = static_cast<int64_t>(info.address);
 		image.image_size = static_cast<int64_t>(info.size);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -425,27 +425,6 @@ struct CocoaDebugImageEntry {
 	int64_t image_size;
 };
 
-// Contains Mach-O debug images.
-// Not part of the FFI contract - used only on the native side.
-struct CocoaDebugImageBuffer {
-	CocoaDebugImageEntry *items;
-	int32_t capacity;
-	int32_t written;
-};
-
-static void _append_debug_image(const sentry::cocoa::MachOImage *p_image, void *p_userdata) {
-	auto *buf = static_cast<CocoaDebugImageBuffer *>(p_userdata);
-	if (buf->written >= buf->capacity) {
-		// Should not happen given the upper-bound invariant.
-		return;
-	}
-	CocoaDebugImageEntry &entry = buf->items[buf->written++];
-	entry.code_file = _make_handle(String::utf8(p_image->code_file));
-	entry.debug_id = _make_handle(String::utf8(p_image->debug_id));
-	entry.image_address = p_image->image_address;
-	entry.image_size = p_image->image_size;
-}
-
 CSHARP_EXPORT int32_t csharp_interop_get_cocoa_debug_images(
 		const int64_t *p_addresses, int32_t p_addresses_count,
 		CocoaDebugImageEntry *r_entries, int32_t p_entries_capacity) {
@@ -453,9 +432,17 @@ CSHARP_EXPORT int32_t csharp_interop_get_cocoa_debug_images(
 		return 0;
 	}
 
-	CocoaDebugImageBuffer buf = { r_entries, p_entries_capacity, 0 };
-	sentry::cocoa::get_debug_images(p_addresses, p_addresses_count, &_append_debug_image, &buf);
-	return buf.written;
+	Vector<sentry::cocoa::DebugImage> images = sentry::cocoa::get_debug_images(p_addresses, p_addresses_count);
+	int32_t count = MIN(static_cast<int32_t>(images.size()), p_entries_capacity);
+	for (int32_t i = 0; i < count; ++i) {
+		const sentry::cocoa::DebugImage &image = images[i];
+		CocoaDebugImageEntry &entry = r_entries[i];
+		entry.code_file = _make_handle(image.code_file);
+		entry.debug_id = _make_handle(image.debug_id);
+		entry.image_address = image.image_address;
+		entry.image_size = image.image_size;
+	}
+	return count;
 }
 
 #endif // SDK_COCOA

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -351,52 +351,6 @@ CSHARP_EXPORT bool csharp_interop_is_android() {
 #endif
 }
 
-#ifdef SDK_COCOA
-
-// Mach-O debug image entry returned to C# for NativeAOT stack symbolication on iOS.
-// Must match layout of CocoaDebugImageEntry in NativeBridge.cs.
-struct CocoaDebugImageEntry {
-	GodotStringHandle code_file;
-	GodotStringHandle debug_id;
-	int64_t image_address;
-	int64_t image_size;
-};
-
-// Contains Mach-O debug images.
-// Not part of the FFI contract - used only on the native side.
-struct CocoaDebugImageBuffer {
-	CocoaDebugImageEntry *items;
-	int32_t capacity;
-	int32_t written;
-};
-
-static void _append_debug_image(const sentry::cocoa::MachOImage *p_image, void *p_userdata) {
-	auto *buf = static_cast<CocoaDebugImageBuffer *>(p_userdata);
-	if (buf->written >= buf->capacity) {
-		// Should not happen given the upper-bound invariant.
-		return;
-	}
-	CocoaDebugImageEntry &entry = buf->items[buf->written++];
-	entry.code_file = _make_handle(String::utf8(p_image->code_file));
-	entry.debug_id = _make_handle(String::utf8(p_image->debug_id));
-	entry.image_address = p_image->image_address;
-	entry.image_size = p_image->image_size;
-}
-
-CSHARP_EXPORT int32_t csharp_interop_get_cocoa_debug_images(
-		const int64_t *p_addresses, int32_t p_addresses_count,
-		CocoaDebugImageEntry *r_entries, int32_t p_entries_capacity) {
-	if (p_addresses == nullptr || p_addresses_count <= 0 || r_entries == nullptr || p_entries_capacity <= 0) {
-		return 0;
-	}
-
-	CocoaDebugImageBuffer buf = { r_entries, p_entries_capacity, 0 };
-	sentry::cocoa::get_debug_images(p_addresses, p_addresses_count, &_append_debug_image, &buf);
-	return buf.written;
-}
-
-#endif // SDK_COCOA
-
 // Remarks:
 // Managed side needs to access assemblies for .NET stack-trace symbolication. On Android, these assemblies live inside
 // the application archive, potentially inside a .pck container, so direct file access is not viable. Routing through
@@ -459,6 +413,52 @@ CSHARP_EXPORT void csharp_interop_close_managed_assembly(void *p_handle) {
 		memdelete(static_cast<Ref<FileAccess> *>(p_handle));
 	}
 }
+
+#ifdef SDK_COCOA
+
+// Mach-O debug image entry returned to C# for NativeAOT stack symbolication on iOS.
+// Must match layout of CocoaDebugImageEntry in NativeBridge.cs.
+struct CocoaDebugImageEntry {
+	GodotStringHandle code_file;
+	GodotStringHandle debug_id;
+	int64_t image_address;
+	int64_t image_size;
+};
+
+// Contains Mach-O debug images.
+// Not part of the FFI contract - used only on the native side.
+struct CocoaDebugImageBuffer {
+	CocoaDebugImageEntry *items;
+	int32_t capacity;
+	int32_t written;
+};
+
+static void _append_debug_image(const sentry::cocoa::MachOImage *p_image, void *p_userdata) {
+	auto *buf = static_cast<CocoaDebugImageBuffer *>(p_userdata);
+	if (buf->written >= buf->capacity) {
+		// Should not happen given the upper-bound invariant.
+		return;
+	}
+	CocoaDebugImageEntry &entry = buf->items[buf->written++];
+	entry.code_file = _make_handle(String::utf8(p_image->code_file));
+	entry.debug_id = _make_handle(String::utf8(p_image->debug_id));
+	entry.image_address = p_image->image_address;
+	entry.image_size = p_image->image_size;
+}
+
+CSHARP_EXPORT int32_t csharp_interop_get_cocoa_debug_images(
+		const int64_t *p_addresses, int32_t p_addresses_count,
+		CocoaDebugImageEntry *r_entries, int32_t p_entries_capacity) {
+	if (p_addresses == nullptr || p_addresses_count <= 0 || r_entries == nullptr || p_entries_capacity <= 0) {
+		return 0;
+	}
+
+	CocoaDebugImageBuffer buf = { r_entries, p_entries_capacity, 0 };
+	sentry::cocoa::get_debug_images(p_addresses, p_addresses_count, &_append_debug_image, &buf);
+	return buf.written;
+}
+
+#endif // SDK_COCOA
 
 static ManagedOptions s_pending_managed_opts;
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -7,6 +7,10 @@
 #include "sentry/sentry_sdk.h"
 #include "sentry/sentry_user.h"
 
+#ifdef SDK_COCOA
+#include "sentry/cocoa/cocoa_debug_images.h"
+#endif
+
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/engine_debugger.hpp>
 #include <godot_cpp/classes/file_access.hpp>
@@ -346,6 +350,52 @@ CSHARP_EXPORT bool csharp_interop_is_android() {
 	return false;
 #endif
 }
+
+#ifdef SDK_COCOA
+
+// Mach-O debug image entry returned to C# for NativeAOT stack symbolication on iOS.
+// Must match layout of CocoaDebugImageEntry in NativeBridge.cs.
+struct CocoaDebugImageEntry {
+	GodotStringHandle code_file;
+	GodotStringHandle debug_id;
+	int64_t image_address;
+	int64_t image_size;
+};
+
+// Contains Mach-O debug images.
+// Not part of the FFI contract - used only on the native side.
+struct CocoaDebugImageBuffer {
+	CocoaDebugImageEntry *items;
+	int32_t capacity;
+	int32_t written;
+};
+
+static void _append_debug_image(const sentry::cocoa::MachOImage *p_image, void *p_userdata) {
+	auto *buf = static_cast<CocoaDebugImageBuffer *>(p_userdata);
+	if (buf->written >= buf->capacity) {
+		// Should not happen given the upper-bound invariant.
+		return;
+	}
+	CocoaDebugImageEntry &entry = buf->items[buf->written++];
+	entry.code_file = _make_handle(String::utf8(p_image->code_file));
+	entry.debug_id = _make_handle(String::utf8(p_image->debug_id));
+	entry.image_address = p_image->image_address;
+	entry.image_size = p_image->image_size;
+}
+
+CSHARP_EXPORT int32_t csharp_interop_get_cocoa_debug_images(
+		const int64_t *p_addresses, int32_t p_addresses_count,
+		CocoaDebugImageEntry *r_entries, int32_t p_entries_capacity) {
+	if (p_addresses == nullptr || p_addresses_count <= 0 || r_entries == nullptr || p_entries_capacity <= 0) {
+		return 0;
+	}
+
+	CocoaDebugImageBuffer buf = { r_entries, p_entries_capacity, 0 };
+	sentry::cocoa::get_debug_images(p_addresses, p_addresses_count, &_append_debug_image, &buf);
+	return buf.written;
+}
+
+#endif // SDK_COCOA
 
 // Remarks:
 // Managed side needs to access assemblies for .NET stack-trace symbolication. On Android, these assemblies live inside

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/CocoaDebugImagesProcessor.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/CocoaDebugImagesProcessor.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using Sentry.Extensibility;
+using Sentry.Godot.Interop;
+
+namespace Sentry.Godot.Internal;
+
+/// <summary>
+/// Attaches Mach-O debug images to events on iOS so NativeAOT stack frames symbolicate server-side.
+/// </summary>
+/// <remarks>
+/// Frames arrive with <c>image_addr</c> set but no matching <c>debug_meta.images</c> entries,
+/// leaving the symbolicator with nothing to bind to. This processor reads the images from
+/// the in-process sentry-cocoa cache and appends them to the event.
+/// </remarks>
+internal sealed class CocoaDebugImagesProcessor : ISentryEventProcessor
+{
+    public SentryEvent? Process(SentryEvent @event)
+    {
+        var addresses = CollectImageAddresses(@event);
+        if (addresses.Count == 0)
+        {
+            return @event;
+        }
+
+        var images = NativeBridge.GetCocoaDebugImages(addresses);
+        if (images.Count == 0)
+        {
+            return @event;
+        }
+
+        @event.DebugImages ??= [];
+
+        // Remember existing images to avoid adding duplicates.
+        var existing = new HashSet<long>();
+        foreach (var img in @event.DebugImages)
+        {
+            if (img.ImageAddress is long addr)
+            {
+                existing.Add(addr);
+            }
+        }
+
+        foreach (var img in images)
+        {
+            if (img.ImageAddress is long addr && existing.Add(addr))
+            {
+                @event.DebugImages.Add(img);
+            }
+        }
+
+        return @event;
+    }
+
+    private static HashSet<long> CollectImageAddresses(SentryEvent @event)
+    {
+        var set = new HashSet<long>();
+
+        var exceptions = @event.SentryExceptions;
+        if (exceptions is not null)
+        {
+            foreach (var ex in exceptions)
+            {
+                AddFramesFrom(ex.Stacktrace, set);
+            }
+        }
+
+        var threads = @event.SentryThreads;
+        if (threads is not null)
+        {
+            foreach (var th in threads)
+            {
+                AddFramesFrom(th.Stacktrace, set);
+            }
+        }
+        return set;
+    }
+
+    private static void AddFramesFrom(SentryStackTrace? trace, HashSet<long> set)
+    {
+        if (trace is null)
+        {
+            return;
+        }
+        foreach (var frame in trace.Frames)
+        {
+            if (frame.ImageAddress is long addr && addr != 0)
+            {
+                set.Add(addr);
+            }
+        }
+    }
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using Sentry.Godot.Internal;
+using Sentry.Protocol;
 
 namespace Sentry.Godot.Interop;
 
@@ -643,6 +644,73 @@ internal static partial class NativeBridge
         {
             csharp_interop_close_managed_assembly(handle);
         }
+    }
+
+    // Must match layout of CocoaDebugImageEntry in csharp_interop.cpp.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CocoaDebugImageEntry
+    {
+        public GodotStringHandle code_file;
+        public GodotStringHandle debug_id;
+        public long image_address;
+        public long image_size;
+    }
+
+    [LibraryImport(Lib)]
+    private static unsafe partial int csharp_interop_get_cocoa_debug_images(
+            long* addresses, int addressesCount,
+            CocoaDebugImageEntry* entries, int entriesCapacity);
+
+    /// <summary>
+    /// Resolves Mach-O debug images for the given image base addresses from the
+    /// Cocoa SDK's in-process cache.
+    /// Used to populate debug_meta.images for NativeAOT frames on iOS, which
+    /// sentry-dotnet would otherwise leave empty for our TFM-neutral build.
+    /// </summary>
+    public static unsafe List<DebugImage> GetCocoaDebugImages(IReadOnlyCollection<long> imageAddresses)
+    {
+        var result = new List<DebugImage>();
+        int count = imageAddresses.Count;
+        if (count == 0)
+        {
+            return result;
+        }
+
+        Span<long> addresses = count <= 64
+                ? stackalloc long[count]
+                : new long[count];
+        int i = 0;
+        foreach (var addr in imageAddresses)
+        {
+            addresses[i++] = addr;
+        }
+
+        Span<CocoaDebugImageEntry> entries = count <= 16
+                ? stackalloc CocoaDebugImageEntry[count]
+                : new CocoaDebugImageEntry[count];
+
+        int written;
+        fixed (long* addressesPtr = addresses)
+        fixed (CocoaDebugImageEntry* entriesPtr = entries)
+        {
+            written = csharp_interop_get_cocoa_debug_images(addressesPtr, count, entriesPtr, count);
+        }
+
+        for (int j = 0; j < written; ++j)
+        {
+            ref CocoaDebugImageEntry entry = ref entries[j];
+            string? codeFile = entry.code_file.TakeString();
+            string? debugId = entry.debug_id.TakeString();
+            result.Add(new DebugImage
+            {
+                Type = "macho",
+                ImageAddress = entry.image_address,
+                ImageSize = entry.image_size != 0 ? entry.image_size : null,
+                DebugId = string.IsNullOrEmpty(debugId) ? null : debugId,
+                CodeFile = string.IsNullOrEmpty(codeFile) ? null : codeFile,
+            });
+        }
+        return result;
     }
 
     [LibraryImport(Lib)]

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -13,6 +13,8 @@ public static partial class SentrySdk
 
     static GodotAssemblyReader? _assemblyReader;
 
+    static CocoaDebugImagesProcessor? _cocoaDebugImagesProcessor;
+
     // Re-entry guard for the Init() -> native init() -> InitFromNative() chain:
     // Init() triggers native initialization, which signals back into the .NET
     // layer via InitFromNative() and would otherwise run InitDotnet() a second
@@ -106,6 +108,7 @@ public static partial class SentrySdk
         CurrentOptions = godotOptions;
         GodotLog.Debug("Initializing Sentry in .NET...");
         ConfigureAssemblyReader(godotOptions);
+        ConfigureCocoaDebugImagesOnIOS(godotOptions);
         Sentry.SentrySdk.Init(godotOptions);
         InitFirstChanceExceptionHandler();
     }
@@ -130,6 +133,22 @@ public static partial class SentrySdk
         _assemblyReader = new GodotAssemblyReader();
         godotOptions.AssemblyReader = _assemblyReader.TryReadAssembly;
         GodotLog.Debug("Assembly reader registered for .NET stack symbolication.");
+    }
+
+    /// <summary>
+    /// On iOS, registers a processor that attaches Mach-O debug images from the in-process
+    /// Cocoa SDK so NativeAOT stack frames can be symbolicated server-side.
+    /// </summary>
+    private static void ConfigureCocoaDebugImagesOnIOS(SentryGodotOptions godotOptions)
+    {
+        if (!OperatingSystem.IsIOS())
+        {
+            return;
+        }
+
+        _cocoaDebugImagesProcessor = new CocoaDebugImagesProcessor();
+        godotOptions.AddEventProcessor(_cocoaDebugImagesProcessor);
+        GodotLog.Debug("Cocoa debug images processor registered for NativeAOT stack symbolication.");
     }
 
     /// <summary>
@@ -188,6 +207,7 @@ public static partial class SentrySdk
         _exceptionHandler?.Dispose();
         _exceptionHandler = null;
         _assemblyReader = null;
+        _cocoaDebugImagesProcessor = null;
         Sentry.SentrySdk.Close();
         CurrentOptions = null;
     }

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -140,6 +140,18 @@ $DotnetCommonTestCases = @(
             $unknown.Count | Should -Be 0
         }
     }
+    @{ Name = "iOS: Mach-O debug image attached for NativeAOT"; TestBlock = {
+            param($SentryEvent, $TestSetup)
+            if (-not ($TestSetup.Platform -match "iOS")) {
+                # iOS-only: NativeAOT is only used on iOS in Godot.
+                return
+            }
+            $SentryEvent.debugmeta | Should -Not -BeNullOrEmpty
+            $machoImages = @($SentryEvent.debugmeta.images |
+                    Where-Object { $_.type -eq "macho" -and $_.debug_id })
+            $machoImages.Count | Should -BeGreaterThan 0
+        }
+    }
 )
 
 BeforeAll {

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -90,6 +90,14 @@ $DotnetCommonTestCases = @(
             $viewHierarchy.size | Should -BeGreaterThan 0
         }
     }
+    @{ Name = "No frames have unknown_image symbolicator status"; TestBlock = {
+            param($SentryEvent)
+            # Without an attached image, the symbolicator can't bind the frame to any image and reports unknown_image.
+            $frames = $SentryEvent.exception.values[0].stacktrace.frames
+            $unknown = @($frames | Where-Object { $_.data.symbolicator_status -eq "unknown_image" })
+            $unknown.Count | Should -Be 0
+        }
+    }
     @{ Name = "Has pe_dotnet debug images"; TestBlock = {
             param($SentryEvent, $TestSetup)
             if ($TestSetup.Platform -match "iOS") {
@@ -127,17 +135,6 @@ $DotnetCommonTestCases = @(
             $projectImage | Should -Not -BeNullOrEmpty
             $projectImage.debug_id | Should -Not -BeNullOrEmpty
             $projectImage.code_id | Should -Not -BeNullOrEmpty
-        }
-    }
-    @{ Name = "Android: No frames have unknown_image symbolicator status"; TestBlock = {
-            param($SentryEvent, $TestSetup)
-            if (-not $TestSetup.IsAndroid) {
-                # Android-only: desktop resolves managed frames locally.
-                return
-            }
-            $frames = $SentryEvent.exception.values[0].stacktrace.frames
-            $unknown = @($frames | Where-Object { $_.data.symbolicator_status -eq "unknown_image" })
-            $unknown.Count | Should -Be 0
         }
     }
     @{ Name = "iOS: Mach-O debug image attached for NativeAOT"; TestBlock = {


### PR DESCRIPTION
Attach Mach-O debug images so NativeAOT stack frames on iOS symbolicate server-side. Uploading debug symbols with `sentry-cli` is required for server-side symbolication to work.

- Closes #725
- Full automation needs #732
- Issue example (with symbols uploaded): https://sentry-sdks.sentry.io/issues/7399299847/events/ba400a137bf24eda889e0b72cb60fa21/ 
