### PR TITLE
ci: Distribute debug symbols in a separate package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
           name: sentry-godot-gdextension
-          path: artifact/
+          path: project/
 
       - name: Decode Apple signing certificate and API key
         if: env.DO_CODESIGN == '1'
@@ -63,18 +63,18 @@ jobs:
         run: |
           rcodesign sign --for-notarization \
             --p12-file ${{ env.APPLE_CERT_PATH }} --p12-password ${{ secrets.APPLE_CERT_PASSWORD }} \
-            artifact/addons/sentry/bin/macos/libsentry.macos.debug.dylib
+            project/addons/sentry/bin/macos/libsentry.macos.debug.dylib
           rcodesign sign --for-notarization \
             --p12-file ${{ env.APPLE_CERT_PATH }} --p12-password ${{ secrets.APPLE_CERT_PASSWORD }} \
-            artifact/addons/sentry/bin/macos/libsentry.macos.release.dylib
+            project/addons/sentry/bin/macos/libsentry.macos.release.dylib
           rcodesign sign --for-notarization \
             --p12-file ${{ env.APPLE_CERT_PATH }} --p12-password ${{ secrets.APPLE_CERT_PASSWORD }} \
-            artifact/addons/sentry/bin/macos/libSentry.dylib
+            project/addons/sentry/bin/macos/libSentry.dylib
 
       - name: Notarize macOS binaries
         if: env.DO_CODESIGN == '1'
         run: |
-          cd artifact/addons/sentry/bin/macos/
+          cd project/addons/sentry/bin/macos/
 
           zip -r sentry-godot-dylibs.zip libsentry.macos.debug.dylib libsentry.macos.release.dylib libSentry.dylib
           rcodesign notary-submit --wait \
@@ -82,34 +82,8 @@ jobs:
             sentry-godot-dylibs.zip
           rm sentry-godot-dylibs.zip
 
-      - name: Prepare artifact
-        shell: bash
-        run: |
-          # * Fix crashpad_handler permissions, workaround for https://github.com/actions/upload-artifact/issues/38
-          find artifact/addons/sentry/bin/ -name "crashpad_handler" -exec chmod 755 "{}" \;
-          # * Create release archive
-          version=$(grep '^VERSION =' SConstruct | cut -d '"' -f 2)
-          git_short_sha=$(git rev-parse --short HEAD)
-          mkdir ${GITHUB_WORKSPACE}/out/
-
-          # Addon-only zip
-          addon_archive="sentry-godot-${version}+${git_short_sha}.zip"
-          cd artifact/
-          zip -r ${GITHUB_WORKSPACE}/out/${addon_archive} addons/sentry/
-          cd ${GITHUB_WORKSPACE}
-
-          # Demo project zip
-          cp -r project/ samples_staging/
-          rm -rf samples_staging/test/ samples_staging/.godot/
-          cp -r artifact/addons samples_staging/
-          # Sanitize project.godot: remove [editor_plugins] and [gdunit4] sections, clear DSN
-          awk '/^\[editor_plugins\]/ { skip=1; next } /^\[gdunit4\]/ { skip=1; next } /^\[/ { skip=0 } !skip' \
-            samples_staging/project.godot > samples_staging/project.godot.tmp
-          mv samples_staging/project.godot.tmp samples_staging/project.godot
-          sed -i '/^options\/dsn=/d' samples_staging/project.godot
-          demo_archive="sentry-godot-demo-project-${version}+${git_short_sha}.zip"
-          cd samples_staging/
-          zip -r ${GITHUB_WORKSPACE}/out/${demo_archive} .
+      - name: Assemble packages
+        run: scripts/package.sh --source project/ --output out/
 
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -85,6 +85,15 @@ jobs:
       - name: Assemble packages
         run: scripts/package.sh --source project/ --output out/
 
