### PR TITLE
ref(anr): Align App Hang options with other gaming SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   - ANR detection is now enabled by default; set `SentryOptions.android.enable_anr_detection` to `false` to opt out
   - ANR detection is now separate from the App Hang Tracking options (`app_hang_tracking`, `app_hang_timeout_sec`), which now apply to Apple platforms only
   - Configure these through `SentryOptions.android`, or in the **Project Settings** under **Sentry > Android > Application Not Responding**
+- Align App Hang Tracking options with other gaming SDKs ([#753](https://github.com/getsentry/sentry-godot/pull/753))
+  - Renamed `SentryOptions.app_hang_tracking` to `SentryOptions.enable_app_hang_tracking`; the old name remains as a deprecated alias.
+  - Renamed `SentryOptions.app_hang_timeout_sec` to `SentryOptions.app_hang_timeout_ms`, now configured in milliseconds; the old name remains as a deprecated alias, and existing Project Settings are migrated automatically.
 
 ### Dependencies
 

--- a/doc_classes/SentryAndroidOptions.xml
+++ b/doc_classes/SentryAndroidOptions.xml
@@ -20,7 +20,7 @@
 		</member>
 		<member name="enable_anr_detection" type="bool" setter="set_enable_anr_detection" getter="get_enable_anr_detection" default="true">
 			If [code]true[/code], detects and reports ANR (Application Not Responding) errors. The SDK monitors the main thread for unresponsiveness and reports an event when an ANR occurs.
-			Android 11 and later use the system-based V2 implementation, while earlier versions use the watchdog-based V1 implementation. See [member anr_timeout_interval_ms] and [member attach_anr_thread_dump] for options specific to each implementation. On Apple platforms, [member SentryOptions.app_hang_tracking] configures the equivalent app hang detection.
+			Android 11 and later use the system-based V2 implementation, while earlier versions use the watchdog-based V1 implementation. See [member anr_timeout_interval_ms] and [member attach_anr_thread_dump] for options specific to each implementation. On Apple platforms, [member SentryOptions.enable_app_hang_tracking] configures the equivalent app hang detection.
 			To learn more, visit [url=https://docs.sentry.io/platforms/android/configuration/app-not-respond/]Application Not Responding documentation[/url].
 		</member>
 	</members>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -19,6 +19,9 @@
 		<member name="app_hang_timeout_ms" type="int" setter="set_app_hang_timeout_ms" getter="get_app_hang_timeout_ms" default="5000">
 			Specifies the timeout duration in milliseconds after which the application is considered to have hanged. When [member enable_app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
 		</member>
+		<member name="app_hang_timeout_sec" type="float" setter="deprecated_set_app_hang_timeout_sec" getter="deprecated_get_app_hang_timeout_sec" default="5.0" deprecated="Use [member app_hang_timeout_ms] instead.">
+			Specifies the timeout duration in seconds after which the application is considered to have hanged.
+		</member>
 		<member name="app_hang_tracking" type="bool" setter="deprecated_set_app_hang_tracking" getter="deprecated_get_app_hang_tracking" default="false" deprecated="Use [member enable_app_hang_tracking] instead.">
 			If [code]true[/code], enables automatic detection and reporting of application hangs.
 		</member>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -16,8 +16,8 @@
 		<member name="android" type="SentryAndroidOptions" setter="" getter="get_android">
 			Configures Android-specific options, such as ANR (Application Not Responding) detection.
 		</member>
-		<member name="app_hang_timeout_sec" type="float" setter="set_app_hang_timeout_sec" getter="get_app_hang_timeout_sec" default="5.0">
-			Specifies the timeout duration in seconds after which the application is considered to have hanged. When [member enable_app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
+		<member name="app_hang_timeout_ms" type="int" setter="set_app_hang_timeout_ms" getter="get_app_hang_timeout_ms" default="5000">
+			Specifies the timeout duration in milliseconds after which the application is considered to have hanged. When [member enable_app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
 		</member>
 		<member name="app_hang_tracking" type="bool" setter="deprecated_set_app_hang_tracking" getter="deprecated_get_app_hang_tracking" default="false" deprecated="Use [member enable_app_hang_tracking] instead.">
 			If [code]true[/code], enables automatic detection and reporting of application hangs.
@@ -83,7 +83,7 @@
 			Data Source Name (DSN): Specifies where the SDK should send the events. If this value is not provided, the SDK will try to read it from the [code]SENTRY_DSN[/code] environment variable. If that variable also does not exist, the SDK will just not send any events.
 		</member>
 		<member name="enable_app_hang_tracking" type="bool" setter="set_app_hang_tracking_enabled" getter="is_app_hang_tracking_enabled" default="false">
-			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_sec]. This helps identify performance issues where the application becomes frozen or unresponsive.
+			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_ms]. This helps identify performance issues where the application becomes frozen or unresponsive.
 			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
 		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true">

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -17,11 +17,10 @@
 			Configures Android-specific options, such as ANR (Application Not Responding) detection.
 		</member>
 		<member name="app_hang_timeout_sec" type="float" setter="set_app_hang_timeout_sec" getter="get_app_hang_timeout_sec" default="5.0">
-			Specifies the timeout duration in seconds after which the application is considered to have hanged. When [member app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
+			Specifies the timeout duration in seconds after which the application is considered to have hanged. When [member enable_app_hang_tracking] is enabled, if the main thread is blocked for longer than this duration, it will be reported as an application hang event to Sentry.
 		</member>
-		<member name="app_hang_tracking" type="bool" setter="set_app_hang_tracking" getter="is_app_hang_tracking_enabled" default="false">
-			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_sec]. This helps identify performance issues where the application becomes frozen or unresponsive.
-			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
+		<member name="app_hang_tracking" type="bool" setter="deprecated_set_app_hang_tracking" getter="deprecated_get_app_hang_tracking" default="false" deprecated="Use [member enable_app_hang_tracking] instead.">
+			If [code]true[/code], enables automatic detection and reporting of application hangs.
 		</member>
 		<member name="attach_log" type="bool" setter="set_attach_log" getter="is_attach_log_enabled" default="true">
 			If [code]true[/code], the SDK will attach the Godot log file to the event.
@@ -82,6 +81,10 @@
 		</member>
 		<member name="dsn" type="String" setter="set_dsn" getter="get_dsn" default="&quot;&quot;">
 			Data Source Name (DSN): Specifies where the SDK should send the events. If this value is not provided, the SDK will try to read it from the [code]SENTRY_DSN[/code] environment variable. If that variable also does not exist, the SDK will just not send any events.
+		</member>
+		<member name="enable_app_hang_tracking" type="bool" setter="set_app_hang_tracking_enabled" getter="is_app_hang_tracking_enabled" default="false">
+			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_sec]. This helps identify performance issues where the application becomes frozen or unresponsive.
+			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
 		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true">
 			Enables Sentry's structured logging. If [code]true[/code], log entries can be emitted through [member SentrySDK.logger], and Godot logger events listed in [member logger_log_mask] are automatically captured as Sentry Logs. [member logger_log_mask] is empty by default, so no events are auto-captured.

--- a/project/project.godot
+++ b/project/project.godot
@@ -58,10 +58,10 @@ textures/vram_compression/import_etc2_astc=true
 
 options/auto_init=false
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
+schema_version=2
 options/attach_scene_tree=true
 logger/include_variables=true
 logger/logs=143
 logger/limits/throttle_window_ms=1000
 experimental/attach_screenshot=true
 experimental/screenshot_level=1
-schema_version=1

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -317,7 +317,7 @@ void CocoaSDK::init() {
 		}
 
 		options.enableAppHangTracking = SENTRY_OPTIONS()->is_app_hang_tracking_enabled();
-		options.appHangTimeoutInterval = SENTRY_OPTIONS()->get_app_hang_timeout_sec();
+		options.appHangTimeoutInterval = SENTRY_OPTIONS()->get_app_hang_timeout_ms() / 1000.0;
 		options.shutdownTimeInterval = SENTRY_OPTIONS()->get_shutdown_timeout_ms() / 1000.0;
 
 		// NOTE: This only works for captureMessage(), unfortunately.

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -133,7 +133,7 @@ struct NativeOptions {
 	uint8_t attach_screenshot;
 	int32_t screenshot_level;
 	uint8_t enable_app_hang_tracking;
-	double app_hang_timeout_sec;
+	int32_t app_hang_timeout_ms;
 
 	// Logger
 	uint8_t logger_enabled;
@@ -195,7 +195,7 @@ struct ManagedOptions {
 	uint8_t attach_screenshot;
 	int32_t screenshot_level;
 	uint8_t enable_app_hang_tracking;
-	double app_hang_timeout_sec;
+	int32_t app_hang_timeout_ms;
 
 	uint8_t logger_enabled;
 	uint8_t logger_include_source;
@@ -243,7 +243,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_attach_screenshot(data.attach_screenshot);
 	options->set_screenshot_level((Level)data.screenshot_level);
 	options->set_app_hang_tracking_enabled(data.enable_app_hang_tracking);
-	options->set_app_hang_timeout_sec(data.app_hang_timeout_sec);
+	options->set_app_hang_timeout_ms(data.app_hang_timeout_ms);
 	options->set_logger_enabled(data.logger_enabled);
 	options->set_logger_include_source(data.logger_include_source);
 	options->set_logger_include_variables(data.logger_include_variables);
@@ -280,7 +280,7 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.attach_screenshot = options->is_attach_screenshot_enabled();
 	r_data.screenshot_level = options->get_screenshot_level();
 	r_data.enable_app_hang_tracking = options->is_app_hang_tracking_enabled();
-	r_data.app_hang_timeout_sec = options->get_app_hang_timeout_sec();
+	r_data.app_hang_timeout_ms = options->get_app_hang_timeout_ms();
 	r_data.logger_enabled = options->is_logger_enabled();
 	r_data.logger_include_source = options->is_logger_include_source_enabled();
 	r_data.logger_include_variables = options->is_logger_include_variables_enabled();

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -132,7 +132,7 @@ struct NativeOptions {
 	uint8_t attach_scene_tree;
 	uint8_t attach_screenshot;
 	int32_t screenshot_level;
-	uint8_t app_hang_tracking;
+	uint8_t enable_app_hang_tracking;
 	double app_hang_timeout_sec;
 
 	// Logger
@@ -194,7 +194,7 @@ struct ManagedOptions {
 	uint8_t attach_scene_tree;
 	uint8_t attach_screenshot;
 	int32_t screenshot_level;
-	uint8_t app_hang_tracking;
+	uint8_t enable_app_hang_tracking;
 	double app_hang_timeout_sec;
 
 	uint8_t logger_enabled;
@@ -242,7 +242,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_attach_scene_tree(data.attach_scene_tree);
 	options->set_attach_screenshot(data.attach_screenshot);
 	options->set_screenshot_level((Level)data.screenshot_level);
-	options->set_app_hang_tracking(data.app_hang_tracking);
+	options->set_app_hang_tracking_enabled(data.enable_app_hang_tracking);
 	options->set_app_hang_timeout_sec(data.app_hang_timeout_sec);
 	options->set_logger_enabled(data.logger_enabled);
 	options->set_logger_include_source(data.logger_include_source);
@@ -279,7 +279,7 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.attach_scene_tree = options->is_attach_scene_tree_enabled();
 	r_data.attach_screenshot = options->is_attach_screenshot_enabled();
 	r_data.screenshot_level = options->get_screenshot_level();
-	r_data.app_hang_tracking = options->is_app_hang_tracking_enabled();
+	r_data.enable_app_hang_tracking = options->is_app_hang_tracking_enabled();
 	r_data.app_hang_timeout_sec = options->get_app_hang_timeout_sec();
 	r_data.logger_enabled = options->is_logger_enabled();
 	r_data.logger_include_source = options->is_logger_include_source_enabled();

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -105,7 +105,7 @@ internal static partial class NativeBridge
         public byte attach_scene_tree;
         public byte attach_screenshot;
         public int screenshot_level;
-        public byte app_hang_tracking;
+        public byte enable_app_hang_tracking;
         public double app_hang_timeout_sec;
         public byte logger_enabled;
         public byte logger_include_source;
@@ -143,7 +143,7 @@ internal static partial class NativeBridge
         public byte attach_scene_tree;
         public byte attach_screenshot;
         public int screenshot_level;
-        public byte app_hang_tracking;
+        public byte enable_app_hang_tracking;
         public double app_hang_timeout_sec;
         public byte logger_enabled;
         public byte logger_include_source;
@@ -474,7 +474,7 @@ internal static partial class NativeBridge
         opts.AttachSceneTree = data.attach_scene_tree != 0;
         opts.AttachScreenshot = data.attach_screenshot != 0;
         opts.ScreenshotLevel = (SentryLevel)data.screenshot_level;
-        opts.AppHangTracking = data.app_hang_tracking != 0;
+        opts.EnableAppHangTracking = data.enable_app_hang_tracking != 0;
         opts.AppHangTimeout = TimeSpan.FromSeconds(data.app_hang_timeout_sec);
         opts.LoggerEnabled = data.logger_enabled != 0;
         opts.LoggerIncludeSource = data.logger_include_source != 0;
@@ -765,7 +765,7 @@ internal static partial class NativeBridge
                 attach_scene_tree = (byte)(opts.AttachSceneTree ? 1 : 0),
                 attach_screenshot = (byte)(opts.AttachScreenshot ? 1 : 0),
                 screenshot_level = (int)opts.ScreenshotLevel,
-                app_hang_tracking = (byte)(opts.AppHangTracking ? 1 : 0),
+                enable_app_hang_tracking = (byte)(opts.EnableAppHangTracking ? 1 : 0),
                 app_hang_timeout_sec = opts.AppHangTimeout.TotalSeconds,
                 logger_enabled = (byte)(opts.LoggerEnabled ? 1 : 0),
                 logger_include_source = (byte)(opts.LoggerIncludeSource ? 1 : 0),

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -106,7 +106,7 @@ internal static partial class NativeBridge
         public byte attach_screenshot;
         public int screenshot_level;
         public byte enable_app_hang_tracking;
-        public double app_hang_timeout_sec;
+        public int app_hang_timeout_ms;
         public byte logger_enabled;
         public byte logger_include_source;
         public byte logger_include_variables;
@@ -144,7 +144,7 @@ internal static partial class NativeBridge
         public byte attach_screenshot;
         public int screenshot_level;
         public byte enable_app_hang_tracking;
-        public double app_hang_timeout_sec;
+        public int app_hang_timeout_ms;
         public byte logger_enabled;
         public byte logger_include_source;
         public byte logger_include_variables;
@@ -475,7 +475,7 @@ internal static partial class NativeBridge
         opts.AttachScreenshot = data.attach_screenshot != 0;
         opts.ScreenshotLevel = (SentryLevel)data.screenshot_level;
         opts.EnableAppHangTracking = data.enable_app_hang_tracking != 0;
-        opts.AppHangTimeout = TimeSpan.FromSeconds(data.app_hang_timeout_sec);
+        opts.AppHangTimeout = TimeSpan.FromMilliseconds(data.app_hang_timeout_ms);
         opts.LoggerEnabled = data.logger_enabled != 0;
         opts.LoggerIncludeSource = data.logger_include_source != 0;
         opts.LoggerIncludeVariables = data.logger_include_variables != 0;
@@ -766,7 +766,7 @@ internal static partial class NativeBridge
                 attach_screenshot = (byte)(opts.AttachScreenshot ? 1 : 0),
                 screenshot_level = (int)opts.ScreenshotLevel,
                 enable_app_hang_tracking = (byte)(opts.EnableAppHangTracking ? 1 : 0),
-                app_hang_timeout_sec = opts.AppHangTimeout.TotalSeconds,
+                app_hang_timeout_ms = (int)opts.AppHangTimeout.TotalMilliseconds,
                 logger_enabled = (byte)(opts.LoggerEnabled ? 1 : 0),
                 logger_include_source = (byte)(opts.LoggerIncludeSource ? 1 : 0),
                 logger_include_variables = (byte)(opts.LoggerIncludeVariables ? 1 : 0),

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -53,7 +53,7 @@ public sealed class SentryGodotOptions : SentryOptions
     /// This feature applies to iOS and macOS only. On Android, <see cref="Android"/> configures
     /// ANR (Application Not Responding) detection instead.
     /// </remarks>
-    public bool AppHangTracking { get; set; } = false;
+    public bool EnableAppHangTracking { get; set; } = false;
 
     /// <summary>
     /// Duration after which the application is considered to have hanged.

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -250,7 +250,7 @@ public sealed class SentryAndroidOptions
     /// <remarks>
     /// Android 11 and later use the system-based V2 implementation, while earlier versions use the watchdog-based V1
     /// implementation. See <see cref="AnrTimeoutInterval"/> and <see cref="AttachAnrThreadDump"/> for options specific
-    /// to each implementation. On Apple platforms, <see cref="SentryGodotOptions.AppHangTracking"/> configures the
+    /// to each implementation. On Apple platforms, <see cref="SentryGodotOptions.EnableAppHangTracking"/> configures the
     /// equivalent app hang detection.
     /// To learn more, visit <see href="https://docs.sentry.io/platforms/android/configuration/app-not-respond/">Application Not Responding documentation</see>.
     /// </remarks>

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -285,6 +285,15 @@ void SentryOptions::deprecated_set_app_hang_tracking(bool p_enabled) {
 	set_app_hang_tracking_enabled(p_enabled);
 }
 
+double SentryOptions::deprecated_get_app_hang_timeout_sec() const {
+	return static_cast<double>(get_app_hang_timeout_ms()) / 1000.0;
+}
+
+void SentryOptions::deprecated_set_app_hang_timeout_sec(double p_seconds) {
+	WARN_DEPRECATED_MSG("The \"app_hang_timeout_sec\" option is deprecated. Use \"app_hang_timeout_ms\" instead.");
+	set_app_hang_timeout_ms(static_cast<int>(Math::round(p_seconds * 1000.0)));
+}
+
 void SentryOptions::set_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
 	logger_limits = p_limits;
 	// Ensure limits are initialized.
@@ -375,10 +384,11 @@ void SentryOptions::_bind_methods() {
 		BIND_BITFIELD_FLAG(MASK_MESSAGE);
 	}
 
-	// DEPRECATED: This property is deprecated and remains for compatibility reasons.
-	// TODO: Remove it after November 2026 or in version 3.0.
+	// DEPRECATED: These properties are deprecated and remain for compatibility reasons.
+	// TODO: Remove these after November 2026 or in version 3.0.
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), set_logger_messages_as_breadcrumbs, is_logger_messages_as_breadcrumbs_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), deprecated_set_app_hang_tracking, deprecated_get_app_hang_tracking);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), deprecated_set_app_hang_timeout_sec, deprecated_get_app_hang_timeout_sec);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -120,7 +120,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/enable_logs", p_options->enable_logs, false);
 
 	_define_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking, false);
-	_define_setting("sentry/options/app_hang/timeout_sec", p_options->app_hang_timeout_sec, false);
+	_define_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms, false);
 
 	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);
