### PR TITLE
PoC: Unified `BeforeSendGodot` callback for managed and native events

### DIFF
--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,5 +1,6 @@
 #include "editor/sentry_editor_plugin.h"
 #include "sentry/disabled/disabled_event.h"
+#include "sentry/dotnet/dotnet_before_send_processor.h"
 #include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/logging/sentry_godot_logger.h"
 #include "sentry/processing/screenshot_processor.h"
@@ -93,6 +94,7 @@ void register_runtime_classes() {
 	GDREGISTER_INTERNAL_CLASS(logging::SentryGodotLogger);
 	GDREGISTER_INTERNAL_CLASS(SentryScopeObserver);
 	GDREGISTER_INTERNAL_CLASS(sentry::dotnet::DotnetScopeObserver);
+	GDREGISTER_INTERNAL_CLASS(sentry::dotnet::DotnetBeforeSendProcessor);
 
 #ifdef SDK_NATIVE
 	GDREGISTER_INTERNAL_CLASS(native::NativeEvent);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -1,9 +1,12 @@
+#include "sentry/dotnet/csharp_interop.h"
+
 #include "gen/sdk_version.gen.h"
 #include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/dotnet/process_default_attachments.h"
 #include "sentry/environment.h"
 #include "sentry/logging/print.h"
 #include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_event.h"
 #include "sentry/sentry_sdk.h"
 #include "sentry/sentry_user.h"
 
@@ -88,6 +91,7 @@ struct ManagedFunctions {
 	void (*remove_tag)(const char16_t *name, int32_t name_len);
 	void (*set_user)(const char16_t *id, int32_t id_len, const char16_t *username, int32_t username_len, const char16_t *email, int32_t email_len, const char16_t *ip, int32_t ip_len);
 	void (*remove_user)();
+	uint8_t (*process_native_event)(void *event_handle); // Returns 1 to keep, 0 to discard.
 };
 
 static ManagedFunctions s_managed_funcs = {};
@@ -525,6 +529,96 @@ CSHARP_EXPORT void csharp_interop_log(int32_t level, const char16_t *msg, int32_
 			String::utf16(msg, len));
 }
 
