### PR TITLE
fix(dotnet): Avoid loading second copy of GDExtension on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - ANR detection is now separate from the App Hang Tracking options (`app_hang_tracking`, `app_hang_timeout_sec`), which now apply to Apple platforms only
   - Configure these through `SentryOptions.android`, or in the **Project Settings** under **Sentry > Android > Application Not Responding**
 
+### Fixes
+
+- Fix editor crash on Windows when opening a project that uses C#/.NET ([#762](https://github.com/getsentry/sentry-godot/pull/762))
+
 ### Dependencies
 
 - Bump Sentry JavaScript from v10.55.0 to v10.57.0 ([#743](https://github.com/getsentry/sentry-godot/pull/743), [#754](https://github.com/getsentry/sentry-godot/pull/754))

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -435,7 +435,7 @@ void SentrySDK::prepare_and_auto_initialize() {
 	// Set library path env var before .NET runtime starts.
 	// C# reads this to register DllImportResolver for interop.
 	OS::get_singleton()->set_environment("SENTRY_GODOT_LIB_PATH",
-			sentry::util::get_gdextension_library_path());
+			sentry::util::get_loaded_gdextension_library_path());
 
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {

--- a/src/sentry/util/library_path.cpp
+++ b/src/sentry/util/library_path.cpp
@@ -1,0 +1,43 @@
+#include "library_path.h"
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else // !_WIN32
+#include <dlfcn.h>
+#endif
+
+namespace sentry::util {
+
+godot::String get_loaded_gdextension_library_path() {
+	// NOTE: In the Windows editor, Godot loads a temporary "~"-prefixed copy of the library,
+	// while gdextension_interface_get_library_path() reports the original path.
+	// Passing that path to C# DllImport resolver would load a second, uninitialized copy of the library
+	// (with a null SentrySDK singleton), so resolve the module that is actually loaded instead.
+	// See issue 761.
+
+#if defined(_WIN32)
+	HMODULE module = nullptr;
+	if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+				reinterpret_cast<LPCWSTR>(&get_loaded_gdextension_library_path),
+				&module) &&
+			module != nullptr) {
+		WCHAR buffer[4096];
+		DWORD length = GetModuleFileNameW(module, buffer, static_cast<DWORD>(sizeof(buffer) / sizeof(buffer[0])));
+		if (length > 0 && length < sizeof(buffer) / sizeof(buffer[0])) {
+			return godot::String::utf16(reinterpret_cast<const char16_t *>(buffer), static_cast<int>(length));
+		}
+	}
+	return godot::String();
+#else
+	Dl_info info = {};
+	if (dladdr(reinterpret_cast<const void *>(&get_loaded_gdextension_library_path), &info) != 0 && info.dli_fname != nullptr) {
+		return godot::String::utf8(info.dli_fname);
+	}
+	return godot::String();
+#endif
+}
+
+} // namespace sentry::util

--- a/src/sentry/util/library_path.cpp
+++ b/src/sentry/util/library_path.cpp
@@ -5,20 +5,17 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#else // !_WIN32
-#include <dlfcn.h>
 #endif
 
 namespace sentry::util {
 
 godot::String get_loaded_gdextension_library_path() {
-	// NOTE: In the Windows editor, Godot loads a temporary "~"-prefixed copy of the library,
+#if defined(_WIN32)
+	// In the Windows editor, Godot loads a temporary "~"-prefixed copy of the library,
 	// while gdextension_interface_get_library_path() reports the original path.
 	// Passing that path to C# DllImport resolver would load a second, uninitialized copy of the library
 	// (with a null SentrySDK singleton), so resolve the module that is actually loaded instead.
 	// See issue 761.
-
-#if defined(_WIN32)
 	HMODULE module = nullptr;
 	if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
 				reinterpret_cast<LPCWSTR>(&get_loaded_gdextension_library_path),
@@ -32,11 +29,9 @@ godot::String get_loaded_gdextension_library_path() {
 	}
 	return godot::String();
 #else
-	Dl_info info = {};
-	if (dladdr(reinterpret_cast<const void *>(&get_loaded_gdextension_library_path), &info) != 0 && info.dli_fname != nullptr) {
-		return godot::String::utf8(info.dli_fname);
-	}
-	return godot::String();
+	godot::String library_path;
+	godot::internal::gdextension_interface_get_library_path(godot::internal::library, library_path._native_ptr());
+	return library_path;
 #endif
 }
 

--- a/src/sentry/util/library_path.h
+++ b/src/sentry/util/library_path.h
@@ -5,10 +5,7 @@
 
 namespace sentry::util {
 
-inline godot::String get_gdextension_library_path() {
-	godot::String library_path;
-	godot::internal::gdextension_interface_get_library_path(godot::internal::library, library_path._native_ptr());
-	return library_path;
-}
+// Returns the FS path of this shared library as it was actually loaded by the OS.
+godot::String get_loaded_gdextension_library_path();
 
 } // namespace sentry::util


### PR DESCRIPTION
Opening the editor for a C# project on Windows could crash with an access violation, particularly after deleting the editor cache folder (`.godot`). This happened while the editor rebuilt class documentation and registered script classes, potentially leaving the project unusable until the cache was regenerated. This PR fixes the crash and allows .NET projects to open reliably.

- Fixes #761 

**What actually happens**: The editor creates and loads a temporary copy of a GDExtension with a "~" prefix but reports the original library path. The C# P/Invoke resolver used the original path and loaded a second, uninitialized copy of the DLL, which crashed when accessed. The fix involves resolving the path of the already-loaded module, ensuring both sides use the same library image. The issue only affected the Windows editor; exported games and other platforms were unaffected.
