### PR TITLE
ref(anr): Add Android-specific ANR detection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-### Improvements
+### Breaking changes
 
-- Add Android-specific ANR (Application Not Responding) detection options, with detection enabled by default ([#749](https://github.com/getsentry/sentry-godot/pull/749))
+- Add Android-specific ANR (Application Not Responding) detection options ([#749](https://github.com/getsentry/sentry-godot/pull/749))
+  - ANR detection is now enabled by default; set `SentryOptions.android.enable_anr_detection` to `false` to opt out
+  - ANR detection is now separate from the App Hang Tracking options (`app_hang_tracking`, `app_hang_timeout_sec`), which now apply to Apple platforms only
   - Configure these through `SentryOptions.android`, or in the **Project Settings** under **Sentry > Android > Application Not Responding**
-  - **Breaking**: Android ANR detection is now separate from the App Hang Tracking options (`app_hang_tracking`, `app_hang_timeout_sec`), which now apply to Apple platforms only
 
 ## 2.0.0-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Add Android-specific ANR (Application Not Responding) detection options, with detection enabled by default ([#749](https://github.com/getsentry/sentry-godot/pull/749))
+  - Configure these through `SentryOptions.android`, or in the **Project Settings** under **Sentry > Android > Application Not Responding**
+  - **Breaking**: Android ANR detection is now separate from the App Hang Tracking options (`app_hang_tracking`, `app_hang_timeout_sec`), which now apply to Apple platforms only
+
 ## 2.0.0-beta.2
 
 ### Features

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -182,9 +182,11 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
             val enableLogs = optionsData["enable_logs"] as Boolean
             val enableMetrics = optionsData["enable_metrics"] as Boolean
-            val appHangTracking = optionsData["app_hang_tracking"] as Boolean
-            val appHangTimeoutSec = optionsData["app_hang_timeout_sec"] as Double
-            val shutdownTimeoutMs = optionsData["shutdown_timeout_ms"].toIntOrThrow()
+            val enableAnrTracking = optionsData["enable_anr_tracking"] as Boolean
+            val anrTimeoutMs = optionsData["anr_timeout_ms"].toLongOrThrow()
+            val reportHistoricalAnrs = optionsData["report_historical_anrs"] as Boolean
+            val attachAnrThreadDump = optionsData["attach_anr_thread_dump"] as Boolean
+            val shutdownTimeoutMs = optionsData["shutdown_timeout_ms"].toLongOrThrow()
 
             SentryAndroid.init(godot.getActivity()!!.applicationContext) { options ->
                 options.dsn = dsn.ifEmpty { null }
@@ -198,9 +200,11 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.nativeSdkName = "sentry.native.android.godot"
                 options.logs.isEnabled = enableLogs
                 options.metrics.isEnabled = enableMetrics
-                options.isAnrEnabled = appHangTracking
-                options.anrTimeoutIntervalMillis = (appHangTimeoutSec * 1000.0).toLong()
-                options.shutdownTimeoutMillis = shutdownTimeoutMs.toLong()
+                options.isAnrEnabled = enableAnrTracking
+                options.anrTimeoutIntervalMillis = anrTimeoutMs
+                options.isReportHistoricalAnrs = reportHistoricalAnrs
+                options.isAttachAnrThreadDump = attachAnrThreadDump
+                options.shutdownTimeoutMillis = shutdownTimeoutMs
                 options.isTombstoneEnabled = true
                 options.beforeSend =
                     SentryOptions.BeforeSendCallback { event: SentryEvent, hint: Hint ->

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -182,7 +182,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
             val enableLogs = optionsData["enable_logs"] as Boolean
             val enableMetrics = optionsData["enable_metrics"] as Boolean
-            val enableAnrTracking = optionsData["enable_anr_tracking"] as Boolean
+            val enableAnrDetection = optionsData["enable_anr_detection"] as Boolean
             val anrTimeoutIntervalMs = optionsData["anr_timeout_interval_ms"].toLongOrThrow()
             val attachAnrThreadDump = optionsData["attach_anr_thread_dump"] as Boolean
             val shutdownTimeoutMs = optionsData["shutdown_timeout_ms"].toLongOrThrow()
@@ -199,7 +199,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.nativeSdkName = "sentry.native.android.godot"
                 options.logs.isEnabled = enableLogs
                 options.metrics.isEnabled = enableMetrics
-                options.isAnrEnabled = enableAnrTracking
+                options.isAnrEnabled = enableAnrDetection
                 options.anrTimeoutIntervalMillis = anrTimeoutIntervalMs
                 options.isAttachAnrThreadDump = attachAnrThreadDump
                 options.shutdownTimeoutMillis = shutdownTimeoutMs

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -183,8 +183,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val enableLogs = optionsData["enable_logs"] as Boolean
             val enableMetrics = optionsData["enable_metrics"] as Boolean
             val enableAnrTracking = optionsData["enable_anr_tracking"] as Boolean
-            val anrTimeoutMs = optionsData["anr_timeout_ms"].toLongOrThrow()
-            val reportHistoricalAnrs = optionsData["report_historical_anrs"] as Boolean
+            val anrTimeoutIntervalMs = optionsData["anr_timeout_interval_ms"].toLongOrThrow()
             val attachAnrThreadDump = optionsData["attach_anr_thread_dump"] as Boolean
             val shutdownTimeoutMs = optionsData["shutdown_timeout_ms"].toLongOrThrow()
 
@@ -201,8 +200,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.logs.isEnabled = enableLogs
                 options.metrics.isEnabled = enableMetrics
                 options.isAnrEnabled = enableAnrTracking
-                options.anrTimeoutIntervalMillis = anrTimeoutMs
-                options.isReportHistoricalAnrs = reportHistoricalAnrs
+                options.anrTimeoutIntervalMillis = anrTimeoutIntervalMs
                 options.isAttachAnrThreadDump = attachAnrThreadDump
                 options.shutdownTimeoutMillis = shutdownTimeoutMs
                 options.isTombstoneEnabled = true

--- a/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
@@ -62,6 +62,13 @@ fun Any?.toIntOrThrow(): Int =
         else -> throw IllegalArgumentException("Expected Int or Long, got ${this?.let { it::class } ?: "null"}")
     }
 
+fun Any?.toLongOrThrow(): Long =
+    when (this) {
+        is Int -> this.toLong()
+        is Long -> this
+        else -> throw IllegalArgumentException("Expected Int or Long, got ${this?.let { it::class } ?: "null"}")
+    }
+
 fun Any?.toLongOrNull(): Long? =
     when (this) {
         is Long -> this

--- a/doc_classes/SentryAndroidOptions.xml
+++ b/doc_classes/SentryAndroidOptions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SentryAndroidOptions" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Android-specific options for Sentry SDK.
+	</brief_description>
+	<description>
+		Contains configuration options that apply only when the project runs on Android, such as ANR (Application Not Responding) detection. Access this configuration through [member SentryOptions.android].
+		See also [SentryOptions].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="anr_timeout_interval_ms" type="int" setter="set_anr_timeout_interval_ms" getter="get_anr_timeout_interval_ms" default="5000">
+			Specifies how long, in milliseconds, the main thread must stay blocked before the SDK reports an ANR.
+			Applies only when [member enable_anr_detection] is enabled, and only to the V1 implementation used on Android versions before 11. On Android 11 and later, the operating system determines when the application stops responding, so this value has no effect.
+		</member>
+		<member name="attach_anr_thread_dump" type="bool" setter="set_attach_anr_thread_dump" getter="get_attach_anr_thread_dump" default="false">
+			If [code]true[/code], attaches the operating system's thread dump to the ANR event as a plain-text attachment, adding detail for investigating where the application became unresponsive.
+			Applies only when [member enable_anr_detection] is enabled, and only to the V2 implementation used on Android 11 and later.
+		</member>
+		<member name="enable_anr_detection" type="bool" setter="set_enable_anr_detection" getter="get_enable_anr_detection" default="true">
+			If [code]true[/code], detects and reports ANR (Application Not Responding) errors. The SDK monitors the main thread for unresponsiveness and reports an event when an ANR occurs.
+			Android 11 and later use the system-based V2 implementation, while earlier versions use the watchdog-based V1 implementation. See [member anr_timeout_interval_ms] and [member attach_anr_thread_dump] for options specific to each implementation. On Apple platforms, [member SentryOptions.app_hang_tracking] configures the equivalent app hang detection.
+			To learn more, visit [url=https://docs.sentry.io/platforms/android/configuration/app-not-respond/]Application Not Responding documentation[/url].
+		</member>
+	</members>
+</class>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -13,12 +13,15 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="android" type="SentryAndroidOptions" setter="" getter="get_android">
+			Configures Android-specific options, such as ANR (Application Not Responding) detection.
+		</member>
 		<member name="app_hang_timeout_sec" type="float" setter="set_app_hang_timeout_sec" getter="get_app_hang_timeout_sec" default="5.0">
 			Specifies the timeout duration in seconds after which the application is considered to have hanged. When [member app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
 		</member>
 		<member name="app_hang_tracking" type="bool" setter="set_app_hang_tracking" getter="is_app_hang_tracking_enabled" default="false">
 			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_sec]. This helps identify performance issues where the application becomes frozen or unresponsive.
-			[b]Note:[/b] This feature is only supported on Android, iOS, and macOS platforms.
+			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
 		<member name="attach_log" type="bool" setter="set_attach_log" getter="is_attach_log_enabled" default="true">
 			If [code]true[/code], the SDK will attach the Godot log file to the event.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -72,6 +72,7 @@ using namespace sentry;
 void register_runtime_classes() {
 	GDREGISTER_CLASS(SentryLoggerLimits);
 	GDREGISTER_CLASS(SentryExperimental);
+	GDREGISTER_CLASS(SentryAndroidOptions);
 	GDREGISTER_CLASS(SentryOptions);
 	GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
 	GDREGISTER_CLASS(SentryUser);

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -350,7 +350,7 @@ void AndroidSDK::init() {
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();
 	optionsData["enable_logs"] = SENTRY_OPTIONS()->get_enable_logs();
 	optionsData["enable_metrics"] = SENTRY_OPTIONS()->get_experimental()->get_enable_metrics();
-	optionsData["enable_anr_tracking"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_tracking();
+	optionsData["enable_anr_detection"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_detection();
 	optionsData["anr_timeout_interval_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_interval_ms();
 	optionsData["attach_anr_thread_dump"] = SENTRY_OPTIONS()->get_android()->get_attach_anr_thread_dump();
 	optionsData["shutdown_timeout_ms"] = SENTRY_OPTIONS()->get_shutdown_timeout_ms();

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -351,8 +351,7 @@ void AndroidSDK::init() {
 	optionsData["enable_logs"] = SENTRY_OPTIONS()->get_enable_logs();
 	optionsData["enable_metrics"] = SENTRY_OPTIONS()->get_experimental()->get_enable_metrics();
 	optionsData["enable_anr_tracking"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_tracking();
-	optionsData["anr_timeout_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_ms();
-	optionsData["report_historical_anrs"] = SENTRY_OPTIONS()->get_android()->get_report_historical_anrs();
+	optionsData["anr_timeout_interval_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_interval_ms();
 	optionsData["attach_anr_thread_dump"] = SENTRY_OPTIONS()->get_android()->get_attach_anr_thread_dump();
 	optionsData["shutdown_timeout_ms"] = SENTRY_OPTIONS()->get_shutdown_timeout_ms();
 

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -350,8 +350,10 @@ void AndroidSDK::init() {
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();
 	optionsData["enable_logs"] = SENTRY_OPTIONS()->get_enable_logs();
 	optionsData["enable_metrics"] = SENTRY_OPTIONS()->get_experimental()->get_enable_metrics();
-	optionsData["app_hang_tracking"] = SENTRY_OPTIONS()->is_app_hang_tracking_enabled();
-	optionsData["app_hang_timeout_sec"] = SENTRY_OPTIONS()->get_app_hang_timeout_sec();
+	optionsData["enable_anr_tracking"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_tracking();
+	optionsData["anr_timeout_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_ms();
+	optionsData["report_historical_anrs"] = SENTRY_OPTIONS()->get_android()->get_report_historical_anrs();
+	optionsData["attach_anr_thread_dump"] = SENTRY_OPTIONS()->get_android()->get_attach_anr_thread_dump();
 	optionsData["shutdown_timeout_ms"] = SENTRY_OPTIONS()->get_shutdown_timeout_ms();
 
 	android_plugin->call(ANDROID_SN(init),

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -236,7 +236,6 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_sample_rate(data.sample_rate);
 	options->set_max_breadcrumbs(data.max_breadcrumbs);
 	options->set_shutdown_timeout_ms(data.shutdown_timeout_ms);
-
 	options->set_send_default_pii(data.send_default_pii);
 	options->set_enable_logs(data.enable_logs);
 	options->set_attach_log(data.attach_log);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -145,6 +145,11 @@ struct NativeOptions {
 
 	// Experimental
 	uint8_t enable_metrics;
+
+	// Android
+	bool android_enable_anr_tracking;
+	int32_t android_anr_timeout_interval_ms;
+	bool android_attach_anr_thread_dump;
 };
 
 // Generic array handle for returning native-allocated arrays across the interop boundary.
@@ -200,6 +205,10 @@ struct ManagedOptions {
 	int32_t logger_log_mask;
 
 	uint8_t enable_metrics;
+
+	bool android_enable_anr_tracking;
+	int32_t android_anr_timeout_interval_ms;
+	bool android_attach_anr_thread_dump;
 };
 
 struct NativeTraceContext {
@@ -242,6 +251,9 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_logger_breadcrumb_mask(data.logger_breadcrumb_mask);
 	options->set_logger_log_mask(data.logger_log_mask);
 	options->get_experimental()->set_enable_metrics(data.enable_metrics);
+	options->get_android()->set_enable_anr_tracking(data.android_enable_anr_tracking);
+	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
+	options->get_android()->set_attach_anr_thread_dump(data.android_attach_anr_thread_dump);
 }
 
 void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &options) {
@@ -276,6 +288,9 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.logger_breadcrumb_mask = options->get_logger_breadcrumb_mask();
 	r_data.logger_log_mask = options->get_logger_log_mask();
 	r_data.enable_metrics = options->get_experimental()->get_enable_metrics();
+	r_data.android_enable_anr_tracking = options->get_android()->get_enable_anr_tracking();
+	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();
+	r_data.android_attach_anr_thread_dump = options->get_android()->get_attach_anr_thread_dump();
 }
 
 // *** Functions called from C#

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -147,9 +147,9 @@ struct NativeOptions {
 	uint8_t enable_metrics;
 
 	// Android
-	bool android_enable_anr_detection;
+	uint8_t android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
-	bool android_attach_anr_thread_dump;
+	uint8_t android_attach_anr_thread_dump;
 };
 
 // Generic array handle for returning native-allocated arrays across the interop boundary.
@@ -206,9 +206,9 @@ struct ManagedOptions {
 
 	uint8_t enable_metrics;
 
-	bool android_enable_anr_detection;
+	uint8_t android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
-	bool android_attach_anr_thread_dump;
+	uint8_t android_attach_anr_thread_dump;
 };
 
 struct NativeTraceContext {
@@ -236,6 +236,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_sample_rate(data.sample_rate);
 	options->set_max_breadcrumbs(data.max_breadcrumbs);
 	options->set_shutdown_timeout_ms(data.shutdown_timeout_ms);
+
 	options->set_send_default_pii(data.send_default_pii);
 	options->set_enable_logs(data.enable_logs);
 	options->set_attach_log(data.attach_log);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -147,7 +147,7 @@ struct NativeOptions {
 	uint8_t enable_metrics;
 
 	// Android
-	bool android_enable_anr_tracking;
+	bool android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
 	bool android_attach_anr_thread_dump;
 };
@@ -206,7 +206,7 @@ struct ManagedOptions {
 
 	uint8_t enable_metrics;
 
-	bool android_enable_anr_tracking;
+	bool android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
 	bool android_attach_anr_thread_dump;
 };
@@ -251,7 +251,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_logger_breadcrumb_mask(data.logger_breadcrumb_mask);
 	options->set_logger_log_mask(data.logger_log_mask);
 	options->get_experimental()->set_enable_metrics(data.enable_metrics);
-	options->get_android()->set_enable_anr_tracking(data.android_enable_anr_tracking);
+	options->get_android()->set_enable_anr_detection(data.android_enable_anr_detection);
 	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
 	options->get_android()->set_attach_anr_thread_dump(data.android_attach_anr_thread_dump);
 }
@@ -288,7 +288,7 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.logger_breadcrumb_mask = options->get_logger_breadcrumb_mask();
 	r_data.logger_log_mask = options->get_logger_log_mask();
 	r_data.enable_metrics = options->get_experimental()->get_enable_metrics();
-	r_data.android_enable_anr_tracking = options->get_android()->get_enable_anr_tracking();
+	r_data.android_enable_anr_detection = options->get_android()->get_enable_anr_detection();
 	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();
 	r_data.android_attach_anr_thread_dump = options->get_android()->get_attach_anr_thread_dump();
 }

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -114,6 +114,9 @@ internal static partial class NativeBridge
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
         public byte enable_metrics;
+        public byte android_enable_anr_tracking;
+        public int android_anr_timeout_interval_ms;
+        public byte android_attach_anr_thread_dump;
     }
 
     // Must match layout of ManagedOptions in csharp_interop.cpp.
@@ -149,6 +152,9 @@ internal static partial class NativeBridge
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
         public byte enable_metrics;
+        public byte android_enable_anr_tracking;
+        public int android_anr_timeout_interval_ms;
+        public byte android_attach_anr_thread_dump;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -477,6 +483,9 @@ internal static partial class NativeBridge
         opts.LoggerBreadcrumbMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_breadcrumb_mask;
         opts.LoggerLogMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_log_mask;
         opts.EnableMetrics = data.enable_metrics != 0;
+        opts.Android.EnableAnrTracking = data.android_enable_anr_tracking != 0;
+        opts.Android.AnrTimeoutInterval = TimeSpan.FromMilliseconds(data.android_anr_timeout_interval_ms);
+        opts.Android.AttachAnrThreadDump = data.android_attach_anr_thread_dump != 0;
     }
 
     public static void ApplyNativeOptions(SentryGodotOptions opts)
@@ -765,6 +774,9 @@ internal static partial class NativeBridge
                 logger_breadcrumb_mask = (int)opts.LoggerBreadcrumbMask,
                 logger_log_mask = (int)opts.LoggerLogMask,
                 enable_metrics = (byte)(opts.EnableMetrics ? 1 : 0),
+                android_enable_anr_tracking = (byte)(opts.Android.EnableAnrTracking ? 1 : 0),
+                android_anr_timeout_interval_ms = (int)opts.Android.AnrTimeoutInterval.TotalMilliseconds,
+                android_attach_anr_thread_dump = (byte)(opts.Android.AttachAnrThreadDump ? 1 : 0),
             };
             csharp_interop_sdk_init(managed);
         }

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -114,7 +114,7 @@ internal static partial class NativeBridge
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
         public byte enable_metrics;
-        public byte android_enable_anr_tracking;
+        public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
         public byte android_attach_anr_thread_dump;
     }
@@ -152,7 +152,7 @@ internal static partial class NativeBridge
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
         public byte enable_metrics;
-        public byte android_enable_anr_tracking;
+        public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
         public byte android_attach_anr_thread_dump;
     }
@@ -483,7 +483,7 @@ internal static partial class NativeBridge
         opts.LoggerBreadcrumbMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_breadcrumb_mask;
         opts.LoggerLogMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_log_mask;
         opts.EnableMetrics = data.enable_metrics != 0;
-        opts.Android.EnableAnrTracking = data.android_enable_anr_tracking != 0;
+        opts.Android.EnableAnrDetection = data.android_enable_anr_detection != 0;
         opts.Android.AnrTimeoutInterval = TimeSpan.FromMilliseconds(data.android_anr_timeout_interval_ms);
         opts.Android.AttachAnrThreadDump = data.android_attach_anr_thread_dump != 0;
     }
@@ -774,7 +774,7 @@ internal static partial class NativeBridge
                 logger_breadcrumb_mask = (int)opts.LoggerBreadcrumbMask,
                 logger_log_mask = (int)opts.LoggerLogMask,
                 enable_metrics = (byte)(opts.EnableMetrics ? 1 : 0),
-                android_enable_anr_tracking = (byte)(opts.Android.EnableAnrTracking ? 1 : 0),
+                android_enable_anr_detection = (byte)(opts.Android.EnableAnrDetection ? 1 : 0),
                 android_anr_timeout_interval_ms = (int)opts.Android.AnrTimeoutInterval.TotalMilliseconds,
                 android_attach_anr_thread_dump = (byte)(opts.Android.AttachAnrThreadDump ? 1 : 0),
             };

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -50,7 +50,8 @@ public sealed class SentryGodotOptions : SentryOptions
     /// when it becomes unresponsive for longer than <see cref="AppHangTimeout"/>.
     /// </summary>
     /// <remarks>
-    /// Only supported on Android, iOS, and macOS.
+    /// This feature applies to iOS and macOS only. On Android, <see cref="Android"/> configures
+    /// ANR (Application Not Responding) detection instead.
     /// </remarks>
     public bool AppHangTracking { get; set; } = false;
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -137,6 +137,11 @@ public sealed class SentryGodotOptions : SentryOptions
     /// </remarks>
     public SentryLoggerLimits LoggerLimits { get; set; } = new SentryLoggerLimits();
 
+    /// <summary>
+    /// Options specific to Android platform.
+    /// </summary>
+    public SentryAndroidOptions Android { get; set; } = new SentryAndroidOptions();
+
     private readonly List<SentryAttachment> _defaultAttachments = [];
 
     internal IReadOnlyList<SentryAttachment> DefaultAttachments => _defaultAttachments;
@@ -228,4 +233,25 @@ public sealed class SentryLoggerLimits
     /// Set to zero to disable this limit.
     /// </summary>
     public TimeSpan ThrottleWindow { get; set; } = TimeSpan.FromMilliseconds(10000);
+}
+
+/// <summary>
+/// Options specific to Android platform.
+/// </summary>
+public sealed class SentryAndroidOptions
+{
+    /// <summary>
+    /// Enables ANR tracking on Android.
+    /// </summary>
+    public bool EnableAnrTracking { get; set; } = true;
+
+    /// <summary>
+    /// Specifies the ANR timeout interval in milliseconds.
+    /// </summary>
+    public TimeSpan AnrTimeoutInterval { get; set; } = TimeSpan.FromMilliseconds(5000);
+
+    /// <summary>
+    /// Attaches the ANR thread dump to the crash report.
+    /// </summary>
+    public bool AttachAnrThreadDump { get; set; } = false;
 }

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -241,9 +241,9 @@ public sealed class SentryLoggerLimits
 public sealed class SentryAndroidOptions
 {
     /// <summary>
-    /// Enables ANR tracking on Android.
+    /// Enables ANR detection on Android.
     /// </summary>
-    public bool EnableAnrTracking { get; set; } = true;
+    public bool EnableAnrDetection { get; set; } = true;
 
     /// <summary>
     /// Specifies the ANR timeout interval in milliseconds.

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -138,7 +138,7 @@ public sealed class SentryGodotOptions : SentryOptions
     public SentryLoggerLimits LoggerLimits { get; set; } = new SentryLoggerLimits();
 
     /// <summary>
-    /// Options specific to Android platform.
+    /// Configures Android-specific options, such as ANR (Application Not Responding) detection.
     /// </summary>
     public SentryAndroidOptions Android { get; set; } = new SentryAndroidOptions();
 
@@ -236,22 +236,42 @@ public sealed class SentryLoggerLimits
 }
 
 /// <summary>
-/// Options specific to Android platform.
+/// Contains configuration options that apply only when the project runs on Android, such as ANR (Application Not
+/// Responding) detection. Access this configuration through <see cref="SentryGodotOptions.Android"/>.
 /// </summary>
+/// <seealso cref="SentryGodotOptions"/>
 public sealed class SentryAndroidOptions
 {
     /// <summary>
-    /// Enables ANR detection on Android.
+    /// Enables detection and reporting of ANR (Application Not Responding) errors. The SDK monitors the main thread
+    /// for unresponsiveness and reports an event when an ANR occurs.
     /// </summary>
+    /// <remarks>
+    /// Android 11 and later use the system-based V2 implementation, while earlier versions use the watchdog-based V1
+    /// implementation. See <see cref="AnrTimeoutInterval"/> and <see cref="AttachAnrThreadDump"/> for options specific
+    /// to each implementation. On Apple platforms, <see cref="SentryGodotOptions.AppHangTracking"/> configures the
+    /// equivalent app hang detection.
+    /// To learn more, visit <see href="https://docs.sentry.io/platforms/android/configuration/app-not-respond/">Application Not Responding documentation</see>.
+    /// </remarks>
     public bool EnableAnrDetection { get; set; } = true;
 
     /// <summary>
-    /// Specifies the ANR timeout interval in milliseconds.
+    /// Specifies how long the main thread must stay blocked before the SDK reports an ANR.
     /// </summary>
+    /// <remarks>
+    /// Applies only when <see cref="EnableAnrDetection"/> is enabled, and only to the V1 implementation used on Android
+    /// versions before 11. On Android 11 and later, the operating system determines when the application stops responding, so
+    /// this value has no effect.
+    /// </remarks>
     public TimeSpan AnrTimeoutInterval { get; set; } = TimeSpan.FromMilliseconds(5000);
 
     /// <summary>
-    /// Attaches the ANR thread dump to the crash report.
+    /// Attaches the operating system's thread dump to the ANR event as a plain-text attachment, adding detail for
+    /// investigating where the application became unresponsive.
     /// </summary>
+    /// <remarks>
+    /// Applies only when <see cref="EnableAnrDetection"/> is enabled, and only to the V2 implementation used on Android
+    /// 11 and later.
+    /// </remarks>
     public bool AttachAnrThreadDump { get; set; } = false;
 }

--- a/src/sentry/logging/sentry_godot_logger.cpp
+++ b/src/sentry/logging/sentry_godot_logger.cpp
@@ -274,19 +274,19 @@ void SentryGodotLogger::_process_frame() {
 void SentryGodotLogger::_apply_startup_limits() {
 	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_logger_limits();
 
-	limits.events_per_frame = MAX(30, logger_limits->events_per_frame);
-	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->repeated_error_window_ms };
-	limits.throttle_events = MAX(30, logger_limits->throttle_events);
+	limits.events_per_frame = MAX(30, logger_limits->get_events_per_frame());
+	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->get_repeated_error_window_ms() };
+	limits.throttle_events = MAX(30, logger_limits->get_throttle_events());
 	limits.throttle_window = std::chrono::milliseconds{ 0 };
 }
 
 void SentryGodotLogger::_apply_normal_limits() {
 	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_logger_limits();
 
-	limits.events_per_frame = logger_limits->events_per_frame;
-	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->repeated_error_window_ms };
-	limits.throttle_events = logger_limits->throttle_events;
-	limits.throttle_window = std::chrono::milliseconds{ logger_limits->throttle_window_ms };
+	limits.events_per_frame = logger_limits->get_events_per_frame();
+	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->get_repeated_error_window_ms() };
+	limits.throttle_events = logger_limits->get_throttle_events();
+	limits.throttle_window = std::chrono::milliseconds{ logger_limits->get_throttle_window_ms() };
 }
 
 void SentryGodotLogger::_log_error(const String &p_function, const String &p_file, int32_t p_line,

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -88,8 +88,7 @@ void SentryExperimental::_bind_methods() {
 
 void SentryAndroidOptions::_bind_methods() {
 	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, enable_anr_tracking);
-	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::INT, anr_timeout_ms);
-	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, report_historical_anrs);
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::INT, anr_timeout_interval_ms);
 	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, attach_anr_thread_dump);
 }
 
@@ -137,8 +136,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_throttle_window_ms(), false);
 
 	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_tracking"), p_options->get_android()->get_enable_anr_tracking(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_ms"), p_options->get_android()->get_anr_timeout_ms(), false);
