### PR TITLE
ref(dotnet): Init native unconditionally in manual SentrySdk.Init()

### DIFF
--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -64,7 +64,7 @@ public static partial class SentrySdk
             godotOptions.ApplyTemplateSubstitutions();
 
             // Use the same order as in automatic initialization for consistency.
-            InitNativeIfNeeded(godotOptions);
+            InitNative(godotOptions);
             // Fetch default attachments after native init resolves them.
             NativeBridge.FetchDefaultAttachments(godotOptions);
             InitDotnet(godotOptions);
@@ -155,12 +155,8 @@ public static partial class SentrySdk
     /// If the native SDK hasn't initialized yet (manual init case),
     /// trigger native initialization via P/Invoke.
     /// </summary>
-    private static void InitNativeIfNeeded(SentryGodotOptions godotOptions)
+    private static void InitNative(SentryGodotOptions godotOptions)
     {
-        if (NativeBridge.IsEnabled())
-        {
-            return;
-        }
         NativeBridge.InitNativeSdk(godotOptions);
     }
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -66,7 +66,7 @@ public static partial class SentrySdk
             // Use the same order as in automatic initialization for consistency.
             // Calling this unconditionally does not break auto-init path, because on
             // auto-init the request comes through a separate path that does not call
-            // `InitNativeSdk` (see SentrySdk.InitFromNative).
+            // InitNativeSdk (see SentrySdk.InitFromNative).
             NativeBridge.InitNativeSdk(godotOptions);
             // Fetch default attachments after native init resolves them.
             NativeBridge.FetchDefaultAttachments(godotOptions);

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -64,7 +64,10 @@ public static partial class SentrySdk
             godotOptions.ApplyTemplateSubstitutions();
 
             // Use the same order as in automatic initialization for consistency.
-            InitNative(godotOptions);
+            // Calling this unconditionally does not break auto-init path, because on
+            // auto-init the request comes through a separate path that does not call
+            // `InitNativeSdk` (see SentrySdk.InitFromNative).
+            NativeBridge.InitNativeSdk(godotOptions);
             // Fetch default attachments after native init resolves them.
             NativeBridge.FetchDefaultAttachments(godotOptions);
             InitDotnet(godotOptions);
@@ -149,15 +152,6 @@ public static partial class SentrySdk
         _cocoaDebugImagesProcessor = new CocoaDebugImagesProcessor();
         godotOptions.AddEventProcessor(_cocoaDebugImagesProcessor);
         GodotLog.Debug("Cocoa debug images processor registered for NativeAOT stack symbolication.");
-    }
-
-    /// <summary>
-    /// If the native SDK hasn't initialized yet (manual init case),
-    /// trigger native initialization via P/Invoke.
-    /// </summary>
-    private static void InitNative(SentryGodotOptions godotOptions)
-    {
-        NativeBridge.InitNativeSdk(godotOptions);
     }
 
     /// <summary>


### PR DESCRIPTION
Init native unconditionally in manual `SentrySdk.Init()` in C#, because the guard is dead code anyways.