### PR TITLE
ref(options): Group Godot logger options under `options.godot_logger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Align App Hang Tracking options with other gaming SDKs ([#753](https://github.com/getsentry/sentry-godot/pull/753))
   - Renamed `SentryOptions.app_hang_tracking` to `SentryOptions.enable_app_hang_tracking`; the old name remains as a deprecated alias.
   - Renamed `SentryOptions.app_hang_timeout_sec` to `SentryOptions.app_hang_timeout_ms`, now configured in milliseconds; the old name remains as a deprecated alias, and existing Project Settings are migrated automatically.
+- Group Godot logger options under `SentryOptions.godot_logger` ([#759](https://github.com/getsentry/sentry-godot/pull/759))
+  - Moved the `SentryOptions.logger_*` options under `SentryOptions.godot_logger` (for example, `logger_event_mask` becomes `godot_logger.event_mask`); the old names remain as deprecated aliases.
+  - Renamed `logger_include_source` to `godot_logger.include_source_context` as part of the move.
+  - Existing Project Settings under **Sentry > Logger** are migrated automatically.
 
 ### Dependencies
 

--- a/doc_classes/SentryGodotLoggerOptions.xml
+++ b/doc_classes/SentryGodotLoggerOptions.xml
@@ -15,7 +15,7 @@
 			Specifies the Godot logger events that are automatically captured as Sentry breadcrumbs. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks.
 		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="get_enabled" default="true">
-			If [code]true[/code], the SDK will capture logged errors as events, breadcrumbs and/or logs, as defined by [member event_mask], [member breadcrumb_mask] and [member log_mask]. Crashes are always captured. See also [member SentryOptions.enable_logs].
+			If [code]true[/code], the SDK will capture logged errors as events, breadcrumbs and/or logs, as defined by [member event_mask], [member breadcrumb_mask] and [member log_mask]. Crashes are always captured.
 		</member>
 		<member name="event_mask" type="int" setter="set_event_mask" getter="get_event_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="13">
 			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks.

--- a/doc_classes/SentryGodotLoggerOptions.xml
+++ b/doc_classes/SentryGodotLoggerOptions.xml
@@ -21,7 +21,7 @@
 			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks.
 			[b]Note:[/b] [code]MASK_MESSAGE[/code] has no effect here. To capture log messages, set it in [member log_mask] and/or [member breadcrumb_mask] instead.
 		</member>
-		<member name="include_source" type="bool" setter="set_include_source" getter="get_include_source" default="true">
+		<member name="include_source_context" type="bool" setter="set_include_source_context" getter="get_include_source_context" default="true">
 			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
 		</member>
 		<member name="include_variables" type="bool" setter="set_include_variables" getter="get_include_variables" default="false">

--- a/doc_classes/SentryGodotLoggerOptions.xml
+++ b/doc_classes/SentryGodotLoggerOptions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SentryGodotLoggerOptions" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Options for capturing Godot errors and log messages.
+	</brief_description>
+	<description>
+		Contains configuration options that control how the SDK captures Godot errors and log messages as Sentry events, breadcrumbs, and logs. This includes engine errors, GDScript and shader errors, GDExtension errors, [code]push_error()[/code] and [code]push_warning()[/code] statements, as well as log messages from [code]print()[/code] and similar functions.
+		Access this configuration through [member SentryOptions.godot_logger].
+		See also [SentryOptions].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="breadcrumb_mask" type="int" setter="set_breadcrumb_mask" getter="get_breadcrumb_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="143">
+			Specifies the Godot logger events that are automatically captured as Sentry breadcrumbs. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks.
+		</member>
+		<member name="enabled" type="bool" setter="set_enabled" getter="get_enabled" default="true">
+			If [code]true[/code], the SDK will capture logged errors as events, breadcrumbs and/or logs, as defined by [member event_mask], [member breadcrumb_mask] and [member log_mask]. Crashes are always captured. See also [member SentryOptions.enable_logs].
+		</member>
+		<member name="event_mask" type="int" setter="set_event_mask" getter="get_event_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="13">
+			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks.
+			[b]Note:[/b] [code]MASK_MESSAGE[/code] has no effect here. To capture log messages, set it in [member log_mask] and/or [member breadcrumb_mask] instead.
+		</member>
+		<member name="include_source" type="bool" setter="set_include_source" getter="get_include_source" default="true">
+			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
+		</member>
+		<member name="include_variables" type="bool" setter="set_include_variables" getter="get_include_variables" default="false">
+			If [code]true[/code], the SDK will include local variables from stack traces when capturing script errors. This allows showing the values of variables at each frame in the call stack. Requires enabling [member ProjectSettings.debug/settings/gdscript/always_track_local_variables].
+			[b]Note:[/b] Enabling this option may impact performance, especially for applications with frequent errors or deep call stacks.
+		</member>
+		<member name="limits" type="SentryLoggerLimits" setter="" getter="get_limits">
+			Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending too many non-critical and repeating error events. See [SentryLoggerLimits].
+		</member>
+		<member name="log_mask" type="int" setter="set_log_mask" getter="get_log_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="0">
+			Specifies the Godot logger events that are automatically captured as Sentry logs. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks. Empty by default, so no events are captured as logs.
+			[b]Note:[/b] Log capture requires [member SentryOptions.enable_logs] to be enabled.
+		</member>
+	</members>
+</class>

--- a/doc_classes/SentryLoggerLimits.xml
+++ b/doc_classes/SentryLoggerLimits.xml
@@ -4,7 +4,8 @@
 		Specifies throttling limits for the error logger.
 	</brief_description>
 	<description>
-		These limits govern the behavior of throttling and are used to prevent the SDK from sending too many non-critical and repeating error events. See also [SentryOptions].
+		These limits govern the behavior of throttling and are used to prevent the SDK from sending too many non-critical and repeating error events. Access this configuration through [member SentryGodotLoggerOptions.limits].
+		See also [SentryGodotLoggerOptions].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -115,7 +115,7 @@
 			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.
 			[b]Note:[/b] [code]MASK_MESSAGE[/code] has no effect here. To capture log messages, set it in [member logger_log_mask] and/or [member logger_breadcrumb_mask] instead.
 		</member>
-		<member name="logger_include_source" type="bool" setter="deprecated_set_logger_include_source" getter="deprecated_is_logger_include_source_enabled" default="true" deprecated="Use [member SentryGodotLoggerOptions.include_source] instead.">
+		<member name="logger_include_source" type="bool" setter="deprecated_set_logger_include_source" getter="deprecated_is_logger_include_source_enabled" default="true" deprecated="Use [member SentryGodotLoggerOptions.include_source_context] instead.">
 			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
 		</member>
 		<member name="logger_include_variables" type="bool" setter="deprecated_set_logger_include_variables" getter="deprecated_is_logger_include_variables_enabled" default="false" deprecated="Use [member SentryGodotLoggerOptions.include_variables] instead.">

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -90,8 +90,8 @@
 			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
 		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true">
-			Enables Sentry's structured logging. If [code]true[/code], log entries can be emitted through [member SentrySDK.logger], and Godot logger events listed in [member logger_log_mask] are automatically captured as Sentry Logs. [member logger_log_mask] is empty by default, so no events are auto-captured.
-			See [member logger_enabled] and the other [code]logger_*[/code] options to capture Godot errors as Sentry events or breadcrumbs.
+			Enables Sentry's structured logging. If [code]true[/code], log entries can be emitted through [member SentrySDK.logger], and Godot logger events listed in [member SentryGodotLoggerOptions.log_mask] are automatically captured as Sentry Logs. [member SentryGodotLoggerOptions.log_mask] is empty by default, so no events are auto-captured.
+			See [member godot_logger] for options to capture Godot errors as Sentry events or breadcrumbs.
 			For more information, see [url=https://docs.sentry.io/platforms/godot/logs/]Sentry Logs[/url] documentation.
 		</member>
 		<member name="environment" type="String" setter="set_environment" getter="get_environment" default="&quot;{auto}&quot;">
@@ -102,30 +102,33 @@
 		<member name="experimental" type="SentryExperimental" setter="" getter="get_experimental">
 			Configures experimental features. Use this to enable and configure features that are not yet stable or generally available in Sentry.
 		</member>
-		<member name="logger_breadcrumb_mask" type="int" setter="set_logger_breadcrumb_mask" getter="get_logger_breadcrumb_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="143">
+		<member name="godot_logger" type="SentryGodotLoggerOptions" setter="" getter="get_godot_logger">
+			Configures the capture of Godot errors and log messages as Sentry events, breadcrumbs, and logs. See [SentryGodotLoggerOptions].
+		</member>
+		<member name="logger_breadcrumb_mask" type="int" setter="deprecated_set_logger_breadcrumb_mask" getter="deprecated_get_logger_breadcrumb_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="143" deprecated="Use [member SentryGodotLoggerOptions.breadcrumb_mask] instead.">
 			Specifies the Godot logger events that are automatically captured as Sentry breadcrumbs. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.
 		</member>
-		<member name="logger_enabled" type="bool" setter="set_logger_enabled" getter="is_logger_enabled" default="true">
+		<member name="logger_enabled" type="bool" setter="deprecated_set_logger_enabled" getter="deprecated_is_logger_enabled" default="true" deprecated="Use [member SentryGodotLoggerOptions.enabled] instead.">
 			If [code]true[/code], the SDK will capture logged errors as events, logs and/or breadcrumbs, as defined by [member logger_event_mask] and [member logger_breadcrumb_mask]. Crashes are always captured. See also [member enable_logs].
 		</member>
-		<member name="logger_event_mask" type="int" setter="set_logger_event_mask" getter="get_logger_event_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="13">
+		<member name="logger_event_mask" type="int" setter="deprecated_set_logger_event_mask" getter="deprecated_get_logger_event_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="13" deprecated="Use [member SentryGodotLoggerOptions.event_mask] instead.">
 			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.
 			[b]Note:[/b] [code]MASK_MESSAGE[/code] has no effect here. To capture log messages, set it in [member logger_log_mask] and/or [member logger_breadcrumb_mask] instead.
 		</member>
-		<member name="logger_include_source" type="bool" setter="set_logger_include_source" getter="is_logger_include_source_enabled" default="true">
+		<member name="logger_include_source" type="bool" setter="deprecated_set_logger_include_source" getter="deprecated_is_logger_include_source_enabled" default="true" deprecated="Use [member SentryGodotLoggerOptions.include_source] instead.">
 			If [code]true[/code], the SDK will include the surrounding source code of logged errors, if available in the exported project.
 		</member>
-		<member name="logger_include_variables" type="bool" setter="set_logger_include_variables" getter="is_logger_include_variables_enabled" default="false">
+		<member name="logger_include_variables" type="bool" setter="deprecated_set_logger_include_variables" getter="deprecated_is_logger_include_variables_enabled" default="false" deprecated="Use [member SentryGodotLoggerOptions.include_variables] instead.">
 			If [code]true[/code], the SDK will include local variables from stack traces when capturing script errors. This allows showing the values of variables at each frame in the call stack. Requires enabling [member ProjectSettings.debug/settings/gdscript/always_track_local_variables].
 			[b]Note:[/b] Enabling this option may impact performance, especially for applications with frequent errors or deep call stacks.
 		</member>
-		<member name="logger_limits" type="SentryLoggerLimits" setter="set_logger_limits" getter="get_logger_limits">
+		<member name="logger_limits" type="SentryLoggerLimits" setter="deprecated_set_logger_limits" getter="deprecated_get_logger_limits" deprecated="Use [member SentryGodotLoggerOptions.limits] instead.">
 			Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending too many non-critical and repeating error events. See [SentryLoggerLimits].
 		</member>
-		<member name="logger_log_mask" type="int" setter="set_logger_log_mask" getter="get_logger_log_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="0">
+		<member name="logger_log_mask" type="int" setter="deprecated_set_logger_log_mask" getter="deprecated_get_logger_log_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="0" deprecated="Use [member SentryGodotLoggerOptions.log_mask] instead.">
 			Specifies the Godot logger events that are automatically captured as Sentry logs. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.
 		</member>
-		<member name="logger_messages_as_breadcrumbs" type="bool" setter="set_logger_messages_as_breadcrumbs" getter="is_logger_messages_as_breadcrumbs_enabled" default="true" deprecated="Set the [code]MASK_MESSAGE[/code] flag in [member logger_breadcrumb_mask] instead.">
+		<member name="logger_messages_as_breadcrumbs" type="bool" setter="deprecated_set_logger_messages_as_breadcrumbs" getter="deprecated_is_logger_messages_as_breadcrumbs_enabled" default="true" deprecated="Set the [code]MASK_MESSAGE[/code] flag in [member SentryGodotLoggerOptions.breadcrumb_mask] instead.">
 			If [code]true[/code], the SDK will capture log messages (such as [code]print()[/code] statements) as breadcrumbs along with events.
 		</member>
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">

--- a/project/project.godot
+++ b/project/project.godot
@@ -58,10 +58,10 @@ textures/vram_compression/import_etc2_astc=true
 
 options/auto_init=false
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
-schema_version=2
+schema_version=3
 options/attach_scene_tree=true
-logger/include_variables=true
-logger/logs=143
-logger/limits/throttle_window_ms=1000
+godot_logger/include_variables=true
+godot_logger/logs=143
+godot_logger/limits/throttle_window_ms=1000
 experimental/attach_screenshot=true
 experimental/screenshot_level=1

--- a/project/test/isolated/test_limit_events_per_frame.gd
+++ b/project/test/isolated/test_limit_events_per_frame.gd
@@ -10,10 +10,10 @@ var _num_events: int = 0
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Only one error is allowed to be logged as event per processed frame.
-		options.logger_limits.events_per_frame = 1
+		options.godot_logger.limits.events_per_frame = 1
 		# Make sure other limits are not interfering.
-		options.logger_limits.repeated_error_window_ms = 0
-		options.logger_limits.throttle_events = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.throttle_events = 88
 		options.before_send = _before_send
 	)
 

--- a/project/test/isolated/test_limit_repeating_error_window.gd
+++ b/project/test/isolated/test_limit_repeating_error_window.gd
@@ -10,10 +10,10 @@ var _num_events: int = 0
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Ignore duplicate errors within 1 second window.
-		options.logger_limits.repeated_error_window_ms = 1000
+		options.godot_logger.limits.repeated_error_window_ms = 1000
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.throttle_events = 88
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.throttle_events = 88
 		options.before_send = _before_send
 	)
 

--- a/project/test/isolated/test_limit_throttling.gd
+++ b/project/test/isolated/test_limit_throttling.gd
@@ -10,11 +10,11 @@ var _num_events: int = 0
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Allow only two errors to be logged as events within 1 second time window.
-		options.logger_limits.throttle_events = 2
-		options.logger_limits.throttle_window_ms = 1000
+		options.godot_logger.limits.throttle_events = 2
+		options.godot_logger.limits.throttle_window_ms = 1000
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
 		options.before_send = _before_send
 	)
 

--- a/project/test/isolated/test_limit_throttling_disabled.gd
+++ b/project/test/isolated/test_limit_throttling_disabled.gd
@@ -10,10 +10,10 @@ var _num_events: int = 0
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Setting throttle window to 0 should disable throttling.
-		options.logger_limits.throttle_window_ms = 0
-		options.logger_limits.throttle_events = 1
+		options.godot_logger.limits.throttle_window_ms = 0
+		options.godot_logger.limits.throttle_events = 1
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
+		options.godot_logger.limits.events_per_frame = 88
 		options.before_send = _before_send
 	)
 

--- a/project/test/isolated/test_limit_throttling_on_startup.gd
+++ b/project/test/isolated/test_limit_throttling_on_startup.gd
@@ -11,11 +11,11 @@ var _num_events: int = 0
 
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.logger_limits.throttle_events = 2
-		options.logger_limits.throttle_window_ms = 100000
+		options.godot_logger.limits.throttle_events = 2
+		options.godot_logger.limits.throttle_window_ms = 100000
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
 		options.before_send = _before_send
 	)
 

--- a/project/test/isolated/test_logger_breadcrumbs.gd
+++ b/project/test/isolated/test_logger_breadcrumbs.gd
@@ -4,7 +4,7 @@ extends SentryTestSuite
 
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.logger_breadcrumb_mask |= SentryOptions.MASK_MESSAGE
+		options.godot_logger.breadcrumb_mask |= SentryOptions.MASK_MESSAGE
 	)
 
 

--- a/project/test/isolated/test_logger_disabled.gd
+++ b/project/test/isolated/test_logger_disabled.gd
@@ -9,13 +9,13 @@ var _num_events: int = 0
 
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.logger_enabled = false
+		options.godot_logger.enabled = false
 
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.throttle_events = 88
-		options.logger_limits.repeated_error_window_ms = 0
-		options.logger_limits.throttle_window_ms = 0
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.throttle_events = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.throttle_window_ms = 0
 
 		options.before_send = _before_send
 	)

--- a/project/test/isolated/test_logger_log_mask.gd
+++ b/project/test/isolated/test_logger_log_mask.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
 ## Errors should be auto-captured as Sentry Logs only when their type bit is
-## set in "logger_log_mask".
+## set in "godot_logger.log_mask".
 
 
 var _captured: Array[Dictionary] = []
@@ -9,14 +9,14 @@ var _captured: Array[Dictionary] = []
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.enable_logs = true
-		options.logger_log_mask = SentryOptions.MASK_ERROR
+		options.godot_logger.log_mask = SentryOptions.MASK_ERROR
 		options.before_send_log = _before_send_log
 
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.throttle_events = 88
-		options.logger_limits.repeated_error_window_ms = 0
-		options.logger_limits.throttle_window_ms = 0
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.throttle_events = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.throttle_window_ms = 0
 	)
 
 

--- a/project/test/isolated/test_logger_with_masks.gd
+++ b/project/test/isolated/test_logger_with_masks.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
-## Events and breadcrumbs should be logged when "logger_event_mask" and
-## "logger_breadcrumb_mask" are configured to include all categories.
+## Events and breadcrumbs should be logged when "godot_logger.event_mask" and
+## "godot_logger.breadcrumb_mask" are configured to include all categories.
 
 
 signal callback_processed
@@ -11,14 +11,14 @@ var _num_events: int = 0
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		var mask = SentryOptions.MASK_ERROR | SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER | SentryOptions.MASK_WARNING
-		options.logger_event_mask = mask
-		options.logger_breadcrumb_mask = mask
+		options.godot_logger.event_mask = mask
+		options.godot_logger.breadcrumb_mask = mask
 
 		# Make sure other limits are not interfering.
-		options.logger_limits.events_per_frame = 88
-		options.logger_limits.throttle_events = 88
-		options.logger_limits.repeated_error_window_ms = 0
-		options.logger_limits.throttle_window_ms = 0
+		options.godot_logger.limits.events_per_frame = 88
+		options.godot_logger.limits.throttle_events = 88
+		options.godot_logger.limits.repeated_error_window_ms = 0
+		options.godot_logger.limits.throttle_window_ms = 0
 
 		options.before_send = _before_send
 	)

--- a/project/test/isolated/test_logger_with_masks_empty.gd
+++ b/project/test/isolated/test_logger_with_masks_empty.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
-## Events and breadcrumbs should not be logged when both "logger_event_mask"
-## and "logger_breadcrumb_mask" are set to zero.
+## Events and breadcrumbs should not be logged when both "godot_logger.event_mask"
+## and "godot_logger.breadcrumb_mask" are set to zero.
 
 
 signal callback_processed
@@ -10,8 +10,8 @@ var _num_events: int = 0
 
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.logger_event_mask = 0
-		options.logger_breadcrumb_mask = 0
+		options.godot_logger.event_mask = 0
+		options.godot_logger.breadcrumb_mask = 0
 
 		options.before_send = _before_send
 	)

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -5,7 +5,7 @@ signal log_processed(entry: SentryLog)
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.enable_logs = true
-		options.logger_log_mask = SentryOptions.MASK_MESSAGE
+		options.godot_logger.log_mask = SentryOptions.MASK_MESSAGE
 		options.before_send_log = _before_send_log
 	)
 

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -29,7 +29,7 @@ func test_bool_properties(property: String, test_parameters := [
 @warning_ignore("unused_parameter")
 func test_godot_logger_bool_properties(property: String, test_parameters := [
 		["enabled"],
-		["include_source"],
+		["include_source_context"],
 		["include_variables"],
 ]) -> void:
 	options.godot_logger.set(property, true)
@@ -96,7 +96,7 @@ func test_logger_limit_properties(property: String, test_parameters := [
 @warning_ignore("unused_parameter")
 func test_deprecated_logger_properties(property: String, new_property: String, value: Variant, test_parameters := [
 		["logger_enabled", "enabled", false],
-		["logger_include_source", "include_source", false],
+		["logger_include_source", "include_source_context", false],
 		["logger_include_variables", "include_variables", true],
 		["logger_event_mask", "event_mask", SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER],
 		["logger_breadcrumb_mask", "breadcrumb_mask", SentryOptions.MASK_SCRIPT],

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -18,13 +18,24 @@ func test_bool_properties(property: String, test_parameters := [
 		["attach_screenshot"],
 		["attach_scene_tree"],
 		["send_default_pii"],
-		["logger_enabled"],
-		["logger_include_source"],
 ]) -> void:
 	options.set(property, true)
 	assert_bool(options.get(property)).is_true()
 	options.set(property, false)
 	assert_bool(options.get(property)).is_false()
+
+
+## Test simple bool properties on godot_logger options.
+@warning_ignore("unused_parameter")
+func test_godot_logger_bool_properties(property: String, test_parameters := [
+		["enabled"],
+		["include_source"],
+		["include_variables"],
+]) -> void:
+	options.godot_logger.set(property, true)
+	assert_bool(options.godot_logger.get(property)).is_true()
+	options.godot_logger.set(property, false)
+	assert_bool(options.godot_logger.get(property)).is_false()
 
 
 ## Test simple string properties.
@@ -57,18 +68,16 @@ func test_shutdown_timeout_ms() -> void:
 	assert_int(options.shutdown_timeout_ms).is_equal(5000)
 
 
-## SentryOptions.logger_event_mask should be set to the specified value.
-func test_logger_event_mask() -> void:
+## Test mask properties on godot_logger options.
+@warning_ignore("unused_parameter")
+func test_godot_logger_mask_properties(property: String, test_parameters := [
+		["event_mask"],
+		["breadcrumb_mask"],
+		["log_mask"],
+]) -> void:
 	var mask := SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER
-	options.logger_event_mask = mask
-	assert_int(options.logger_event_mask).is_equal(mask)
-
-
-## SentryOptions.logger_breadcrumb_mask should be set to the specified value.
-func test_logger_breadcrumb_mask() -> void:
-	var mask := SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER
-	options.logger_breadcrumb_mask = mask
-	assert_int(options.logger_breadcrumb_mask).is_equal(mask)
+	options.godot_logger.set(property, mask)
+	assert_int(options.godot_logger.get(property)).is_equal(mask)
 
 
 ## Test integer error logger limit properties.
@@ -79,8 +88,31 @@ func test_logger_limit_properties(property: String, test_parameters := [
 		["throttle_events"],
 		["throttle_window_ms"],
 ]) -> void:
-	options.logger_limits.set(property, 42)
-	assert_int(options.logger_limits.get(property)).is_equal(42)
+	options.godot_logger.limits.set(property, 42)
+	assert_int(options.godot_logger.limits.get(property)).is_equal(42)
+
+
+## Deprecated flat logger_* properties should proxy to godot_logger options.
+@warning_ignore("unused_parameter")
+func test_deprecated_logger_properties(property: String, new_property: String, value: Variant, test_parameters := [
+		["logger_enabled", "enabled", false],
+		["logger_include_source", "include_source", false],
+		["logger_include_variables", "include_variables", true],
+		["logger_event_mask", "event_mask", SentryOptions.MASK_SCRIPT | SentryOptions.MASK_SHADER],
+		["logger_breadcrumb_mask", "breadcrumb_mask", SentryOptions.MASK_SCRIPT],
+		["logger_log_mask", "log_mask", SentryOptions.MASK_ERROR],
+]) -> void:
+	options.set(property, value)
+	assert_that(options.godot_logger.get(new_property)).is_equal(value)
+	assert_that(options.get(property)).is_equal(value)
+
+
+## Deprecated logger_messages_as_breadcrumbs should toggle MASK_MESSAGE in godot_logger.breadcrumb_mask.
+func test_deprecated_logger_messages_as_breadcrumbs() -> void:
+	options.logger_messages_as_breadcrumbs = false
+	assert_int(options.godot_logger.breadcrumb_mask & SentryOptions.MASK_MESSAGE).is_equal(0)
+	options.logger_messages_as_breadcrumbs = true
+	assert_int(options.godot_logger.breadcrumb_mask & SentryOptions.MASK_MESSAGE).is_equal(SentryOptions.MASK_MESSAGE)
 
 
 ## Test properties with SentrySDK.Level type.

--- a/project/test/util/sentry_test_suite.gd
+++ b/project/test/util/sentry_test_suite.gd
@@ -51,7 +51,7 @@ func before() -> void:
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		# Disable message breadcrumbs to avoid interfering with normal testing.
-		options.logger_breadcrumb_mask &= ~SentryOptions.MASK_MESSAGE
+		options.godot_logger.breadcrumb_mask &= ~SentryOptions.MASK_MESSAGE
 	)
 
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -73,6 +73,7 @@ void register_runtime_classes() {
 	GDREGISTER_CLASS(SentryLoggerLimits);
 	GDREGISTER_CLASS(SentryExperimental);
 	GDREGISTER_CLASS(SentryAndroidOptions);
+	GDREGISTER_CLASS(SentryGodotLoggerOptions);
 	GDREGISTER_CLASS(SentryOptions);
 	GDREGISTER_INTERNAL_CLASS(RuntimeConfig);
 	GDREGISTER_CLASS(SentryUser);

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -217,11 +217,7 @@ struct NativeTraceContext {
 };
 
 static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions> options) {
-	Ref<SentryLoggerLimits> logger_limits = options->get_logger_limits();
-	if (logger_limits.is_null()) {
-		logger_limits.instantiate();
-		options->set_logger_limits(logger_limits);
-	}
+	Ref<SentryLoggerLimits> logger_limits = options->get_godot_logger()->get_limits();
 	logger_limits->set_events_per_frame(data.logger_limits.events_per_frame);
 	logger_limits->set_repeated_error_window_ms(data.logger_limits.repeated_error_window_ms);
 	logger_limits->set_throttle_events(data.logger_limits.throttle_events);
@@ -244,12 +240,12 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_screenshot_level((Level)data.screenshot_level);
 	options->set_app_hang_tracking_enabled(data.enable_app_hang_tracking);
 	options->set_app_hang_timeout_ms(data.app_hang_timeout_ms);
-	options->set_logger_enabled(data.logger_enabled);
-	options->set_logger_include_source(data.logger_include_source);
-	options->set_logger_include_variables(data.logger_include_variables);
-	options->set_logger_event_mask(data.logger_event_mask);
-	options->set_logger_breadcrumb_mask(data.logger_breadcrumb_mask);
-	options->set_logger_log_mask(data.logger_log_mask);
+	options->get_godot_logger()->set_enabled(data.logger_enabled);
+	options->get_godot_logger()->set_include_source(data.logger_include_source);
+	options->get_godot_logger()->set_include_variables(data.logger_include_variables);
+	options->get_godot_logger()->set_event_mask(data.logger_event_mask);
+	options->get_godot_logger()->set_breadcrumb_mask(data.logger_breadcrumb_mask);
+	options->get_godot_logger()->set_log_mask(data.logger_log_mask);
 	options->get_experimental()->set_enable_metrics(data.enable_metrics);
 	options->get_android()->set_enable_anr_detection(data.android_enable_anr_detection);
 	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
@@ -259,10 +255,11 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &options) {
 	r_data = {};
 
-	r_data.logger_limits.events_per_frame = options->get_logger_limits()->get_events_per_frame();
-	r_data.logger_limits.repeated_error_window_ms = options->get_logger_limits()->get_repeated_error_window_ms();
-	r_data.logger_limits.throttle_events = options->get_logger_limits()->get_throttle_events();
-	r_data.logger_limits.throttle_window_ms = options->get_logger_limits()->get_throttle_window_ms();
+	Ref<SentryLoggerLimits> limits = options->get_godot_logger()->get_limits();
+	r_data.logger_limits.events_per_frame = limits->get_events_per_frame();
+	r_data.logger_limits.repeated_error_window_ms = limits->get_repeated_error_window_ms();
+	r_data.logger_limits.throttle_events = limits->get_throttle_events();
+	r_data.logger_limits.throttle_window_ms = limits->get_throttle_window_ms();
 
 	r_data.dsn = _make_handle(options->get_dsn());
 	r_data.release = _make_handle(options->get_release());
@@ -281,12 +278,12 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.screenshot_level = options->get_screenshot_level();
 	r_data.enable_app_hang_tracking = options->is_app_hang_tracking_enabled();
 	r_data.app_hang_timeout_ms = options->get_app_hang_timeout_ms();
-	r_data.logger_enabled = options->is_logger_enabled();
-	r_data.logger_include_source = options->is_logger_include_source_enabled();
-	r_data.logger_include_variables = options->is_logger_include_variables_enabled();
-	r_data.logger_event_mask = options->get_logger_event_mask();
-	r_data.logger_breadcrumb_mask = options->get_logger_breadcrumb_mask();
-	r_data.logger_log_mask = options->get_logger_log_mask();
+	r_data.logger_enabled = options->get_godot_logger()->get_enabled();
+	r_data.logger_include_source = options->get_godot_logger()->get_include_source();
+	r_data.logger_include_variables = options->get_godot_logger()->get_include_variables();
+	r_data.logger_event_mask = options->get_godot_logger()->get_event_mask();
+	r_data.logger_breadcrumb_mask = options->get_godot_logger()->get_breadcrumb_mask();
+	r_data.logger_log_mask = options->get_godot_logger()->get_log_mask();
 	r_data.enable_metrics = options->get_experimental()->get_enable_metrics();
 	r_data.android_enable_anr_detection = options->get_android()->get_enable_anr_detection();
 	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -137,7 +137,7 @@ struct NativeOptions {
 
 	// Logger
 	uint8_t logger_enabled;
-	uint8_t logger_include_source;
+	uint8_t logger_include_source_context;
 	uint8_t logger_include_variables;
 	int32_t logger_event_mask;
 	int32_t logger_breadcrumb_mask;
@@ -198,7 +198,7 @@ struct ManagedOptions {
 	int32_t app_hang_timeout_ms;
 
 	uint8_t logger_enabled;
-	uint8_t logger_include_source;
+	uint8_t logger_include_source_context;
 	uint8_t logger_include_variables;
 	int32_t logger_event_mask;
 	int32_t logger_breadcrumb_mask;
@@ -241,7 +241,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_app_hang_tracking_enabled(data.enable_app_hang_tracking);
 	options->set_app_hang_timeout_ms(data.app_hang_timeout_ms);
 	options->get_godot_logger()->set_enabled(data.logger_enabled);
-	options->get_godot_logger()->set_include_source(data.logger_include_source);
+	options->get_godot_logger()->set_include_source_context(data.logger_include_source_context);
 	options->get_godot_logger()->set_include_variables(data.logger_include_variables);
 	options->get_godot_logger()->set_event_mask(data.logger_event_mask);
 	options->get_godot_logger()->set_breadcrumb_mask(data.logger_breadcrumb_mask);
@@ -279,7 +279,7 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.enable_app_hang_tracking = options->is_app_hang_tracking_enabled();
 	r_data.app_hang_timeout_ms = options->get_app_hang_timeout_ms();
 	r_data.logger_enabled = options->get_godot_logger()->get_enabled();
-	r_data.logger_include_source = options->get_godot_logger()->get_include_source();
+	r_data.logger_include_source_context = options->get_godot_logger()->get_include_source_context();
 	r_data.logger_include_variables = options->get_godot_logger()->get_include_variables();
 	r_data.logger_event_mask = options->get_godot_logger()->get_event_mask();
 	r_data.logger_breadcrumb_mask = options->get_godot_logger()->get_breadcrumb_mask();

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -452,7 +452,7 @@ internal static partial class NativeBridge
 
     private static void ApplyNativeOptions(NativeOptions data, SentryGodotOptions opts)
     {
-        opts.LoggerLimits = new SentryLoggerLimits
+        opts.GodotLogger.Limits = new SentryLoggerLimits
         {
             EventsPerFrame = data.logger_limits.events_per_frame,
             RepeatedErrorWindow = TimeSpan.FromMilliseconds(data.logger_limits.repeated_error_window_ms),
@@ -476,12 +476,12 @@ internal static partial class NativeBridge
         opts.ScreenshotLevel = (SentryLevel)data.screenshot_level;
         opts.EnableAppHangTracking = data.enable_app_hang_tracking != 0;
         opts.AppHangTimeout = TimeSpan.FromMilliseconds(data.app_hang_timeout_ms);
-        opts.LoggerEnabled = data.logger_enabled != 0;
-        opts.LoggerIncludeSource = data.logger_include_source != 0;
-        opts.LoggerIncludeVariables = data.logger_include_variables != 0;
-        opts.LoggerEventMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_event_mask;
-        opts.LoggerBreadcrumbMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_breadcrumb_mask;
-        opts.LoggerLogMask = (SentryGodotOptions.GodotLoggerEventMask)data.logger_log_mask;
+        opts.GodotLogger.Enabled = data.logger_enabled != 0;
+        opts.GodotLogger.IncludeSource = data.logger_include_source != 0;
+        opts.GodotLogger.IncludeVariables = data.logger_include_variables != 0;
+        opts.GodotLogger.EventMask = (GodotLoggerEventMask)data.logger_event_mask;
+        opts.GodotLogger.BreadcrumbMask = (GodotLoggerEventMask)data.logger_breadcrumb_mask;
+        opts.GodotLogger.LogMask = (GodotLoggerEventMask)data.logger_log_mask;
         opts.EnableMetrics = data.enable_metrics != 0;
         opts.Android.EnableAnrDetection = data.android_enable_anr_detection != 0;
         opts.Android.AnrTimeoutInterval = TimeSpan.FromMilliseconds(data.android_anr_timeout_interval_ms);
@@ -741,10 +741,10 @@ internal static partial class NativeBridge
             {
                 logger_limits = new LoggerLimitsData
                 {
-                    events_per_frame = opts.LoggerLimits.EventsPerFrame,
-                    repeated_error_window_ms = (int)opts.LoggerLimits.RepeatedErrorWindow.TotalMilliseconds,
-                    throttle_events = opts.LoggerLimits.ThrottleEvents,
-                    throttle_window_ms = (int)opts.LoggerLimits.ThrottleWindow.TotalMilliseconds,
+                    events_per_frame = opts.GodotLogger.Limits.EventsPerFrame,
+                    repeated_error_window_ms = (int)opts.GodotLogger.Limits.RepeatedErrorWindow.TotalMilliseconds,
+                    throttle_events = opts.GodotLogger.Limits.ThrottleEvents,
+                    throttle_window_ms = (int)opts.GodotLogger.Limits.ThrottleWindow.TotalMilliseconds,
                 },
                 dsn = dsnPtr,
                 dsn_len = dsn.Length,
@@ -767,12 +767,12 @@ internal static partial class NativeBridge
                 screenshot_level = (int)opts.ScreenshotLevel,
                 enable_app_hang_tracking = (byte)(opts.EnableAppHangTracking ? 1 : 0),
                 app_hang_timeout_ms = (int)opts.AppHangTimeout.TotalMilliseconds,
-                logger_enabled = (byte)(opts.LoggerEnabled ? 1 : 0),
-                logger_include_source = (byte)(opts.LoggerIncludeSource ? 1 : 0),
-                logger_include_variables = (byte)(opts.LoggerIncludeVariables ? 1 : 0),
-                logger_event_mask = (int)opts.LoggerEventMask,
-                logger_breadcrumb_mask = (int)opts.LoggerBreadcrumbMask,
-                logger_log_mask = (int)opts.LoggerLogMask,
+                logger_enabled = (byte)(opts.GodotLogger.Enabled ? 1 : 0),
+                logger_include_source = (byte)(opts.GodotLogger.IncludeSource ? 1 : 0),
+                logger_include_variables = (byte)(opts.GodotLogger.IncludeVariables ? 1 : 0),
+                logger_event_mask = (int)opts.GodotLogger.EventMask,
+                logger_breadcrumb_mask = (int)opts.GodotLogger.BreadcrumbMask,
+                logger_log_mask = (int)opts.GodotLogger.LogMask,
                 enable_metrics = (byte)(opts.EnableMetrics ? 1 : 0),
                 android_enable_anr_detection = (byte)(opts.Android.EnableAnrDetection ? 1 : 0),
                 android_anr_timeout_interval_ms = (int)opts.Android.AnrTimeoutInterval.TotalMilliseconds,

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -108,7 +108,7 @@ internal static partial class NativeBridge
         public byte enable_app_hang_tracking;
         public int app_hang_timeout_ms;
         public byte logger_enabled;
-        public byte logger_include_source;
+        public byte logger_include_source_context;
         public byte logger_include_variables;
         public int logger_event_mask;
         public int logger_breadcrumb_mask;
@@ -146,7 +146,7 @@ internal static partial class NativeBridge
         public byte enable_app_hang_tracking;
         public int app_hang_timeout_ms;
         public byte logger_enabled;
-        public byte logger_include_source;
+        public byte logger_include_source_context;
         public byte logger_include_variables;
         public int logger_event_mask;
         public int logger_breadcrumb_mask;
@@ -477,7 +477,7 @@ internal static partial class NativeBridge
         opts.EnableAppHangTracking = data.enable_app_hang_tracking != 0;
         opts.AppHangTimeout = TimeSpan.FromMilliseconds(data.app_hang_timeout_ms);
         opts.GodotLogger.Enabled = data.logger_enabled != 0;
-        opts.GodotLogger.IncludeSource = data.logger_include_source != 0;
+        opts.GodotLogger.IncludeSourceContext = data.logger_include_source_context != 0;
         opts.GodotLogger.IncludeVariables = data.logger_include_variables != 0;
         opts.GodotLogger.EventMask = (GodotLoggerEventMask)data.logger_event_mask;
         opts.GodotLogger.BreadcrumbMask = (GodotLoggerEventMask)data.logger_breadcrumb_mask;
@@ -768,7 +768,7 @@ internal static partial class NativeBridge
                 enable_app_hang_tracking = (byte)(opts.EnableAppHangTracking ? 1 : 0),
                 app_hang_timeout_ms = (int)opts.AppHangTimeout.TotalMilliseconds,
                 logger_enabled = (byte)(opts.GodotLogger.Enabled ? 1 : 0),
-                logger_include_source = (byte)(opts.GodotLogger.IncludeSource ? 1 : 0),
+                logger_include_source_context = (byte)(opts.GodotLogger.IncludeSourceContext ? 1 : 0),
                 logger_include_variables = (byte)(opts.GodotLogger.IncludeVariables ? 1 : 0),
                 logger_event_mask = (int)opts.GodotLogger.EventMask,
                 logger_breadcrumb_mask = (int)opts.GodotLogger.BreadcrumbMask,

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -185,7 +185,7 @@ public sealed class SentryGodotLoggerOptions
     /// <remarks>
     /// This setting controls GDScript error reporting, not .NET errors.
     /// </remarks>
-    public bool IncludeSourceContext { get; set; } = false;
+    public bool IncludeSourceContext { get; set; } = true;
 
     /// <summary>
     /// If enabled, the SDK will include local variables from stack traces when capturing script errors.

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -60,83 +60,7 @@ public sealed class SentryGodotOptions : SentryOptions
     /// </summary>
     public TimeSpan AppHangTimeout { get; set; } = TimeSpan.FromSeconds(5.0);
 
-    /// <summary>
-    /// If enabled, the SDK captures logged GDScript and engine runtime errors as events and/or breadcrumbs,
-    /// as defined by <see cref="LoggerEventMask"/> and <see cref="LoggerBreadcrumbMask"/>.
-    /// </summary>
-    /// <remarks>
-    /// This setting controls GDScript/engine error reporting, not .NET errors.
-    /// </remarks>
-    public bool LoggerEnabled { get; set; } = true;
-
-    /// <summary>
-    /// If enabled, the SDK includes surrounding source code of logged errors, if available.
-    /// </summary>
-    /// <remarks>
-    /// This setting controls GDScript error reporting, not .NET errors.
-    /// </remarks>
-    public bool LoggerIncludeSource { get; set; } = false;
-
-    /// <summary>
-    /// If enabled, the SDK includes local variables from stack traces when capturing script errors.
-    /// </summary>
-    /// <remarks>
-    /// May impact performance, especially for applications with frequent errors or deep call stacks.
-    /// This setting controls GDScript error reporting, not .NET errors.
-    /// </remarks>
-    public bool LoggerIncludeVariables { get; set; } = false;
-
-    /// <summary>
-    /// Bitfield mask for Godot logger events.
-    /// </summary>
-    /// <remarks>
-    /// Used to specify which Godot logger events are captured as Sentry events, breadcrumbs and logs.
-    /// </remarks>
-    [Flags]
-    public enum GodotLoggerEventMask
-    {
-        /// <summary>No logger errors or messages will be captured.</summary>
-        None = 0,
-        /// <summary>Native (C++) and engine errors, which may also originate from a script.</summary>
-        Error = 1 << 0,
-        /// <summary>Warnings.</summary>
-        Warning = 1 << 1,
-        /// <summary>Script errors.</summary>
-        Script = 1 << 2,
-        /// <summary>Shader errors.</summary>
-        Shader = 1 << 3,
-        // NOTE: Bits 4-6 are reserved for any additional Godot error types that may be added in the future.
-        /// <summary>Log messages such as <c>GD.Print()</c> statements.</summary>
-        Message = 1 << 7
-    }
-
-    /// <summary>
-    /// Specifies which Godot logger events are captured as Sentry events.
-    /// </summary>
-    /// <remarks>
-    /// <see cref="GodotLoggerEventMask.Message"/> has no effect here. To capture log messages,
-    /// set it in <see cref="LoggerLogMask"/> or <see cref="LoggerBreadcrumbMask"/> instead.
-    /// </remarks>
-    public GodotLoggerEventMask LoggerEventMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader;
-
-    /// <summary>
-    /// Specifies which Godot logger events are captured as Sentry breadcrumbs.
-    /// </summary>
-    public GodotLoggerEventMask LoggerBreadcrumbMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Warning | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader | GodotLoggerEventMask.Message;
-
-    /// <summary>
-    /// Specifies which Godot logger events are captured as Sentry logs.
-    /// </summary>
-    public GodotLoggerEventMask LoggerLogMask { get; set; } = GodotLoggerEventMask.None;
-
-    /// <summary>
-    /// Defines throttling limits for the error logger. These limits are used to prevent the SDK from sending
-    /// too many non-critical and repeating error events. See <see cref="SentryLoggerLimits"/>.
-    /// </summary>
-    /// <remarks>
-    /// This setting controls GDScript/engine error reporting, not .NET errors.
-    /// </remarks>
-    public SentryLoggerLimits LoggerLimits { get; set; } = new SentryLoggerLimits();
+    public SentryGodotLoggerOptions GodotLogger { get; set; } = new SentryGodotLoggerOptions();
 
     /// <summary>
     /// Configures Android-specific options, such as ANR (Application Not Responding) detection.
@@ -200,6 +124,47 @@ public sealed class SentryGodotOptions : SentryOptions
             }
         }
     }
+}
+
+/// <summary>
+/// Bitfield mask for Godot logger events.
+/// </summary>
+/// <remarks>
+/// Used to specify which Godot logger events are captured as Sentry events, breadcrumbs and logs.
+/// </remarks>
+[Flags]
+public enum GodotLoggerEventMask
+{
+    /// <summary>No logger errors or messages will be captured.</summary>
+    None = 0,
+    /// <summary>Native (C++) and engine errors, which may also originate from a script.</summary>
+    Error = 1 << 0,
+    /// <summary>Warnings.</summary>
+    Warning = 1 << 1,
+    /// <summary>Script errors.</summary>
+    Script = 1 << 2,
+    /// <summary>Shader errors.</summary>
+    Shader = 1 << 3,
+    // NOTE: Bits 4-6 are reserved for any additional Godot error types that may be added in the future.
+    /// <summary>Log messages such as <c>GD.Print()</c> statements.</summary>
+    Message = 1 << 7
+}
+
+public sealed class SentryGodotLoggerOptions
+{
+    public bool Enabled { get; set; } = true;
+
+    public bool IncludeSource { get; set; } = false;
+
+    public bool IncludeVariables { get; set; } = false;
+
+    public GodotLoggerEventMask EventMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader;
+
+    public GodotLoggerEventMask BreadcrumbMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Warning | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader | GodotLoggerEventMask.Message;
+
+    public GodotLoggerEventMask LogMask { get; set; } = GodotLoggerEventMask.None;
+
+    public SentryLoggerLimits Limits { get; set; } = new SentryLoggerLimits();
 }
 
 /// <summary>

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -185,7 +185,7 @@ public sealed class SentryGodotLoggerOptions
     /// <remarks>
     /// This setting controls GDScript error reporting, not .NET errors.
     /// </remarks>
-    public bool IncludeSource { get; set; } = false;
+    public bool IncludeSourceContext { get; set; } = false;
 
     /// <summary>
     /// If enabled, the SDK will include local variables from stack traces when capturing script errors.

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -171,7 +171,7 @@ public sealed class SentryGodotLoggerOptions
     /// <summary>
     /// If enabled, the SDK will capture logged errors as events, breadcrumbs and/or logs, as defined
     /// by <see cref="EventMask"/>, <see cref="BreadcrumbMask"/> and <see cref="LogMask"/>.
-    /// Crashes are always captured. See also <see cref="SentryOptions.EnableLogs"/>.
+    /// Crashes are always captured.
     /// </summary>
     /// <remarks>
     /// This setting controls GDScript/engine error reporting, not .NET errors.

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -60,6 +60,10 @@ public sealed class SentryGodotOptions : SentryOptions
     /// </summary>
     public TimeSpan AppHangTimeout { get; set; } = TimeSpan.FromSeconds(5.0);
 
+    /// <summary>
+    /// Configures the capture of Godot errors and log messages as Sentry events, breadcrumbs,
+    /// and logs. See <see cref="SentryGodotLoggerOptions"/>.
+    /// </summary>
     public SentryGodotLoggerOptions GodotLogger { get; set; } = new SentryGodotLoggerOptions();
 
     /// <summary>
@@ -150,20 +154,83 @@ public enum GodotLoggerEventMask
     Message = 1 << 7
 }
 
+/// <summary>
+/// Contains configuration options that control how the SDK captures Godot errors and log messages
+/// as Sentry events, breadcrumbs, and logs. Access this configuration through
+/// <see cref="SentryGodotOptions.GodotLogger"/>.
+/// </summary>
+/// <remarks>
+/// This includes engine errors, GDScript and shader errors, GDExtension errors, <c>GD.PushError()</c>
+/// and <c>GD.PushWarning()</c> statements, as well as log messages from <c>GD.Print()</c> and
+/// similar functions.
+/// These options control Godot-side error reporting, not .NET errors.
+/// </remarks>
+/// <seealso cref="SentryGodotOptions"/>
 public sealed class SentryGodotLoggerOptions
 {
+    /// <summary>
+    /// If enabled, the SDK will capture logged errors as events, breadcrumbs and/or logs, as defined
+    /// by <see cref="EventMask"/>, <see cref="BreadcrumbMask"/> and <see cref="LogMask"/>.
+    /// Crashes are always captured. See also <see cref="SentryOptions.EnableLogs"/>.
+    /// </summary>
+    /// <remarks>
+    /// This setting controls GDScript/engine error reporting, not .NET errors.
+    /// </remarks>
     public bool Enabled { get; set; } = true;
 
+    /// <summary>
+    /// If enabled, the SDK will include the surrounding source code of logged errors, if available
+    /// in the exported project.
+    /// </summary>
+    /// <remarks>
+    /// This setting controls GDScript error reporting, not .NET errors.
+    /// </remarks>
     public bool IncludeSource { get; set; } = false;
 
+    /// <summary>
+    /// If enabled, the SDK will include local variables from stack traces when capturing script errors.
+    /// This allows showing the values of variables at each frame in the call stack. Requires enabling
+    /// the <c>debug/settings/gdscript/always_track_local_variables</c> project setting.
+    /// </summary>
+    /// <remarks>
+    /// May impact performance, especially for applications with frequent errors or deep call stacks.
+    /// This setting controls GDScript error reporting, not .NET errors.
+    /// </remarks>
     public bool IncludeVariables { get; set; } = false;
 
+    /// <summary>
+    /// Specifies the Godot logger events that are automatically captured as Sentry events.
+    /// Accepts a single value or a bitwise combination of <see cref="GodotLoggerEventMask"/> masks.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="GodotLoggerEventMask.Message"/> has no effect here. To capture log messages,
+    /// set it in <see cref="LogMask"/> and/or <see cref="BreadcrumbMask"/> instead.
+    /// </remarks>
     public GodotLoggerEventMask EventMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader;
 
+    /// <summary>
+    /// Specifies the Godot logger events that are automatically captured as Sentry breadcrumbs.
+    /// Accepts a single value or a bitwise combination of <see cref="GodotLoggerEventMask"/> masks.
+    /// </summary>
     public GodotLoggerEventMask BreadcrumbMask { get; set; } = GodotLoggerEventMask.Error | GodotLoggerEventMask.Warning | GodotLoggerEventMask.Script | GodotLoggerEventMask.Shader | GodotLoggerEventMask.Message;
 
+    /// <summary>
+    /// Specifies the Godot logger events that are automatically captured as Sentry logs.
+    /// Accepts a single value or a bitwise combination of <see cref="GodotLoggerEventMask"/> masks.
+    /// Empty by default, so no events are captured as logs.
+    /// </summary>
+    /// <remarks>
+    /// Log capture requires <see cref="SentryOptions.EnableLogs"/> to be enabled.
+    /// </remarks>
     public GodotLoggerEventMask LogMask { get; set; } = GodotLoggerEventMask.None;
 
+    /// <summary>
+    /// Defines throttling limits for the error logger. These limits are used to prevent the SDK
+    /// from sending too many non-critical and repeating error events. See <see cref="SentryLoggerLimits"/>.
+    /// </summary>
+    /// <remarks>
+    /// This setting controls GDScript/engine error reporting, not .NET errors.
+    /// </remarks>
     public SentryLoggerLimits Limits { get; set; } = new SentryLoggerLimits();
 }
 

--- a/src/sentry/godot_error_types.h
+++ b/src/sentry/godot_error_types.h
@@ -28,7 +28,7 @@ _FORCE_INLINE_ godot::String GODOT_ERROR_MASK_EXPORT_STRING() {
 			int(MASK_ERROR), int(MASK_WARNING), int(MASK_SCRIPT), int(MASK_SHADER), int(MASK_MESSAGE));
 }
 
-// Used for exporting `logger_event_mask` as PropertyInfo.
+// Used for exporting `godot_logger.event_mask` as PropertyInfo.
 // MASK_MESSAGE is omitted because log messages should not be captured as Sentry events.
 _FORCE_INLINE_ godot::String GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS() {
 	return godot::vformat("Error:%d,Warning:%d,Script:%d,Shader:%d",

--- a/src/sentry/logging/sentry_godot_logger.cpp
+++ b/src/sentry/logging/sentry_godot_logger.cpp
@@ -122,7 +122,7 @@ Vector<SentryEvent::StackFrame> _extract_error_stack_frames_from_backtraces(
 			};
 
 			// Provide script source code context for script errors if available.
-			if (SENTRY_OPTIONS()->get_godot_logger()->get_include_source()) {
+			if (SENTRY_OPTIONS()->get_godot_logger()->get_include_source_context()) {
 				String context_line;
 				PackedStringArray pre_context;
 				PackedStringArray post_context;

--- a/src/sentry/logging/sentry_godot_logger.cpp
+++ b/src/sentry/logging/sentry_godot_logger.cpp
@@ -122,7 +122,7 @@ Vector<SentryEvent::StackFrame> _extract_error_stack_frames_from_backtraces(
 			};
 
 			// Provide script source code context for script errors if available.
-			if (SENTRY_OPTIONS()->is_logger_include_source_enabled()) {
+			if (SENTRY_OPTIONS()->get_godot_logger()->get_include_source()) {
 				String context_line;
 				PackedStringArray pre_context;
 				PackedStringArray post_context;
@@ -272,7 +272,7 @@ void SentryGodotLogger::_process_frame() {
 }
 
 void SentryGodotLogger::_apply_startup_limits() {
-	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_logger_limits();
+	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_godot_logger()->get_limits();
 
 	limits.events_per_frame = MAX(30, logger_limits->get_events_per_frame());
 	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->get_repeated_error_window_ms() };
@@ -281,7 +281,7 @@ void SentryGodotLogger::_apply_startup_limits() {
 }
 
 void SentryGodotLogger::_apply_normal_limits() {
-	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_logger_limits();
+	Ref<SentryLoggerLimits> logger_limits = SENTRY_OPTIONS()->get_godot_logger()->get_limits();
 
 	limits.events_per_frame = logger_limits->get_events_per_frame();
 	limits.repeated_error_window = std::chrono::milliseconds{ logger_limits->get_repeated_error_window_ms() };
@@ -381,8 +381,10 @@ void SentryGodotLogger::_log_error(const String &p_function, const String &p_fil
 	// Capture error as event.
 	if (as_event) {
 		// Backtraces don't include variables by default, so if we need them, we must capture them separately.
-		bool include_variables = SENTRY_OPTIONS()->is_logger_include_variables_enabled();
-		TypedArray<ScriptBacktrace> script_backtraces = include_variables ? Engine::get_singleton()->capture_script_backtraces(true) : p_script_backtraces;
+		bool include_variables = SENTRY_OPTIONS()->get_godot_logger()->get_include_variables();
+		TypedArray<ScriptBacktrace> script_backtraces = include_variables
+				? Engine::get_singleton()->capture_script_backtraces(true)
+				: p_script_backtraces;
 
 		Vector<SentryEvent::StackFrame> frames = _extract_error_stack_frames_from_backtraces(
 				script_backtraces, p_file, p_line, include_variables);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -291,7 +291,7 @@ Ref<SentryOptions> SentryOptions::create_from_project_settings() {
 }
 
 void SentryOptions::deprecated_set_logger_messages_as_breadcrumbs(bool p_enabled) {
-	WARN_DEPRECATED_MSG("The \"logger_messages_as_breadcrumbs\" option is deprecated. Set the MASK_MESSAGE flag in \"logger_breadcrumb_mask\" instead.");
+	WARN_DEPRECATED_MSG("The \"logger_messages_as_breadcrumbs\" option is deprecated. Set the MASK_MESSAGE flag in \"godot_logger.breadcrumb_mask\" instead.");
 	BitField<GodotLoggerEventMask> mask = godot_logger->get_breadcrumb_mask();
 	if (p_enabled) {
 		mask.set_flag(GodotLoggerEventMask::MASK_MESSAGE);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -430,7 +430,7 @@ void SentryOptions::_bind_methods() {
 	}
 
 	// DEPRECATED: These properties are deprecated and remain for compatibility reasons.
-	// TODO: Remove these after December 2026 or in version 3.0.
+	// TODO: Remove these in January 2027 or in version 3.0.
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), deprecated_set_logger_messages_as_breadcrumbs, deprecated_is_logger_messages_as_breadcrumbs_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), deprecated_set_app_hang_tracking, deprecated_get_app_hang_tracking);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), deprecated_set_app_hang_timeout_sec, deprecated_get_app_hang_timeout_sec);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -430,7 +430,7 @@ void SentryOptions::_bind_methods() {
 	}
 
 	// DEPRECATED: These properties are deprecated and remain for compatibility reasons.
-	// TODO: Remove these after November 2026 or in version 3.0.
+	// TODO: Remove these after December 2026 or in version 3.0.
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), deprecated_set_logger_messages_as_breadcrumbs, deprecated_is_logger_messages_as_breadcrumbs_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), deprecated_set_app_hang_tracking, deprecated_get_app_hang_tracking);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), deprecated_set_app_hang_timeout_sec, deprecated_get_app_hang_timeout_sec);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -61,7 +61,7 @@ void SentryGodotLoggerOptions::deprecated_set_limits(const Ref<SentryLoggerLimit
 
 void SentryGodotLoggerOptions::_bind_methods() {
 	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, enabled);
-	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, include_source);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, include_source_context);
 	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, include_variables);
 	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::INT, event_mask);
 	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::INT, breadcrumb_mask);
@@ -148,7 +148,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 
 	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
 	_define_setting("sentry/logger/logger_enabled", logger_options->get_enabled());
-	_define_setting("sentry/logger/include_source", logger_options->get_include_source(), false);
+	_define_setting("sentry/logger/include_source", logger_options->get_include_source_context(), false);
 	_define_setting("sentry/logger/include_variables", logger_options->get_include_variables(), false);
 	_requires_restart("sentry/logger/include_variables");
 	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS()), logger_options->get_event_mask(), false);
@@ -241,7 +241,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
 	logger_options->set_enabled(ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", logger_options->get_enabled()));
-	logger_options->set_include_source(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", logger_options->get_include_source()));
+	logger_options->set_include_source_context(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", logger_options->get_include_source_context()));
 	logger_options->set_include_variables(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_variables", logger_options->get_include_variables()));
 	logger_options->set_event_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", logger_options->get_event_mask()));
 	logger_options->set_breadcrumb_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", logger_options->get_breadcrumb_mask()));
@@ -325,8 +325,8 @@ void SentryOptions::deprecated_set_logger_enabled(bool p_enabled) {
 }
 
 void SentryOptions::deprecated_set_logger_include_source(bool p_enable) {
-	WARN_DEPRECATED_MSG("The \"logger_include_source\" option is deprecated. Use \"godot_logger.include_source\" instead.");
-	godot_logger->set_include_source(p_enable);
+	WARN_DEPRECATED_MSG("The \"logger_include_source\" option is deprecated. Use \"godot_logger.include_source_context\" instead.");
+	godot_logger->set_include_source_context(p_enable);
 }
 
 void SentryOptions::deprecated_set_logger_include_variables(bool p_logger_include_variables) {

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -50,6 +50,30 @@ void SentryLoggerLimits::_bind_methods() {
 	BIND_PROPERTY_SIMPLE(SentryLoggerLimits, Variant::INT, throttle_window_ms);
 }
 
+// *** SentryGodotLoggerOptions
+
+void SentryGodotLoggerOptions::deprecated_set_limits(const Ref<SentryLoggerLimits> &p_limits) {
+	limits = p_limits;
+	if (limits.is_null()) {
+		limits.instantiate();
+	}
+}
+
+void SentryGodotLoggerOptions::_bind_methods() {
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, enabled);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, include_source);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::BOOL, include_variables);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::INT, event_mask);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::INT, breadcrumb_mask);
+	BIND_PROPERTY_SIMPLE(SentryGodotLoggerOptions, Variant::INT, log_mask);
+
+	BIND_PROPERTY_READONLY(SentryGodotLoggerOptions, PropertyInfo(Variant::OBJECT, "limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), get_limits);
+}
+
+SentryGodotLoggerOptions::SentryGodotLoggerOptions() {
+	limits.instantiate();
+}
+
 // *** SentryExperimental
 
 void SentryExperimental::set_enable_logs(bool p_value) {
@@ -122,18 +146,20 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/app_hang/timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), p_options->app_hang_timeout_ms, false);
 
-	_define_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
-	_define_setting("sentry/logger/include_source", p_options->logger_include_source, false);
-	_define_setting("sentry/logger/include_variables", p_options->logger_include_variables, false);
+	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
+	_define_setting("sentry/logger/logger_enabled", logger_options->get_enabled());
+	_define_setting("sentry/logger/include_source", logger_options->get_include_source(), false);
+	_define_setting("sentry/logger/include_variables", logger_options->get_include_variables(), false);
 	_requires_restart("sentry/logger/include_variables");
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS()), p_options->logger_event_mask, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_breadcrumb_mask, false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/logs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), p_options->logger_log_mask, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS()), logger_options->get_event_mask(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_breadcrumb_mask(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/logs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_log_mask(), false);
 
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->get_events_per_frame(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_repeated_error_window_ms(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), p_options->logger_limits->get_throttle_events(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), p_options->logger_limits->get_throttle_window_ms(), false);
+	Ref<SentryLoggerLimits> limits = logger_options->get_limits();
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), limits->get_events_per_frame(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_repeated_error_window_ms(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), limits->get_throttle_events(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_throttle_window_ms(), false);
 
 	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_detection"), p_options->get_android()->get_enable_anr_detection(), false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_interval_ms"), p_options->get_android()->get_anr_timeout_interval_ms(), false);
@@ -213,17 +239,19 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->enable_app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking);
 	p_options->app_hang_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms);
 
-	p_options->logger_enabled = ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", p_options->logger_enabled);
-	p_options->logger_include_source = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", p_options->logger_include_source);
-	p_options->logger_include_variables = ProjectSettings::get_singleton()->get_setting("sentry/logger/include_variables", p_options->logger_include_variables);
-	p_options->logger_event_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", p_options->logger_event_mask);
-	p_options->logger_breadcrumb_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", p_options->logger_breadcrumb_mask);
-	p_options->logger_log_mask = (int)ProjectSettings::get_singleton()->get_setting("sentry/logger/logs", p_options->logger_log_mask);
+	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
+	logger_options->set_enabled(ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", logger_options->get_enabled()));
+	logger_options->set_include_source(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", logger_options->get_include_source()));
+	logger_options->set_include_variables(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_variables", logger_options->get_include_variables()));
+	logger_options->set_event_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", logger_options->get_event_mask()));
+	logger_options->set_breadcrumb_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", logger_options->get_breadcrumb_mask()));
+	logger_options->set_log_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/logs", logger_options->get_log_mask()));
 
-	p_options->logger_limits->set_events_per_frame(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", p_options->logger_limits->get_events_per_frame()));
-	p_options->logger_limits->set_repeated_error_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", p_options->logger_limits->get_repeated_error_window_ms()));
-	p_options->logger_limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", p_options->logger_limits->get_throttle_events()));
-	p_options->logger_limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", p_options->logger_limits->get_throttle_window_ms()));
+	Ref<SentryLoggerLimits> limits = logger_options->get_limits();
+	limits->set_events_per_frame(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", limits->get_events_per_frame()));
+	limits->set_repeated_error_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", limits->get_repeated_error_window_ms()));
+	limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", limits->get_throttle_events()));
+	limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", limits->get_throttle_window_ms()));
 
 	p_options->android->set_enable_anr_detection(
 			ProjectSettings::get_singleton()->get_setting(
@@ -262,18 +290,15 @@ Ref<SentryOptions> SentryOptions::create_from_project_settings() {
 	return options;
 }
 
-bool SentryOptions::is_logger_messages_as_breadcrumbs_enabled() const {
-	// DEPRECATED: Scheduled for removal.
-	return logger_breadcrumb_mask.has_flag(GodotLoggerEventMask::MASK_MESSAGE);
-}
-
-void SentryOptions::set_logger_messages_as_breadcrumbs(bool p_enabled) {
+void SentryOptions::deprecated_set_logger_messages_as_breadcrumbs(bool p_enabled) {
 	WARN_DEPRECATED_MSG("The \"logger_messages_as_breadcrumbs\" option is deprecated. Set the MASK_MESSAGE flag in \"logger_breadcrumb_mask\" instead.");
+	BitField<GodotLoggerEventMask> mask = godot_logger->get_breadcrumb_mask();
 	if (p_enabled) {
-		logger_breadcrumb_mask.set_flag(GodotLoggerEventMask::MASK_MESSAGE);
+		mask.set_flag(GodotLoggerEventMask::MASK_MESSAGE);
 	} else {
-		logger_breadcrumb_mask.clear_flag(GodotLoggerEventMask::MASK_MESSAGE);
+		mask.clear_flag(GodotLoggerEventMask::MASK_MESSAGE);
 	}
+	godot_logger->set_breadcrumb_mask(mask);
 }
 
 bool SentryOptions::deprecated_get_app_hang_tracking() const {
@@ -294,12 +319,39 @@ void SentryOptions::deprecated_set_app_hang_timeout_sec(double p_seconds) {
 	set_app_hang_timeout_ms(static_cast<int>(Math::round(p_seconds * 1000.0)));
 }
 
-void SentryOptions::set_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
-	logger_limits = p_limits;
-	// Ensure limits are initialized.
-	if (logger_limits.is_null()) {
-		logger_limits.instantiate();
-	}
+void SentryOptions::deprecated_set_logger_enabled(bool p_enabled) {
+	WARN_DEPRECATED_MSG("The \"logger_enabled\" option is deprecated. Use \"godot_logger.enabled\" instead.");
+	godot_logger->set_enabled(p_enabled);
+}
+
+void SentryOptions::deprecated_set_logger_include_source(bool p_enable) {
+	WARN_DEPRECATED_MSG("The \"logger_include_source\" option is deprecated. Use \"godot_logger.include_source\" instead.");
+	godot_logger->set_include_source(p_enable);
+}
+
+void SentryOptions::deprecated_set_logger_include_variables(bool p_logger_include_variables) {
+	WARN_DEPRECATED_MSG("The \"logger_include_variables\" option is deprecated. Use \"godot_logger.include_variables\" instead.");
+	godot_logger->set_include_variables(p_logger_include_variables);
+}
+
+void SentryOptions::deprecated_set_logger_event_mask(BitField<GodotLoggerEventMask> p_mask) {
+	WARN_DEPRECATED_MSG("The \"logger_event_mask\" option is deprecated. Use \"godot_logger.event_mask\" instead.");
+	godot_logger->set_event_mask(p_mask);
+}
+
+void SentryOptions::deprecated_set_logger_breadcrumb_mask(BitField<GodotLoggerEventMask> p_mask) {
+	WARN_DEPRECATED_MSG("The \"logger_breadcrumb_mask\" option is deprecated. Use \"godot_logger.breadcrumb_mask\" instead.");
+	godot_logger->set_breadcrumb_mask(p_mask);
+}
+
+void SentryOptions::deprecated_set_logger_log_mask(BitField<GodotLoggerEventMask> p_mask) {
+	WARN_DEPRECATED_MSG("The \"logger_log_mask\" option is deprecated. Use \"godot_logger.log_mask\" instead.");
+	godot_logger->set_log_mask(p_mask);
+}
+
+void SentryOptions::deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &p_limits) {
+	WARN_DEPRECATED_MSG("The \"logger_limits\" option is deprecated. Use \"godot_logger.limits\" instead.");
+	godot_logger->deprecated_set_limits(p_limits);
 }
 
 void SentryOptions::set_release(const String &p_release) {
@@ -360,19 +412,12 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_app_hang_tracking"), set_app_hang_tracking_enabled, is_app_hang_tracking_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "app_hang_timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), set_app_hang_timeout_ms, get_app_hang_timeout_ms);
 
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), set_logger_enabled, is_logger_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), set_logger_include_source, is_logger_include_source_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_variables"), set_logger_include_variables, is_logger_include_variables_enabled);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_event_mask"), set_logger_event_mask, get_logger_event_mask);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), set_logger_breadcrumb_mask, get_logger_breadcrumb_mask);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_log_mask"), set_logger_log_mask, get_logger_log_mask);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), set_logger_limits, get_logger_limits);
-
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send"), set_before_send, get_before_send);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_capture_screenshot"), set_before_capture_screenshot, get_before_capture_screenshot);
 
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "experimental", PROPERTY_HINT_TYPE_STRING, "SentryExperimental", PROPERTY_USAGE_NONE), get_experimental);
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "android", PROPERTY_HINT_TYPE_STRING, "SentryAndroidOptions", PROPERTY_USAGE_NONE), get_android);
+	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "godot_logger", PROPERTY_HINT_TYPE_STRING, "SentryGodotLoggerOptions", PROPERTY_USAGE_NONE), get_godot_logger);
 
 	{
 		using namespace sentry;
@@ -386,16 +431,23 @@ void SentryOptions::_bind_methods() {
 
 	// DEPRECATED: These properties are deprecated and remain for compatibility reasons.
 	// TODO: Remove these after November 2026 or in version 3.0.
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), set_logger_messages_as_breadcrumbs, is_logger_messages_as_breadcrumbs_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_messages_as_breadcrumbs"), deprecated_set_logger_messages_as_breadcrumbs, deprecated_is_logger_messages_as_breadcrumbs_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "app_hang_tracking"), deprecated_set_app_hang_tracking, deprecated_get_app_hang_tracking);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "app_hang_timeout_sec"), deprecated_set_app_hang_timeout_sec, deprecated_get_app_hang_timeout_sec);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_enabled"), deprecated_set_logger_enabled, deprecated_is_logger_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_source"), deprecated_set_logger_include_source, deprecated_is_logger_include_source_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "logger_include_variables"), deprecated_set_logger_include_variables, deprecated_is_logger_include_variables_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_event_mask"), deprecated_set_logger_event_mask, deprecated_get_logger_event_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), deprecated_set_logger_breadcrumb_mask, deprecated_get_logger_breadcrumb_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_log_mask"), deprecated_set_logger_log_mask, deprecated_get_logger_log_mask);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), deprecated_set_logger_limits, deprecated_get_logger_limits);
 }
 
 SentryOptions::SentryOptions() {
-	logger_limits.instantiate();
 	experimental.instantiate();
 	experimental->owner = this;
 	android.instantiate();
+	godot_logger.instantiate();
 
 	_init_debug_option(DEBUG_DEFAULT);
 }

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -147,19 +147,19 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/app_hang/timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), p_options->app_hang_timeout_ms, false);
 
 	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
-	_define_setting("sentry/logger/logger_enabled", logger_options->get_enabled());
-	_define_setting("sentry/logger/include_source", logger_options->get_include_source_context(), false);
-	_define_setting("sentry/logger/include_variables", logger_options->get_include_variables(), false);
-	_requires_restart("sentry/logger/include_variables");
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS()), logger_options->get_event_mask(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_breadcrumb_mask(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/logs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_log_mask(), false);
+	_define_setting("sentry/godot_logger/enabled", logger_options->get_enabled());
+	_define_setting("sentry/godot_logger/include_source_context", logger_options->get_include_source_context(), false);
+	_define_setting("sentry/godot_logger/include_variables", logger_options->get_include_variables(), false);
+	_requires_restart("sentry/godot_logger/include_variables");
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/events", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING_FOR_EVENTS()), logger_options->get_event_mask(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/breadcrumbs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_breadcrumb_mask(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/logs", PROPERTY_HINT_FLAGS, sentry::GODOT_ERROR_MASK_EXPORT_STRING()), logger_options->get_log_mask(), false);
 
 	Ref<SentryLoggerLimits> limits = logger_options->get_limits();
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), limits->get_events_per_frame(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_repeated_error_window_ms(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), limits->get_throttle_events(), false);
-	_define_setting(PropertyInfo(Variant::INT, "sentry/logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_throttle_window_ms(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/limits/events_per_frame", PROPERTY_HINT_RANGE, "0,20"), limits->get_events_per_frame(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/limits/repeated_error_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_repeated_error_window_ms(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/limits/throttle_events", PROPERTY_HINT_RANGE, "0,20"), limits->get_throttle_events(), false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/godot_logger/limits/throttle_window_ms", PROPERTY_HINT_RANGE, "0,10000"), limits->get_throttle_window_ms(), false);
 
 	_define_setting(PropertyInfo(Variant::BOOL, "sentry/android/application_not_responding/enable_detection"), p_options->get_android()->get_enable_anr_detection(), false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/android/application_not_responding/timeout_interval_ms"), p_options->get_android()->get_anr_timeout_interval_ms(), false);
@@ -240,18 +240,18 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->app_hang_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms);
 
 	Ref<SentryGodotLoggerOptions> logger_options = p_options->get_godot_logger();
-	logger_options->set_enabled(ProjectSettings::get_singleton()->get_setting("sentry/logger/logger_enabled", logger_options->get_enabled()));
-	logger_options->set_include_source_context(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_source", logger_options->get_include_source_context()));
-	logger_options->set_include_variables(ProjectSettings::get_singleton()->get_setting("sentry/logger/include_variables", logger_options->get_include_variables()));
-	logger_options->set_event_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/events", logger_options->get_event_mask()));
-	logger_options->set_breadcrumb_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/breadcrumbs", logger_options->get_breadcrumb_mask()));
-	logger_options->set_log_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/logger/logs", logger_options->get_log_mask()));
+	logger_options->set_enabled(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/enabled", logger_options->get_enabled()));
+	logger_options->set_include_source_context(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/include_source_context", logger_options->get_include_source_context()));
+	logger_options->set_include_variables(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/include_variables", logger_options->get_include_variables()));
+	logger_options->set_event_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/events", logger_options->get_event_mask()));
+	logger_options->set_breadcrumb_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/breadcrumbs", logger_options->get_breadcrumb_mask()));
+	logger_options->set_log_mask((int)ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/logs", logger_options->get_log_mask()));
 
 	Ref<SentryLoggerLimits> limits = logger_options->get_limits();
-	limits->set_events_per_frame(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/events_per_frame", limits->get_events_per_frame()));
-	limits->set_repeated_error_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/repeated_error_window_ms", limits->get_repeated_error_window_ms()));
-	limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_events", limits->get_throttle_events()));
-	limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/logger/limits/throttle_window_ms", limits->get_throttle_window_ms()));
+	limits->set_events_per_frame(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/limits/events_per_frame", limits->get_events_per_frame()));
+	limits->set_repeated_error_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/limits/repeated_error_window_ms", limits->get_repeated_error_window_ms()));
+	limits->set_throttle_events(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/limits/throttle_events", limits->get_throttle_events()));
+	limits->set_throttle_window_ms(ProjectSettings::get_singleton()->get_setting("sentry/godot_logger/limits/throttle_window_ms", limits->get_throttle_window_ms()));
 
 	p_options->android->set_enable_anr_detection(
 			ProjectSettings::get_singleton()->get_setting(

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -37,7 +37,7 @@ class SentryGodotLoggerOptions : public RefCounted {
 	GDCLASS(SentryGodotLoggerOptions, RefCounted);
 
 	SIMPLE_PROPERTY(bool, enabled, true);
-	SIMPLE_PROPERTY(bool, include_source, true);
+	SIMPLE_PROPERTY(bool, include_source_context, true);
 	SIMPLE_PROPERTY(bool, include_variables, false);
 	SIMPLE_PROPERTY(BitField<GodotLoggerEventMask>, event_mask, GodotLoggerEventMask::MASK_ERROR | GodotLoggerEventMask::MASK_SCRIPT | GodotLoggerEventMask::MASK_SHADER);
 	SIMPLE_PROPERTY(BitField<GodotLoggerEventMask>, breadcrumb_mask, GodotLoggerEventMask::MASK_ALL);
@@ -266,7 +266,7 @@ public:
 	bool deprecated_is_logger_enabled() const { return godot_logger->get_enabled(); }
 	void deprecated_set_logger_enabled(bool p_enabled);
 
-	bool deprecated_is_logger_include_source_enabled() const { return godot_logger->get_include_source(); }
+	bool deprecated_is_logger_include_source_enabled() const { return godot_logger->get_include_source_context(); }
 	void deprecated_set_logger_include_source(bool p_enable);
 
 	bool deprecated_is_logger_include_variables_enabled() const { return godot_logger->get_include_variables(); }

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -32,6 +32,30 @@ protected:
 	static void _bind_methods();
 };
 
+// Godot logger integration options.
+class SentryGodotLoggerOptions : public RefCounted {
+	GDCLASS(SentryGodotLoggerOptions, RefCounted);
+
+	SIMPLE_PROPERTY(bool, enabled, true);
+	SIMPLE_PROPERTY(bool, include_source, true);
+	SIMPLE_PROPERTY(bool, include_variables, false);
+	SIMPLE_PROPERTY(BitField<GodotLoggerEventMask>, event_mask, GodotLoggerEventMask::MASK_ERROR | GodotLoggerEventMask::MASK_SCRIPT | GodotLoggerEventMask::MASK_SHADER);
+	SIMPLE_PROPERTY(BitField<GodotLoggerEventMask>, breadcrumb_mask, GodotLoggerEventMask::MASK_ALL);
+	SIMPLE_PROPERTY(BitField<GodotLoggerEventMask>, log_mask, GodotLoggerEventMask::MASK_NONE);
+
+private:
+	Ref<SentryLoggerLimits> limits;
+
+protected:
+	static void _bind_methods();
+
+public:
+	_FORCE_INLINE_ Ref<SentryLoggerLimits> get_limits() const { return limits; }
+	void deprecated_set_limits(const Ref<SentryLoggerLimits> &p_limits);
+
+	SentryGodotLoggerOptions();
+};
+
 class SentryOptions;
 
 // Experimental options.
@@ -113,16 +137,9 @@ private:
 	bool enable_app_hang_tracking = false;
 	int app_hang_timeout_ms = 5000;
 
-	bool logger_enabled = true;
-	bool logger_include_source = true;
-	bool logger_include_variables = false;
-	BitField<GodotLoggerEventMask> logger_event_mask = GodotLoggerEventMask::MASK_ERROR | GodotLoggerEventMask::MASK_SCRIPT | GodotLoggerEventMask::MASK_SHADER;
-	BitField<GodotLoggerEventMask> logger_breadcrumb_mask = GodotLoggerEventMask::MASK_ALL;
-	BitField<GodotLoggerEventMask> logger_log_mask = GodotLoggerEventMask::MASK_NONE;
-	Ref<SentryLoggerLimits> logger_limits;
-
 	Ref<SentryExperimental> experimental;
 	Ref<SentryAndroidOptions> android;
+	Ref<SentryGodotLoggerOptions> godot_logger;
 
 	Callable before_send;
 	Callable before_capture_screenshot;
@@ -202,44 +219,8 @@ public:
 	_FORCE_INLINE_ bool is_app_hang_tracking_enabled() const { return enable_app_hang_tracking; }
 	_FORCE_INLINE_ void set_app_hang_tracking_enabled(bool p_enabled) { enable_app_hang_tracking = p_enabled; }
 
-	bool deprecated_get_app_hang_tracking() const;
-	void deprecated_set_app_hang_tracking(bool p_enabled);
-
 	_FORCE_INLINE_ int get_app_hang_timeout_ms() const { return app_hang_timeout_ms; }
 	_FORCE_INLINE_ void set_app_hang_timeout_ms(int p_milliseconds) { app_hang_timeout_ms = p_milliseconds; }
-
-	double deprecated_get_app_hang_timeout_sec() const;
-	void deprecated_set_app_hang_timeout_sec(double p_seconds);
-
-	_FORCE_INLINE_ bool is_logger_enabled() const { return logger_enabled; }
-	_FORCE_INLINE_ void set_logger_enabled(bool p_enabled) { logger_enabled = p_enabled; }
-
-	_FORCE_INLINE_ bool is_logger_include_source_enabled() const { return logger_include_source; }
-	_FORCE_INLINE_ void set_logger_include_source(bool p_enable) { logger_include_source = p_enable; }
-
-	_FORCE_INLINE_ bool is_logger_include_variables_enabled() const { return logger_include_variables; }
-	_FORCE_INLINE_ void set_logger_include_variables(bool p_logger_include_variables) { logger_include_variables = p_logger_include_variables; }
-
-	bool is_logger_messages_as_breadcrumbs_enabled() const;
-	void set_logger_messages_as_breadcrumbs(bool p_enabled);
-
-	_FORCE_INLINE_ BitField<GodotLoggerEventMask> get_logger_event_mask() const { return logger_event_mask; }
-	_FORCE_INLINE_ void set_logger_event_mask(BitField<GodotLoggerEventMask> p_mask) { logger_event_mask = p_mask; }
-
-	_FORCE_INLINE_ BitField<GodotLoggerEventMask> get_logger_breadcrumb_mask() const { return logger_breadcrumb_mask; }
-	_FORCE_INLINE_ void set_logger_breadcrumb_mask(BitField<GodotLoggerEventMask> p_mask) { logger_breadcrumb_mask = p_mask; }
-
-	_FORCE_INLINE_ BitField<GodotLoggerEventMask> get_logger_log_mask() const { return logger_log_mask; }
-	_FORCE_INLINE_ void set_logger_log_mask(BitField<GodotLoggerEventMask> p_mask) { logger_log_mask = p_mask; }
-
-	_FORCE_INLINE_ bool should_capture_event(GodotErrorType p_error_type) { return logger_event_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
-	_FORCE_INLINE_ bool should_capture_breadcrumb(GodotErrorType p_error_type) { return logger_breadcrumb_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
-	_FORCE_INLINE_ bool should_capture_log(GodotErrorType p_error_type) { return enable_logs && logger_log_mask.has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
-	_FORCE_INLINE_ bool should_capture_message_breadcrumb() { return logger_breadcrumb_mask.has_flag(MASK_MESSAGE); }
-	_FORCE_INLINE_ bool should_capture_message_log() { return enable_logs && logger_log_mask.has_flag(MASK_MESSAGE); }
-
-	_FORCE_INLINE_ Ref<SentryLoggerLimits> get_logger_limits() const { return logger_limits; }
-	void set_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
 
 	_FORCE_INLINE_ Callable get_before_send() const { return before_send; }
 	_FORCE_INLINE_ void set_before_send(const Callable &p_before_send) { before_send = p_before_send; }
@@ -249,6 +230,13 @@ public:
 
 	_FORCE_INLINE_ Ref<SentryExperimental> get_experimental() const { return experimental; }
 	_FORCE_INLINE_ Ref<SentryAndroidOptions> get_android() const { return android; }
+	_FORCE_INLINE_ Ref<SentryGodotLoggerOptions> get_godot_logger() const { return godot_logger; }
+
+	_FORCE_INLINE_ bool should_capture_event(GodotErrorType p_error_type) { return godot_logger->get_event_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_breadcrumb(GodotErrorType p_error_type) { return godot_logger->get_breadcrumb_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_log(GodotErrorType p_error_type) { return enable_logs && godot_logger->get_log_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_message_breadcrumb() { return godot_logger->get_breadcrumb_mask().has_flag(MASK_MESSAGE); }
+	_FORCE_INLINE_ bool should_capture_message_log() { return enable_logs && godot_logger->get_log_mask().has_flag(MASK_MESSAGE); }
 
 	void add_event_processor(const Ref<SentryEventProcessor> &p_processor);
 	void remove_event_processor(const Ref<SentryEventProcessor> &p_processor);
@@ -266,6 +254,38 @@ public:
 
 	SentryOptions();
 	~SentryOptions();
+
+	// *** Deprecated
+
+	bool deprecated_get_app_hang_tracking() const;
+	void deprecated_set_app_hang_tracking(bool p_enabled);
+
+	double deprecated_get_app_hang_timeout_sec() const;
+	void deprecated_set_app_hang_timeout_sec(double p_seconds);
+
+	bool deprecated_is_logger_enabled() const { return godot_logger->get_enabled(); }
+	void deprecated_set_logger_enabled(bool p_enabled);
+
+	bool deprecated_is_logger_include_source_enabled() const { return godot_logger->get_include_source(); }
+	void deprecated_set_logger_include_source(bool p_enable);
+
+	bool deprecated_is_logger_include_variables_enabled() const { return godot_logger->get_include_variables(); }
+	void deprecated_set_logger_include_variables(bool p_logger_include_variables);
+
+	bool deprecated_is_logger_messages_as_breadcrumbs_enabled() const { return godot_logger->get_breadcrumb_mask().has_flag(GodotLoggerEventMask::MASK_MESSAGE); }
+	void deprecated_set_logger_messages_as_breadcrumbs(bool p_enabled);
+
+	BitField<GodotLoggerEventMask> deprecated_get_logger_event_mask() const { return godot_logger->get_event_mask(); }
+	void deprecated_set_logger_event_mask(BitField<GodotLoggerEventMask> p_mask);
+
+	BitField<GodotLoggerEventMask> deprecated_get_logger_breadcrumb_mask() const { return godot_logger->get_breadcrumb_mask(); }
+	void deprecated_set_logger_breadcrumb_mask(BitField<GodotLoggerEventMask> p_mask);
+
+	BitField<GodotLoggerEventMask> deprecated_get_logger_log_mask() const { return godot_logger->get_log_mask(); }
+	void deprecated_set_logger_log_mask(BitField<GodotLoggerEventMask> p_mask);
+
+	Ref<SentryLoggerLimits> deprecated_get_logger_limits() const { return godot_logger->get_limits(); }
+	void deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
 };
 
 } // namespace sentry

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -60,7 +60,7 @@ void _verify_project_settings() {
 			ERR_PRINT("Sentry: Please enable `debug/settings/gdscript/always_track_call_stacks` in your Project Settings. This is required for supporting script stack traces.");
 		}
 	}
-	if (options->is_logger_include_variables_enabled() &&
+	if (options->get_godot_logger()->get_include_variables() &&
 			!ps->get_setting("debug/settings/gdscript/always_track_local_variables")) {
 		if (Engine::get_singleton()->is_editor_hint()) {
 			ps->set_setting("debug/settings/gdscript/always_track_local_variables", true);
@@ -192,7 +192,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 			_init_contexts();
 		}
 
-		if (options->is_logger_enabled()) {
+		if (options->get_godot_logger()->get_enabled()) {
 			if (godot_logger.is_null()) {
 				godot_logger.instantiate();
 			}

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -81,11 +81,28 @@ void _migrate_to_v2() {
 	_migrate_app_hang_timeout_to_ms();
 }
 
+void _migrate_logger_settings_to_godot_logger() {
+	_rename_setting("sentry/logger/logger_enabled", "sentry/godot_logger/enabled");
+	_rename_setting("sentry/logger/include_source", "sentry/godot_logger/include_source_context");
+	_rename_setting("sentry/logger/include_variables", "sentry/godot_logger/include_variables");
+	_rename_setting("sentry/logger/events", "sentry/godot_logger/events");
+	_rename_setting("sentry/logger/breadcrumbs", "sentry/godot_logger/breadcrumbs");
+	_rename_setting("sentry/logger/logs", "sentry/godot_logger/logs");
+	_rename_setting("sentry/logger/limits/events_per_frame", "sentry/godot_logger/limits/events_per_frame");
+	_rename_setting("sentry/logger/limits/repeated_error_window_ms", "sentry/godot_logger/limits/repeated_error_window_ms");
+	_rename_setting("sentry/logger/limits/throttle_events", "sentry/godot_logger/limits/throttle_events");
+	_rename_setting("sentry/logger/limits/throttle_window_ms", "sentry/godot_logger/limits/throttle_window_ms");
+}
+
+void _migrate_to_v3() {
+	_migrate_logger_settings_to_godot_logger();
+}
+
 } // unnamed namespace
 
 namespace sentry {
 
-constexpr static int SCHEMA_VERSION = 2;
+constexpr static int SCHEMA_VERSION = 3;
 
 void run_project_settings_migrations() {
 	const String schema_version_key = "sentry/schema_version";
@@ -113,6 +130,10 @@ void run_project_settings_migrations() {
 
 	if (from_version < 2) {
 		_migrate_to_v2();
+	}
+
+	if (from_version < 3) {
+		_migrate_to_v3();
 	}
 
 	if (from_version < SCHEMA_VERSION) {


### PR DESCRIPTION
This PR groups the flat `logger_*` options into a new `godot_logger` options object on `SentryOptions`. These options configure the SDK's integration with Godot's logging system, which captures engine errors, script errors, and printed messages as Sentry events, breadcrumbs, and logs. The new structure follows how other Sentry SDKs group feature-specific options (for example, the `Logs` and `Metrics` option groups in sentry-java), shortens the option names, and removes the ambiguity between this integration and `SentrySDK.logger`, Sentry's structured-logging API.

- Closes #758 
- Waiting for: 
  - #753
  - #749
- Docs https://github.com/getsentry/sentry-docs/pull/18297

## For reviewers

- The old flat `logger_*` properties remain as deprecated aliases that proxy to the new object and warn on use, following the same pattern as the earlier app hang renames. Removal is scheduled with the other deprecations (January 2027 or version 3.0).
- Two deliberate naming decisions: `include_source` became `include_source_context` (matches the Python SDK option), and `GodotLoggerEventMask` with its `MASK_*` constants intentionally stays on `SentryOptions` (namespace level in C#) so that future options outside the logger group can reference it.
- Project settings moved to `sentry/godot_logger/*`, with a schema v3 migration that renames persisted settings automatically; the demo project's settings are migrated as part of this PR.
- The C# layer mirrors the new structure as a clean break without `[Obsolete]` shims, since it has never been released as stable.