-	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/report_historical_anrs"), p_options->get_android()->get_report_historical_anrs(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_interval_ms"), p_options->get_android()->get_anr_timeout_interval_ms(), false);
 	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/attach_thread_dump"), p_options->get_android()->get_attach_anr_thread_dump(), false);
 
 	_define_setting("sentry/experimental/attach_screenshot", p_options->attach_screenshot);
@@ -231,14 +229,10 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 			ProjectSettings::get_singleton()->get_setting(
 					"sentry/android/application_not_responding/enable_tracking",
 					p_options->android->get_enable_anr_tracking()));
-	p_options->android->set_anr_timeout_ms(
+	p_options->android->set_anr_timeout_interval_ms(
 			ProjectSettings::get_singleton()->get_setting(
-					"sentry/android/application_not_responding/timeout_ms",
-					p_options->android->get_anr_timeout_ms()));
-	p_options->android->set_report_historical_anrs(
-			ProjectSettings::get_singleton()->get_setting(
-					"sentry/android/application_not_responding/report_historical_anrs",
-					p_options->android->get_report_historical_anrs()));
+					"sentry/android/application_not_responding/timeout_interval_ms",
+					p_options->android->get_anr_timeout_interval_ms()));
 	p_options->android->set_attach_anr_thread_dump(
 			ProjectSettings::get_singleton()->get_setting(
 					"sentry/android/application_not_responding/attach_thread_dump",

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -87,7 +87,7 @@ void SentryExperimental::_bind_methods() {
 // *** SentryAndroidOptions
 
 void SentryAndroidOptions::_bind_methods() {
-	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, enable_anr_tracking);
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, enable_anr_detection);
 	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::INT, anr_timeout_interval_ms);
 	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, attach_anr_thread_dump);
 }