@@ -211,7 +211,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->enable_logs = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_logs", p_options->enable_logs);
 
 	p_options->enable_app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking);
-	p_options->app_hang_timeout_sec = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_sec", p_options->app_hang_timeout_sec);
+	p_options->app_hang_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms);
 
 	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	p_options->logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", p_options->logger_include_source);
@@ -349,7 +349,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_log"), set_before_send_log, get_before_send_log);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_app_hang_tracking"), set_app_hang_tracking_enabled, is_app_hang_tracking_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), set_app_hang_timeout_sec, get_app_hang_timeout_sec);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "app_hang_timeout_ms"), set_app_hang_timeout_ms, get_app_hang_timeout_ms);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -119,7 +119,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 
 	_define_setting("sentry/options/enable_logs", p_options->enable_logs, false);
 
-	_define_setting("sentry/options/app_hang/tracking", p_options->app_hang_tracking, false);
+	_define_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking, false);
 	_define_setting("sentry/options/app_hang/timeout_sec", p_options->app_hang_timeout_sec, false);
 
 	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
@@ -210,7 +210,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->enable_logs = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_logs", p_options->enable_logs);
 
-	p_options->app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->app_hang_tracking);
+	p_options->enable_app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking);
 	p_options->app_hang_timeout_sec = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_sec", p_options->app_hang_timeout_sec);
 
 	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