+      - name: List package contents
+        shell: bash
+        run: |
+          for zip in out/*.zip; do
+            echo "::group::$(basename "$zip")"
+            unzip -l "$zip"
+            echo "::endgroup::"
+          done
+
       - name: Upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -89,7 +89,7 @@ jobs:
         shell: bash
         run: |
           for zip in out/*.zip; do
-            echo "::group::$(basename "$zip")"
+            echo "::group::$(basename "$zip") ($(du -h "$zip" | cut -f1))"
             unzip -l "$zip"
             echo "::endgroup::"
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Distribute native debug symbols in a separate `sentry-godot-debug-symbols` archive instead of bundling them with the addon, reducing the size of the released addon and demo-project packages ([#747](https://github.com/getsentry/sentry-godot/pull/747))
+
 ## 2.0.0-beta.2
 
 ### Features

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Assemble the Sentry Godot packages (addon, demo project, debug symbols) by
+# zipping a prebuilt source tree. Run with --help for usage.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF' >&2
+Usage: package.sh [options]
+
+Assemble the packages from a source tree that contains the demo project and the
+built addon (addons/sentry/):
+  <name>-<version>.zip                 addon only (addons/sentry/), symbols removed
+  <name>-demo-project-<version>.zip    demo project bundled with the addon
+  <name>-debug-symbols-<version>.zip   split native debug symbols
+
+Options:
+  --source <dir>     Tree with addons/ and the demo project (default: project)
+  --output <dir>     Directory to write the zips into (default: out)
+  --name <name>      Archive base name (default: sentry-godot)
+  --version <ver>    Version tag used in filenames, e.g. 2.0.0+abc1234
+                     (default: <VERSION from ./SConstruct>+<git short sha>)
+  -h, --help         Show this help
+EOF
+    exit "$1"
+}
+
+# Debug-symbol paths dropped from addon and demo zips.
+# Zip globs span '/', so one '*' covers per-arch subdirs.
+# Keep patterns platform-specific to avoid matching:
+#   - iOS XCFramework binary literally named "libsentry.ios.debug"
+#   - .NET pdbs under addons/sentry/dotnet/ are needed for local stack walking
+SYMBOL_PATTERNS=(
+    "addons/sentry/bin/linux/*.debug"
+    "addons/sentry/bin/android/*.debug"
+    "addons/sentry/bin/web/*.debug"
+    "addons/sentry/bin/windows/*.pdb"
+    "addons/sentry/bin/macos/dSYMs/*"
+    "addons/sentry/bin/ios/dSYMs/*"
+)
+
+# Paths dropped from the demo-project zip (in addition to the symbol patterns).
+DEMO_EXCLUDE_PATTERNS=(
+    "project.godot"       # re-added sanitized after zipping
+    "test/*"              # test suites and harness
+    ".*"                  # top-level dotfiles (.godot cache, .vscode, .zed, etc.)
+    "android/*"           # Godot Android build template (regenerated on export)
+    "addons/gdUnit4/*"    # test framework
+    "reports/*"           # local test reports
+    "export_presets.cfg"  # local export config
+)
+
+# Usage: abort <message> [exit-code]
+abort() {
+    echo "Error: $1" >&2
+    exit "${2:-1}"
+}
+
+# Usage: make_zip <zipfile> <items...>
+# Runs from $SOURCE so paths are stored tree-relative. Aborts on zip error.
+make_zip() {
+    local zipfile="$1"; shift
+    rm -f "$zipfile"
+    local rc=0
+    ( cd "$SOURCE" && zip -qr "$zipfile" "$@" ) || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        abort "zip failed with code $rc ($zipfile)" "$rc"
+    fi
+}
+
+# --- Parse arguments ---
+
+SOURCE="project"
+OUTPUT="out"
+NAME="sentry-godot"
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source) SOURCE="${2%/}"; shift 2;;
+        --output) OUTPUT="${2%/}"; shift 2;;
+        --name) NAME="$2"; shift 2;;
+        --version) VERSION="$2"; shift 2;;
+        -h|--help) usage 0;;
+        -*) echo "Unknown option: $1" >&2; usage 1;;
+        *) echo "Unexpected argument: $1" >&2; usage 1;;
+    esac
+done
+
+mkdir -p "$OUTPUT"
+OUT_ABS="$(cd "$OUTPUT" && pwd)"
+
+# --- Resolve version ---
+
+# Default version tag is "<SConstruct VERSION>+<git short sha>".
+if [[ -z "$VERSION" ]]; then
+    ver=""
+    [[ -f SConstruct ]] && ver="$(grep '^VERSION =' SConstruct | cut -d '"' -f 2)"
+    sha="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    if [[ -z "$ver" || -z "$sha" ]]; then
+        abort "could not derive version tag; pass --version <version>+<sha>"
+    fi
+    VERSION="${ver}+${sha}"
+fi
+
+# --- Prepare addon ---
+
+if [[ ! -d "$SOURCE/addons" ]]; then
+    abort "addons not found in source tree: $SOURCE/addons"
+fi
+
+# Fix crashpad_handler permissions;
+# workaround for https://github.com/actions/upload-artifact/issues/38
+if [[ -d "$SOURCE/addons/sentry/bin" ]]; then
+    find "$SOURCE/addons/sentry/bin/" -name "crashpad_handler" -exec chmod 755 "{}" \;
+fi
+
+# --- Debug symbols package ---
+
+zipfile="$OUT_ABS/${NAME}-debug-symbols-${VERSION}.zip"
+make_zip "$zipfile" addons -i "${SYMBOL_PATTERNS[@]}"
+echo "Wrote $zipfile"
+
+# --- Addon package ---
+
+zipfile="$OUT_ABS/${NAME}-${VERSION}.zip"
+make_zip "$zipfile" addons/sentry -x "${SYMBOL_PATTERNS[@]}"
+echo "Wrote $zipfile"
+
+# --- Demo project package ---
+
+if [[ ! -f "$SOURCE/project.godot" ]]; then
+    abort "project.godot not found in source tree: $SOURCE"
+fi
+
+zipfile="$OUT_ABS/${NAME}-demo-project-${VERSION}.zip"
+make_zip "$zipfile" . -x "${DEMO_EXCLUDE_PATTERNS[@]}" "${SYMBOL_PATTERNS[@]}"
+
+# Sanitize project.godot: drop [editor_plugins]/[gdunit4] sections, clear DSN.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+awk '/^\[editor_plugins\]/ { skip=1; next } /^\[gdunit4\]/ { skip=1; next } /^\[/ { skip=0 } !skip' \
+    "$SOURCE/project.godot" | sed '/^options\/dsn=/d' > "$tmp/project.godot"
+( cd "$tmp" && zip -q "$zipfile" project.godot )
+echo "Wrote $zipfile"


### PR DESCRIPTION
This PR moves SDK's native debug symbols into a separate archive so the distributed addon and demo packages no longer contain them. It introduces a new `scripts/package.sh` that assembles all three zips (the addon, the demo project and new debug-symbols package) from one prebuilt project.

Package contents and sizes can now be inspected in the CI log output.

- Refs #748
- Makes [#733](https://github.com/getsentry/sentry-godot/pull/733) redundant.