@@ -135,7 +135,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->get_throttle_events(), false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_throttle_window_ms(), false);
 
-	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_tracking"), p_options->get_android()->get_enable_anr_tracking(), false);
+	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_detection"), p_options->get_android()->get_enable_anr_detection(), false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_interval_ms"), p_options->get_android()->get_anr_timeout_interval_ms(), false);
 	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/attach_thread_dump"), p_options->get_android()->get_attach_anr_thread_dump(), false);
 
@@ -225,10 +225,10 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->logger_limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", p_options->logger_limits->get_throttle_events()));
 	p_options->logger_limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", p_options->logger_limits->get_throttle_window_ms()));
 
-	p_options->android->set_enable_anr_tracking(
+	p_options->android->set_enable_anr_detection(
 			ProjectSettings::get_singleton()->get_setting(
-					"sentry/android/application_not_responding/enable_tracking",
-					p_options->android->get_enable_anr_tracking()));
+					"sentry/android/application_not_responding/enable_detection",
+					p_options->android->get_enable_anr_detection()));
 	p_options->android->set_anr_timeout_interval_ms(
 			ProjectSettings::get_singleton()->get_setting(
 					"sentry/android/application_not_responding/timeout_interval_ms",

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -84,6 +84,15 @@ void SentryExperimental::_bind_methods() {
 	BIND_PROPERTY_SIMPLE(SentryExperimental, Variant::CALLABLE, before_send_log);
 }
 
+// *** SentryAndroidOptions
+
+void SentryAndroidOptions::_bind_methods() {
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, enable_anr_tracking);
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::INT, anr_timeout_ms);
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, report_historical_anrs);
+	BIND_PROPERTY_SIMPLE(SentryAndroidOptions, Variant::BOOL, attach_anr_thread_dump);
+}
+
 // *** SentryOptions
 
 void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options) {
@@ -122,10 +131,15 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_breadcrumb_mask, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/logs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_log_mask, false);
 
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->events_per_frame, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->repeated_error_window_ms, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->throttle_events, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->throttle_window_ms, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->get_events_per_frame(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_repeated_error_window_ms(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->get_throttle_events(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_throttle_window_ms(), false);
+
+	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_tracking"), p_options->get_android()->get_enable_anr_tracking(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_ms"), p_options->get_android()->get_anr_timeout_ms(), false);
+	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/report_historical_anrs"), p_options->get_android()->get_report_historical_anrs(), false);
+	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/attach_thread_dump"), p_options->get_android()->get_attach_anr_thread_dump(), false);
 
 	_define_setting("sentry/experimental/attach_screenshot", p_options->attach_screenshot);
 	_define_setting(sentry::make_level_enum_property("sentry/experimental/screenshot_level"), p_options->screenshot_level, false);