@@ -276,6 +276,15 @@ void SentryOptions::set_logger_messages_as_breadcrumbs(bool p_enabled) {
 	}
 }
 
+bool SentryOptions::deprecated_get_app_hang_tracking() const {
+	return is_app_hang_tracking_enabled();
+}
+
+void SentryOptions::deprecated_set_app_hang_tracking(bool p_enabled) {
+	WARN_DEPRECATED_MSG("The \"app_hang_tracking\" option is deprecated. Use \"enable_app_hang_tracking\" instead.");
+	set_app_hang_tracking_enabled(p_enabled);
+}
+
 void SentryOptions::set_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
 	logger_limits = p_limits;
 	// Ensure limits are initialized.
@@ -339,7 +348,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_logs"), set_enable_logs, get_enable_logs);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_log"), set_before_send_log, get_before_send_log);
 
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), set_app_hang_tracking, is_app_hang_tracking_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_app_hang_tracking"), set_app_hang_tracking_enabled, is_app_hang_tracking_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), set_app_hang_timeout_sec, get_app_hang_timeout_sec);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
@@ -369,6 +378,7 @@ void SentryOptions::_bind_methods() {
 	// DEPRECATED: This property is deprecated and remains for compatibility reasons.
 	// TODO: Remove it after November 2026 or in version 3.0.
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), set_logger_messages_as_breadcrumbs, is_logger_messages_as_breadcrumbs_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), deprecated_set_app_hang_tracking, deprecated_get_app_hang_tracking);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -358,7 +358,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_log"), set_before_send_log, get_before_send_log);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_app_hang_tracking"), set_app_hang_tracking_enabled, is_app_hang_tracking_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "app_hang_timeout_ms"), set_app_hang_timeout_ms, get_app_hang_timeout_ms);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "app_hang_timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), set_app_hang_timeout_ms, get_app_hang_timeout_ms);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -120,7 +120,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/enable_logs", p_options->enable_logs, false);
 
 	_define_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking, false);
