### PR TITLE
ref(build): Use `.debugsymbols` extension on Linux and WebAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - *Experimental*: C#/.NET support (started in `2.0.0-beta.0`)
   - Symbolicate managed stack frames on Android server-side ([#724](https://github.com/getsentry/sentry-godot/pull/724))
 
+### Improvements
+
+- Rename separated debug symbol files to the `.debugsymbols` extension on Linux and Web, so they can be excluded with a single `*.debugsymbols` `.gitignore` rule ([#733](https://github.com/getsentry/sentry-godot/pull/733))
+
 ### Dependencies
 
 - Bump Sentry Android from v8.42.0 to v8.43.0 ([#731](https://github.com/getsentry/sentry-godot/pull/731))

--- a/SConstruct
+++ b/SConstruct
@@ -150,7 +150,7 @@ if internal_sdk == SDK.NATIVE:
 
     if env["separate_debug_symbols"] and platform == "linux":
         handler_path = str(deploy_crashpad_handler[0])
-        symbols_path = f"{handler_path}.debug"
+        symbols_path = f"{handler_path}.debugsymbols"
         Default(env.SeparateDebugSymbols(File(symbols_path), File(handler_path)))
 
 
@@ -278,12 +278,8 @@ if env["debug_symbols"] and env["separate_debug_symbols"]:
     if platform in ["macos", "ios"]:
         dsym_path = f"{out_dir}/dSYMs/{lib_name}.dSYM"
         env.SeparateDebugSymbols(Dir(dsym_path), library)
-    elif platform in ["linux", "android"]:
-        symbols_path = f"{out_dir}/{lib_name}.debug"
-        env.SeparateDebugSymbols(File(symbols_path), library)
-    elif platform == "web":
-        debug_name = lib_name.removesuffix(".wasm") + ".debug"
-        symbols_path = f"{out_dir}/{debug_name}"
+    elif platform in ["linux", "android", "web"]:
+        symbols_path = f"{out_dir}/{lib_name}.debugsymbols"
         env.SeparateDebugSymbols(File(symbols_path), library)
 
 


### PR DESCRIPTION
Rename separated debug symbol files from `.debug` to `.debugsymbols` to enable a clean `.gitignore` rule, addressing an issue specific to iOS where the `.debug` suffix conflicted with existing build artifact names and made it hard to distinguish symbol files from debug builds. With the new convention, Linux and WebAssembly consistently use `.debugsymbols` to full artifact names, allowing a single `*.debugsymbols` pattern to ignore symbol files reliably. The same convention exists in Godot Engine.