@@ -208,10 +222,27 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", p_options->logger_breadcrumb_mask);
 	p_options->logger_log_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/logs", p_options->logger_log_mask);
 
-	p_options->logger_limits->events_per_frame = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", p_options->logger_limits->events_per_frame);
-	p_options->logger_limits->repeated_error_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", p_options->logger_limits->repeated_error_window_ms);
-	p_options->logger_limits->throttle_events = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", p_options->logger_limits->throttle_events);
-	p_options->logger_limits->throttle_window_ms = ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", p_options->logger_limits->throttle_window_ms);
+	p_options->logger_limits->set_events_per_frame(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", p_options->logger_limits->get_events_per_frame()));
+	p_options->logger_limits->set_repeated_error_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", p_options->logger_limits->get_repeated_error_window_ms()));
+	p_options->logger_limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", p_options->logger_limits->get_throttle_events()));
+	p_options->logger_limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", p_options->logger_limits->get_throttle_window_ms()));
+
+	p_options->android->set_enable_anr_tracking(
+			ProjectSettings::get_singleton()->get_setting(
+					"sentry/android/application_not_responding/enable_tracking",
+					p_options->android->get_enable_anr_tracking()));
+	p_options->android->set_anr_timeout_ms(
+			ProjectSettings::get_singleton()->get_setting(
+					"sentry/android/application_not_responding/timeout_ms",
+					p_options->android->get_anr_timeout_ms()));
+	p_options->android->set_report_historical_anrs(
+			ProjectSettings::get_singleton()->get_setting(
+					"sentry/android/application_not_responding/report_historical_anrs",
+					p_options->android->get_report_historical_anrs()));
+	p_options->android->set_attach_anr_thread_dump(
+			ProjectSettings::get_singleton()->get_setting(
+					"sentry/android/application_not_responding/attach_thread_dump",
+					p_options->android->get_attach_anr_thread_dump()));
 
 	p_options->attach_screenshot = ProjectSettings::get_singleton()->get_setting("sentry/experimental/attach_screenshot", p_options->attach_screenshot);
 	p_options->screenshot_level = (sentry::Level)(int)ProjectSettings::get_singleton()->get_setting("sentry/experimental/screenshot_level", p_options->screenshot_level);
@@ -329,6 +360,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_capture_screenshot"), set_before_capture_screenshot, get_before_capture_screenshot);
 
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "experimental", PROPERTY_HINT_TYPE_STRING, "SentryExperimental", PROPERTY_USAGE_NONE), get_experimental);
+	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "android", PROPERTY_HINT_TYPE_STRING, "SentryAndroidOptions", PROPERTY_USAGE_NONE), get_android);
 
 	{
 		using namespace sentry;
@@ -349,6 +381,7 @@ SentryOptions::SentryOptions() {
 	logger_limits.instantiate();
 	experimental.instantiate();
 	experimental->owner = this;
+	android.instantiate();
 
 	_init_debug_option(DEBUG_DEFAULT);
 }

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -65,7 +65,7 @@ protected:
 class SentryAndroidOptions : public RefCounted {
 	GDCLASS(SentryAndroidOptions, RefCounted);
 
-	SIMPLE_PROPERTY(bool, enable_anr_tracking, true);
+	SIMPLE_PROPERTY(bool, enable_anr_detection, true);
 	SIMPLE_PROPERTY(int, anr_timeout_interval_ms, 5000);
 	SIMPLE_PROPERTY(bool, attach_anr_thread_dump, false);
 

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -18,7 +18,6 @@ namespace sentry {
 class SentryLoggerLimits : public RefCounted {
 	GDCLASS(SentryLoggerLimits, RefCounted);
 
-public:
 	// Protect frametime budget.
 	SIMPLE_PROPERTY(int, events_per_frame, 5);
 
@@ -58,6 +57,18 @@ public:
 	bool get_enable_logs();
 	void set_before_send_log(Callable p_value);
 	Callable get_before_send_log();
+
+protected:
+	static void _bind_methods();
+};
+
+class SentryAndroidOptions : public RefCounted {
+	GDCLASS(SentryAndroidOptions, RefCounted);
+
+	SIMPLE_PROPERTY(bool, enable_anr_tracking, true);
+	SIMPLE_PROPERTY(int, anr_timeout_ms, 5000);
+	SIMPLE_PROPERTY(bool, report_historical_anrs, false);
+	SIMPLE_PROPERTY(bool, attach_anr_thread_dump, false);
 
 protected:
 	static void _bind_methods();
@@ -112,6 +123,7 @@ private:
 	Ref<SentryLoggerLimits> logger_limits;
 
 	Ref<SentryExperimental> experimental;
+	Ref<SentryAndroidOptions> android;
 
 	Callable before_send;
 	Callable before_capture_screenshot;
@@ -231,6 +243,7 @@ public:
 	_FORCE_INLINE_ void set_before_capture_screenshot(const Callable &p_before_capture_screenshot) { before_capture_screenshot = p_before_capture_screenshot; }
 
 	_FORCE_INLINE_ Ref<SentryExperimental> get_experimental() const { return experimental; }
+	_FORCE_INLINE_ Ref<SentryAndroidOptions> get_android() const { return android; }
 
 	void add_event_processor(const Ref<SentryEventProcessor> &p_processor);
 	void remove_event_processor(const Ref<SentryEventProcessor> &p_processor);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -66,8 +66,7 @@ class SentryAndroidOptions : public RefCounted {
 	GDCLASS(SentryAndroidOptions, RefCounted);
 
 	SIMPLE_PROPERTY(bool, enable_anr_tracking, true);
-	SIMPLE_PROPERTY(int, anr_timeout_ms, 5000);
-	SIMPLE_PROPERTY(bool, report_historical_anrs, false);
+	SIMPLE_PROPERTY(int, anr_timeout_interval_ms, 5000);
 	SIMPLE_PROPERTY(bool, attach_anr_thread_dump, false);
 
 protected:

--- a/src/sentry/util/simple_bind.h
+++ b/src/sentry/util/simple_bind.h
@@ -40,6 +40,9 @@ _FORCE_INLINE_ void bind_property_readonly(const godot::StringName &p_class, con
 // Macro to define a simple property with accessors and a default value.
 // Note: The property will be compatible with BIND_PROPERTY_SIMPLE macro.
 #define SIMPLE_PROPERTY(m_type, m_property, m_default)              \
+private:                                                            \
 	m_type m_property = m_default;                                  \
+                                                                    \
+public:                                                             \
 	void set_##m_property(m_type p_value) { m_property = p_value; } \
 	m_type get_##m_property() { return m_property; }


### PR DESCRIPTION
In this PR:
- Add Android-specific ANR (Application Not Responding) detection options under `options.android` (in the **Project Settings** under **Sentry > Android > Application Not Responding**): 
  - `enable_anr_detection`, `anr_timeout_interval_ms`, `attach_anr_thread_dump`.
- ANR detection is now separate from the App Hang Tracking options
- Change ANR detection to be enabled by default 
- All according to [Grand Plan](https://linear.app/getsentry/project/anr-app-hang-parity-for-gaming-sdks-unity-unreal-godot-5ecfa2a16e7d/overview) (or at least I think so)
- Closes #750
- Refs https://github.com/getsentry/team-gdx/issues/166
- Docs PR: https://github.com/getsentry/sentry-docs/pull/18294

<img width="809" height="544" alt="image" src="https://github.com/user-attachments/assets/96c932a5-9791-4e9a-b6e0-c6521250aa5e" />