-	_define_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/app_hang/timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), p_options->app_hang_timeout_ms, false);
 
 	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
 	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -208,6 +208,9 @@ public:
 	_FORCE_INLINE_ int get_app_hang_timeout_ms() const { return app_hang_timeout_ms; }
 	_FORCE_INLINE_ void set_app_hang_timeout_ms(int p_milliseconds) { app_hang_timeout_ms = p_milliseconds; }
 
+	double deprecated_get_app_hang_timeout_sec() const;
+	void deprecated_set_app_hang_timeout_sec(double p_seconds);
+
 	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
 	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }
 

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -111,7 +111,7 @@ private:
 	Callable before_send_log;
 
 	bool enable_app_hang_tracking = false;
-	double app_hang_timeout_sec = 5.0;
+	int app_hang_timeout_ms = 5000;
 
 	bool logger_enabled = true;
 	bool logger_include_source = true;
@@ -205,8 +205,8 @@ public:
 	bool deprecated_get_app_hang_tracking() const;
 	void deprecated_set_app_hang_tracking(bool p_enabled);
 
-	_FORCE_INLINE_ double get_app_hang_timeout_sec() const { return app_hang_timeout_sec; }
-	_FORCE_INLINE_ void set_app_hang_timeout_sec(double p_seconds) { app_hang_timeout_sec = p_seconds; }
+	_FORCE_INLINE_ int get_app_hang_timeout_ms() const { return app_hang_timeout_ms; }
+	_FORCE_INLINE_ void set_app_hang_timeout_ms(int p_milliseconds) { app_hang_timeout_ms = p_milliseconds; }
 
 	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
 	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -110,7 +110,7 @@ private:
 	bool enable_logs = true;
 	Callable before_send_log;
 