+// *** Event accessors used by the .NET BeforeSendGodot callback.
+
+// The handle is the SentryEvent* passed to the managed layer; it is valid only for the duration of that call.
+// The managed wrapper SentryNativeEvent reads and writes the event lazily through these functions,
+// so cost is proportional to the fields touched.
+
+static inline SentryEvent *_event_from_handle(void *p_handle) {
+	return static_cast<SentryEvent *>(p_handle);
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_id(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_id());
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_platform(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_platform());
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_message(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_message());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_message(void *p_handle, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_message(String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT int32_t csharp_interop_event_get_level(void *p_handle) {
+	return static_cast<int32_t>(_event_from_handle(p_handle)->get_level());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_level(void *p_handle, int32_t p_level) {
+	_event_from_handle(p_handle)->set_level(static_cast<sentry::Level>(p_level));
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_logger(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_logger());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_logger(void *p_handle, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_logger(String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_release(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_release());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_release(void *p_handle, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_release(String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_dist(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_dist());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_dist(void *p_handle, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_dist(String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_environment(void *p_handle) {
+	return _make_handle(_event_from_handle(p_handle)->get_environment());
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_environment(void *p_handle, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_environment(String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_tag(void *p_handle, const char16_t *p_key, int32_t p_key_len) {
+	return _make_handle(_event_from_handle(p_handle)->get_tag(String::utf16(p_key, p_key_len)));
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_tag(void *p_handle, const char16_t *p_key, int32_t p_key_len, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_tag(String::utf16(p_key, p_key_len), String::utf16(p_value, p_value_len));
+}
+
+CSHARP_EXPORT void csharp_interop_event_remove_tag(void *p_handle, const char16_t *p_key, int32_t p_key_len) {
+	_event_from_handle(p_handle)->remove_tag(String::utf16(p_key, p_key_len));
+}
+
+CSHARP_EXPORT int32_t csharp_interop_event_get_exception_count(void *p_handle) {
+	return _event_from_handle(p_handle)->get_exception_count();
+}
+
+CSHARP_EXPORT GodotStringHandle csharp_interop_event_get_exception_value(void *p_handle, int32_t p_index) {
+	return _make_handle(_event_from_handle(p_handle)->get_exception_value(p_index));
+}
+
+CSHARP_EXPORT void csharp_interop_event_set_exception_value(void *p_handle, int32_t p_index, const char16_t *p_value, int32_t p_value_len) {
+	_event_from_handle(p_handle)->set_exception_value(p_index, String::utf16(p_value, p_value_len));
+}
+
 } // extern "C"
 
 // *** Functions called from native
@@ -604,6 +698,26 @@ void remove_user() {
 	if (s_managed_funcs.remove_user) {
 		s_managed_funcs.remove_user();
 	}
+}
+
+bool process_event_in_managed_layer(const Ref<SentryEvent> &p_event) {
+	FAIL_COND_V_PRINT_ERROR(p_event.is_null(), true, "Internal error: Sentry .NET before-send processing received a null native event.");
+
+	if (s_managed_funcs.process_native_event == nullptr) {
+		// .NET layer not available.
+		return true;
+	}
+
+	static thread_local bool in_before_send = false;
+	if (in_before_send) {
+		return true;
+	}
+	in_before_send = true;
+
+	const bool keep = s_managed_funcs.process_native_event((void *)p_event.ptr()) != 0;
+
+	in_before_send = false;
+	return keep;
 }
 
 } // namespace sentry::dotnet

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_event.h"
 #include "sentry/sentry_user.h"
 
 #include <godot_cpp/variant/string.hpp>
@@ -25,5 +26,10 @@ void remove_tag(const String &p_key);
 
 void set_user(const Ref<SentryUser> &p_user);
 void remove_user();
+
+// Forwards a native/engine event to the .NET before-send callback.
+// Returns true to keep the event, false to discard it. Mutates the event in place.
+// No-op returning true when the .NET layer or callback is unavailable.
+bool process_event_in_managed_layer(const Ref<SentryEvent> &p_event);
 
 } // namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_before_send_processor.cpp
+++ b/src/sentry/dotnet/dotnet_before_send_processor.cpp
@@ -1,0 +1,19 @@
+#include "dotnet_before_send_processor.h"
+
+#include "sentry/dotnet/csharp_interop.h"
+
+namespace sentry::dotnet {
+
+Ref<SentryEvent> DotnetBeforeSendProcessor::process_event(const Ref<SentryEvent> &p_event) {
+	// TODO: Determine when crash events can be safely processed in the managed layer. Skipped for now.
+	if (p_event.is_null() || p_event->is_crash()) {
+		return p_event;
+	}
+	if (!process_event_in_managed_layer(p_event)) {
+		// Event was discarded by the .NET callback.
+		return nullptr;
+	}
+	return p_event;
+}
+
+} // namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_before_send_processor.h
+++ b/src/sentry/dotnet/dotnet_before_send_processor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "sentry/processing/sentry_event_processor.h"
+
+namespace sentry::dotnet {
+
+// Forwards non-crash native events to the .NET BeforeSendGodot callback.
+// Registered only when the .NET layer is present.
+class DotnetBeforeSendProcessor : public SentryEventProcessor {
+	GDCLASS(DotnetBeforeSendProcessor, SentryEventProcessor);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual Ref<SentryEvent> process_event(const Ref<SentryEvent> &p_event) override;
+};
+
+} // namespace sentry::dotnet

--- a/src/sentry/dotnet/managed/Sentry.Godot/ISentryGodotEvent.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/ISentryGodotEvent.cs
@@ -1,0 +1,90 @@
+namespace Sentry.Godot;
+
+/// <summary>
+/// Provides a user-facing, mutable view of an event passed to SentryGodotOptions.BeforeSendGodot.
+/// </summary>
+/// <remarks>
+/// This callback receives both managed events, wrapped as SentryManagedEvent, and native
+/// GDScript or engine events, wrapped as SentryNativeEvent. Members expose only the data
+/// both layers can support; implementation-specific gaps are documented by each wrapper.
+/// Native crash events are not routed through this callback.
+/// </remarks>
+public interface ISentryGodotEvent
+{
+    /// <summary>
+    /// The event's unique identifier.
+    /// </summary>
+    string? Id { get; }
+
+    /// <summary>
+    /// The platform that produced the event.
+    /// </summary>
+    string? Platform { get; }
+
+    /// <summary>
+    /// The message that describes the event.
+    /// </summary>
+    string? Message { get; set; }
+
+    /// <summary>
+    /// The severity of the event.
+    /// </summary>
+    SentryLevel? Level { get; set; }
+
+    /// <summary>
+    /// The name of the logger that captured the event.
+    /// </summary>
+    string? Logger { get; set; }
+
+    /// <summary>
+    /// The release version of the application.
+    /// </summary>
+    string? Release { get; set; }
+
+    /// <summary>
+    /// The distribution of the application.
+    /// </summary>
+    string? Distribution { get; set; }
+
+    /// <summary>
+    /// The environment the event was captured in.
+    /// </summary>
+    string? Environment { get; set; }
+
+    /// <summary>
+    /// Returns the value of the tag with the given key, or null if the tag is not set.
+    /// </summary>
+    string? GetTag(string key);
+
+    /// <summary>
+    /// Sets the tag with the given key to the given value.
+    /// </summary>
+    void SetTag(string key, string value);
+
+    /// <summary>
+    /// Removes the tag with the given key.
+    /// </summary>
+    void UnsetTag(string key);
+
+    /// <summary>
+    /// The number of exceptions attached to the event.
+    /// </summary>
+    int ExceptionCount { get; }
+
+    /// <summary>
+    /// Returns the message of the exception at the given index, or null if the index is out of range.
+    /// </summary>
+    string? GetExceptionValue(int index);
+
+    /// <summary>
+    /// Sets the message of the exception at the given index.
+    /// </summary>
+    void SetExceptionValue(int index, string value);
+
+    // Gaps (not bridged yet): fingerprint, user, extra data, breadcrumbs, contexts, and
+    // stack-frame variables are intentionally left out of the unified surface. Several of
+    // these have no accessor on the native SentryEvent yet (for example, fingerprint isn't
+    // reachable from GDScript), so they are omitted until both layers can back them rather
+    // than exposing members that only work on one side.
+    // See: https://github.com/getsentry/sentry-godot/issues/706
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotBeforeSendProcessor.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Internal/GodotBeforeSendProcessor.cs
@@ -1,0 +1,28 @@
+using Sentry.Extensibility;
+
+namespace Sentry.Godot.Internal;
+
+/// <summary>
+/// Invokes the user-configured BeforeSendGodot callback for managed events.
+/// </summary>
+/// <remarks>
+/// Managed events are passed to the callback as <see cref="SentryManagedEvent" /> instances,
+/// allowing the event to be modified before it is sent. Return the event to keep it, or return
+/// null to discard it. The same callback is also used for engine and GDScript events, providing
+/// a single place to filter all Godot events.
+/// </remarks>
+internal sealed class GodotBeforeSendProcessor : ISentryEventProcessor
+{
+    public SentryEvent? Process(SentryEvent @event)
+    {
+        var callback = Sentry.Godot.SentrySdk.CurrentOptions?.BeforeSendGodot;
+        if (callback is null)
+        {
+            return @event;
+        }
+
+        var result = callback(new SentryManagedEvent(@event));
+
+        return result is null ? null : @event;
+    }
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -238,6 +238,7 @@ internal static partial class NativeBridge
         public delegate* unmanaged[Cdecl]<char*, int, void> remove_tag;
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, char*, int, void> set_user;
         public delegate* unmanaged[Cdecl]<void> remove_user;
+        public delegate* unmanaged[Cdecl]<IntPtr, byte> process_native_event;
     }
 
     [LibraryImport(Lib)]
@@ -276,6 +277,7 @@ internal static partial class NativeBridge
             remove_tag = &RemoveTagCallback,
             set_user = &SetUserCallback,
             remove_user = &RemoveUserCallback,
+            process_native_event = &ProcessNativeEventCallback,
         });
     }
 
@@ -435,6 +437,30 @@ internal static partial class NativeBridge
         catch (Exception ex)
         {
             GodotLog.Error($"Failed to forward remove_user to Sentry .NET layer: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Called by native for each native/engine event; runs <c>BeforeSendGodot</c> with a temporary event wrapper.
+    /// Returns 1 to keep the event, 0 to discard.
+    /// </summary>
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static byte ProcessNativeEventCallback(IntPtr eventHandle)
+    {
+        try
+        {
+            var callback = Sentry.Godot.SentrySdk.CurrentOptions?.BeforeSendGodot;
+            if (callback is null)
+            {
+                return 1;
+            }
+            var result = callback(new SentryNativeEvent(eventHandle));
+            return (byte)(result is null ? 0 : 1);
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Error in BeforeSendGodot callback for native event: {ex}");
+            return 1;
         }
     }
 
@@ -902,6 +928,155 @@ internal static partial class NativeBridge
                         emailPtr, email.Length,
                         ipAddressPtr, ipAddress.Length);
             }
+        }
+    }
+
+    // Native event accessors used by SentryNativeEvent during the BeforeSendGodot callback.
+    // The handle is a native SentryEvent pointer, valid only for the duration of the callback.
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_id(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_platform(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_message(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_message(IntPtr handle, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static partial int csharp_interop_event_get_level(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static partial void csharp_interop_event_set_level(IntPtr handle, int level);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_logger(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_logger(IntPtr handle, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_release(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_release(IntPtr handle, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_dist(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_dist(IntPtr handle, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_environment(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_environment(IntPtr handle, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_tag(IntPtr handle, char* key, int keyLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_tag(IntPtr handle, char* key, int keyLen, char* value, int valueLen);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_remove_tag(IntPtr handle, char* key, int keyLen);
+
+    [LibraryImport(Lib)]
+    private static partial int csharp_interop_event_get_exception_count(IntPtr handle);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial GodotStringHandle csharp_interop_event_get_exception_value(IntPtr handle, int index);
+
+    [LibraryImport(Lib)]
+    private static unsafe partial void csharp_interop_event_set_exception_value(IntPtr handle, int index, char* value, int valueLen);
+
+    // Helper for setting a native string property by pinning the managed string for the duration of the call.
+    private static unsafe void EventSetStringProperty(IntPtr handle, string value, delegate*<IntPtr, char*, int, void> nativeSetter)
+    {
+        fixed (char* ptr = value)
+        {
+            nativeSetter(handle, ptr, value.Length);
+        }
+    }
+
+    public static string? EventGetId(IntPtr handle) => csharp_interop_event_get_id(handle).TakeString();
+
+    public static string? EventGetPlatform(IntPtr handle) => csharp_interop_event_get_platform(handle).TakeString();
+
+    public static string? EventGetMessage(IntPtr handle) => csharp_interop_event_get_message(handle).TakeString();
+
+    public static unsafe void EventSetMessage(IntPtr handle, string value)
+        => EventSetStringProperty(handle, value, &csharp_interop_event_set_message);
+
+    public static int EventGetLevel(IntPtr handle) => csharp_interop_event_get_level(handle);
+
+    public static void EventSetLevel(IntPtr handle, int level) => csharp_interop_event_set_level(handle, level);
+
+    public static string? EventGetLogger(IntPtr handle) => csharp_interop_event_get_logger(handle).TakeString();
+
+    public static unsafe void EventSetLogger(IntPtr handle, string value)
+        => EventSetStringProperty(handle, value, &csharp_interop_event_set_logger);
+
+    public static string? EventGetRelease(IntPtr handle) => csharp_interop_event_get_release(handle).TakeString();
+
+    public static unsafe void EventSetRelease(IntPtr handle, string value)
+        => EventSetStringProperty(handle, value, &csharp_interop_event_set_release);
+
+    public static string? EventGetDist(IntPtr handle) => csharp_interop_event_get_dist(handle).TakeString();
+
+    public static unsafe void EventSetDist(IntPtr handle, string value)
+        => EventSetStringProperty(handle, value, &csharp_interop_event_set_dist);
+
+    public static string? EventGetEnvironment(IntPtr handle)
+        => csharp_interop_event_get_environment(handle).TakeString();
+
+    public static unsafe void EventSetEnvironment(IntPtr handle, string value)
+        => EventSetStringProperty(handle, value, &csharp_interop_event_set_environment);
+
+    public static unsafe string? EventGetTag(IntPtr handle, string key)
+    {
+        fixed (char* keyPtr = key)
+        {
+            // Native returns an empty string for unset tags.
+            var value = csharp_interop_event_get_tag(handle, keyPtr, key.Length).TakeString();
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+    }
+
+    public static unsafe void EventSetTag(IntPtr handle, string key, string value)
+    {
+        fixed (char* keyPtr = key)
+        fixed (char* valuePtr = value)
+        {
+            csharp_interop_event_set_tag(handle, keyPtr, key.Length, valuePtr, value.Length);
+        }
+    }
+
+    public static unsafe void EventRemoveTag(IntPtr handle, string key)
+    {
+        fixed (char* keyPtr = key)
+        {
+            csharp_interop_event_remove_tag(handle, keyPtr, key.Length);
+        }
+    }
+
+    public static int EventGetExceptionCount(IntPtr handle) => csharp_interop_event_get_exception_count(handle);
+
+    public static string? EventGetExceptionValue(IntPtr handle, int index)
+    {
+        var value = csharp_interop_event_get_exception_value(handle, index).TakeString();
+        return string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    public static unsafe void EventSetExceptionValue(IntPtr handle, int index, string value)
+    {
+        fixed (char* valuePtr = value)
+        {
+            csharp_interop_event_set_exception_value(handle, index, valuePtr, value.Length);
         }
     }
 }

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -23,6 +23,27 @@ public sealed class SentryGodotOptions : SentryOptions
     }
 
     /// <summary>
+    /// Called before an event is sent to Sentry, allowing you to inspect, modify, or drop it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This callback is invoked for managed (.NET) events as well as native events, including GDScript and engine events.
+    /// Managed events are represented by <see cref="SentryManagedEvent"/>
+    /// and native events by <see cref="SentryNativeEvent"/>;
+    /// both implement <see cref="ISentryGodotEvent"/>.
+    /// </para>
+    /// <para>
+    /// Return the event to send it, or return <c>null</c> to discard it.
+    /// Native crash events are not passed to this callback.
+    /// </para>
+    /// <para>
+    /// This is the Godot integration's unified alternative to the upstream BeforeSend,
+    /// which only receives managed events.
+    /// </para>
+    /// </remarks>
+    public Func<ISentryGodotEvent, ISentryGodotEvent?>? BeforeSendGodot { get; set; }
+
+    /// <summary>
     /// If enabled, the SDK will attach the Godot log file to the event.
     /// </summary>
     public bool AttachLog { get; set; } = true;

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryManagedEvent.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryManagedEvent.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+
+namespace Sentry.Godot;
+
+/// <summary>
+/// Wraps a managed Sentry event for use with the unified BeforeSendGodot callback.
+/// </summary>
+/// <remarks>
+/// Changes made through this wrapper update the underlying event.
+/// Use <see cref="Inner"/> to access managed-only details such as fingerprint, user, and contexts.
+/// </remarks>
+public sealed class SentryManagedEvent : ISentryGodotEvent
+{
+    /// <summary>
+    /// The wrapped managed event. Use it to access properties that are not part of the unified interface.
+    /// </summary>
+    public SentryEvent Inner { get; }
+
+    internal SentryManagedEvent(SentryEvent inner)
+    {
+        Inner = inner;
+    }
+
+    /// <inheritdoc/>
+    public string? Id => Inner.EventId.ToString();
+
+    /// <inheritdoc/>
+    public string? Platform => Inner.Platform;
+
+    /// <inheritdoc/>
+    public string? Message
+    {
+        get => Inner.Message?.Formatted ?? Inner.Message?.Message;
+        set => Inner.Message = value;
+    }
+
+    /// <inheritdoc/>
+    public SentryLevel? Level { get => Inner.Level; set => Inner.Level = value; }
+
+    /// <inheritdoc/>
+    public string? Logger { get => Inner.Logger; set => Inner.Logger = value; }
+
+    /// <inheritdoc/>
+    public string? Release { get => Inner.Release; set => Inner.Release = value; }
+
+    /// <inheritdoc/>
+    public string? Distribution { get => Inner.Distribution; set => Inner.Distribution = value; }
+
+    /// <inheritdoc/>
+    public string? Environment { get => Inner.Environment; set => Inner.Environment = value; }
+
+    /// <inheritdoc/>
+    public string? GetTag(string key) => Inner.Tags.TryGetValue(key, out var value) ? value : null;
+
+    /// <inheritdoc/>
+    public void SetTag(string key, string value) => Inner.SetTag(key, value);
+
+    /// <inheritdoc/>
+    public void UnsetTag(string key) => Inner.UnsetTag(key);
+
+    /// <inheritdoc/>
+    public int ExceptionCount => Inner.SentryExceptions?.Count() ?? 0;
+
+    /// <inheritdoc/>
+    public string? GetExceptionValue(int index) => Inner.SentryExceptions?.ElementAtOrDefault(index)?.Value;
+
+    /// <inheritdoc/>
+    public void SetExceptionValue(int index, string value)
+    {
+        var exception = Inner.SentryExceptions?.ElementAtOrDefault(index);
+        if (exception is not null)
+        {
+            exception.Value = value;
+        }
+    }
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryNativeEvent.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryNativeEvent.cs
@@ -1,0 +1,107 @@
+using System;
+using Sentry.Godot.Interop;
+
+namespace Sentry.Godot;
+
+/// <summary>
+/// Represents a native Godot event passed to the <see cref="SentryGodotOptions.BeforeSendGodot"/> callback.
+/// </summary>
+/// <remarks>
+/// This instance is valid only while the callback is running and must not be retained.
+/// </remarks>
+public sealed class SentryNativeEvent : ISentryGodotEvent
+{
+    private readonly IntPtr _handle;
+
+    internal SentryNativeEvent(IntPtr handle)
+    {
+        _handle = handle;
+    }
+
+    /// <inheritdoc/>
+    public string? Id => NativeBridge.EventGetId(_handle);
+
+    /// <inheritdoc/>
+    public string? Platform => NativeBridge.EventGetPlatform(_handle);
+
+    /// <inheritdoc/>
+    public string? Message
+    {
+        get => NativeBridge.EventGetMessage(_handle);
+        set => NativeBridge.EventSetMessage(_handle, value ?? "");
+    }
+
+    /// <inheritdoc/>
+    public SentryLevel? Level
+    {
+        get => (SentryLevel)NativeBridge.EventGetLevel(_handle);
+        set
+        {
+            if (value.HasValue)
+            {
+                NativeBridge.EventSetLevel(_handle, (int)value.Value);
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public string? Logger
+    {
+        get => NativeBridge.EventGetLogger(_handle);
+        set => NativeBridge.EventSetLogger(_handle, value ?? "");
+    }
+
+    /// <inheritdoc/>
+    public string? Release
+    {
+        get => NativeBridge.EventGetRelease(_handle);
+        set => NativeBridge.EventSetRelease(_handle, value ?? "");
+    }
+
+    /// <inheritdoc/>
+    public string? Distribution
+    {
+        get => NativeBridge.EventGetDist(_handle);
+        set => NativeBridge.EventSetDist(_handle, value ?? "");
+    }
+
+    /// <inheritdoc/>
+    public string? Environment
+    {
+        get => NativeBridge.EventGetEnvironment(_handle);
+        set => NativeBridge.EventSetEnvironment(_handle, value ?? "");
+    }
+
+    /// <inheritdoc/>
+    public string? GetTag(string key)
+    {
+        return NativeBridge.EventGetTag(_handle, key);
+    }
+
+    /// <inheritdoc/>
+    public void SetTag(string key, string value)
+    {
+        NativeBridge.EventSetTag(_handle, key, value);
+    }
+
+    /// <inheritdoc/>
+    public void UnsetTag(string key)
+    {
+        NativeBridge.EventRemoveTag(_handle, key);
+    }
+
+    /// <inheritdoc/>
+    public int ExceptionCount => NativeBridge.EventGetExceptionCount(_handle);
+
+    /// <inheritdoc/>
+    public string? GetExceptionValue(int index)
+    {
+        return NativeBridge.EventGetExceptionValue(_handle, index);
+    }
+
+    /// <inheritdoc/>
+    public void SetExceptionValue(int index, string value)
+    {
+        NativeBridge.EventSetExceptionValue(_handle, index, value);
+    }
+}

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -109,6 +109,7 @@ public static partial class SentrySdk
         GodotLog.Debug("Initializing Sentry in .NET...");
         ConfigureAssemblyReader(godotOptions);
         ConfigureCocoaDebugImagesOnIOS(godotOptions);
+        godotOptions.AddEventProcessor(new GodotBeforeSendProcessor());
         Sentry.SentrySdk.Init(godotOptions);
         InitFirstChanceExceptionHandler();
     }

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -5,6 +5,7 @@
 #include "sentry/contexts.h"
 #include "sentry/disabled/disabled_sdk.h"
 #include "sentry/dotnet/csharp_interop.h"
+#include "sentry/dotnet/dotnet_before_send_processor.h"
 #include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/godot_singletons.h"
 #include "sentry/logging/print.h"
@@ -162,6 +163,10 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 	// Add built-in scope observers.
 	if (ClassDB::class_exists("CSharpScript")) {
 		options->add_scope_observer(memnew(sentry::dotnet::DotnetScopeObserver));
+
+		// Enables processing events in managed layer.
+		// Add last so BeforeSendGodot sees the fully-enriched event.
+		options->add_event_processor(memnew(sentry::dotnet::DotnetBeforeSendProcessor));
 	}
 
 	// Add default attachments.


### PR DESCRIPTION
Proof of concept. This PR introduces a unified before-send callback in .NET layer that runs for managed, GDScript and engine events, without paying the cost of marshaling and re-parsing the whole native event upfront. It gives a single place to inspect, mutate, or drop events from either layer before they are sent.

- Refs #706

Native events are exposed through a lazy proxy, so only the fields a callback actually touches cross the interop boundary. Events expose only the fields available in both layers; for managed events, the full underlying event remains accessible via the `Inner` property. Crash events are excluded, since native crash handling can run in a context where calling into the managed runtime is unsafe.