-	bool app_hang_tracking = false;
+	bool enable_app_hang_tracking = false;
 	double app_hang_timeout_sec = 5.0;
 
 	bool logger_enabled = true;
@@ -199,8 +199,11 @@ public:
 	_FORCE_INLINE_ Callable get_before_send_log() const { return before_send_log; }
 	_FORCE_INLINE_ void set_before_send_log(const Callable &p_callback) { before_send_log = p_callback; }
 
-	_FORCE_INLINE_ bool is_app_hang_tracking_enabled() const { return app_hang_tracking; }
-	_FORCE_INLINE_ void set_app_hang_tracking(bool p_enabled) { app_hang_tracking = p_enabled; }
+	_FORCE_INLINE_ bool is_app_hang_tracking_enabled() const { return enable_app_hang_tracking; }
+	_FORCE_INLINE_ void set_app_hang_tracking_enabled(bool p_enabled) { enable_app_hang_tracking = p_enabled; }
+
+	bool deprecated_get_app_hang_tracking() const;
+	void deprecated_set_app_hang_tracking(bool p_enabled);
 
 	_FORCE_INLINE_ double get_app_hang_timeout_sec() const { return app_hang_timeout_sec; }
 	_FORCE_INLINE_ void set_app_hang_timeout_sec(double p_seconds) { app_hang_timeout_sec = p_seconds; }

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -66,11 +66,26 @@ void _migrate_to_v1() {
 	_migrate_messages_as_breadcrumbs();
 }
 
+void _migrate_app_hang_timeout_to_ms() {
+	const String old_setting = "sentry/options/app_hang/timeout_sec";
+	const String new_setting = "sentry/options/app_hang/timeout_ms";
+
+	if (ProjectSettings::get_singleton()->has_setting(old_setting)) {
+		const double seconds = ProjectSettings::get_singleton()->get_setting(old_setting);
+		ProjectSettings::get_singleton()->set_setting(new_setting, UtilityFunctions::roundi(seconds * 1000.0));
+		ProjectSettings::get_singleton()->set_setting(old_setting, Variant());
+	}
+}
+
+void _migrate_to_v2() {
+	_migrate_app_hang_timeout_to_ms();
+}
+
 } // unnamed namespace
 
 namespace sentry {
 
-constexpr static int SCHEMA_VERSION = 1;
+constexpr static int SCHEMA_VERSION = 2;
 
 void run_project_settings_migrations() {
 	const String schema_version_key = "sentry/schema_version";
@@ -94,6 +109,10 @@ void run_project_settings_migrations() {
 
 	if (from_version < 1) {
 		_migrate_to_v1();
+	}
+
+	if (from_version < 2) {
+		_migrate_to_v2();
 	}
 
 	if (from_version < SCHEMA_VERSION) {


### PR DESCRIPTION
Aligns the app hang options with the other gaming SDKs, continuing the cross-SDK effort to standardize how detection of a frozen main thread is configured. The master toggle is renamed to `enable_app_hang_tracking` (`EnableAppHangTracking` in the C# layer), and the timeout is now expressed in milliseconds as `app_hang_timeout_ms` to match the units used elsewhere. The former `app_hang_tracking` and `app_hang_timeout_sec` options remain as deprecated aliases that forward to the new ones, and a Project Settings migration rewrites existing persisted values (converting the timeout from seconds to milliseconds) so projects upgrade without manual changes. 
- Waiting for #749 
- Refs https://github.com/getsentry/team-gdx/issues/166
