### PR TITLE
feat: Add `SentrySDK.bad_code` API for crash testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   - Renamed `SentryOptions.app_hang_tracking` to `SentryOptions.enable_app_hang_tracking`; the old name remains as a deprecated alias.
   - Renamed `SentryOptions.app_hang_timeout_sec` to `SentryOptions.app_hang_timeout_ms`, now configured in milliseconds; the old name remains as a deprecated alias, and existing Project Settings are migrated automatically.
 
+### Features
+
+- Add `SentrySDK.bad_code` API for deliberately crashing the application to test crash reporting and native stack traces ([#765](https://github.com/getsentry/sentry-godot/pull/765))
+
 ### Improvements
 
 - Distribute native debug symbols in a separate `sentry-godot-debug-symbols` archive instead of bundling them with the addon, reducing the size of the released addon and demo-project packages ([#747](https://github.com/getsentry/sentry-godot/pull/747))

--- a/doc_classes/SentryBadCode.xml
+++ b/doc_classes/SentryBadCode.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SentryBadCode" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Deliberately crashes the application to test crash reporting.
+	</brief_description>
+	<description>
+		Provides methods that intentionally crash the application in different ways, letting you confirm that crash reporting and native stack traces work as expected. Access this API through [member SentrySDK.bad_code].
+		[b]Warning:[/b] Every method here crashes the running application on purpose. These methods are meant for testing and demonstration only and must never be called in shipped code.
+		[codeblock]
+		# Crash the application with a null pointer dereference.
+		SentrySDK.bad_code.crash_with_null_dereference()
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="crash_with_abort">
+			<return type="void" />
+			<description>
+				Crashes the application by calling the C [code]abort()[/code] function, which raises [code]SIGABRT[/code].
+			</description>
+		</method>
+		<method name="crash_with_division_by_zero">
+			<return type="void" />
+			<description>
+				Crashes the application by performing an integer division by zero, which raises [code]SIGFPE[/code].
+				[b]Note:[/b] On ARM architectures (used by most Android and iOS devices), integer division by zero returns zero instead of raising a hardware exception, so this method does not crash there.
+			</description>
+		</method>
+		<method name="crash_with_null_dereference">
+			<return type="void" />
+			<description>
+				Crashes the application by writing through a null pointer, which raises a segmentation fault ([code]SIGSEGV[/code]).
+			</description>
+		</method>
+		<method name="crash_with_stack_overflow">
+			<return type="void" />
+			<description>
+				Crashes the application by overflowing the call stack through unbounded recursion.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -179,6 +179,10 @@
 		</method>
 	</methods>
 	<members>
+		<member name="bad_code" type="SentryBadCode" setter="" getter="get_bad_code">
+			Provides access to methods that deliberately crash the application, letting you test crash reporting and native stack traces. See [SentryBadCode] for more details.
+			[b]Warning:[/b] Every method exposed here crashes the running application on purpose. It is meant for testing and demonstration only and must never be called in shipped code.
+		</member>
 		<member name="logger" type="SentryLogger" setter="" getter="get_logger">
 			Provides access to Sentry's structured logging API. Use this to send log messages to Sentry when [member SentryExperimental.enable_logs] is enabled. The dedicated logger API offers methods for different log levels and enables you to capture structured data with your log messages.
 			See [SentryLogger] for more details.

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -75,7 +75,7 @@ func _cmd_crash_capture() -> int:
 	await get_tree().create_timer(0.5).timeout
 
 	# Use the same crash method as the demo
-	SentrySDK._demo_helper_crash_app()
+	SentrySDK.bad_code.crash_with_null_dereference()
 	return 0
 
 

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -74,7 +74,6 @@ func _cmd_crash_capture() -> int:
 	# NOTE: On Android, NDK scope sync seems to happen with delay.
 	await get_tree().create_timer(0.5).timeout
 
-	# Use the same crash method as the demo
 	SentrySDK.bad_code.crash_with_null_dereference()
 	return 0
 

--- a/project/views/capture_events.gd
+++ b/project/views/capture_events.gd
@@ -69,7 +69,7 @@ func _on_capture_button_pressed() -> void:
 
 func _on_crash_button_pressed() -> void:
 	DemoOutput.print_info("Crashing app...")
-	SentrySDK._demo_helper_crash_app()
+	SentrySDK.bad_code.crash_with_null_dereference()
 
 
 func _on_set_user_button_pressed() -> void:

--- a/project/views/capture_events.gd
+++ b/project/views/capture_events.gd
@@ -67,11 +67,6 @@ func _on_capture_button_pressed() -> void:
 	DemoOutput.print_info("Captured message event. Event ID: " + event_id)
 
 
-func _on_crash_button_pressed() -> void:
-	DemoOutput.print_info("Crashing app...")
-	SentrySDK.bad_code.crash_with_null_dereference()
-
-
 func _on_set_user_button_pressed() -> void:
 	DemoOutput.print_info("Setting user info...")
 	var user := SentryUser.new()
@@ -114,3 +109,23 @@ func _generate_native_error() -> void:
 
 func _on_user_feedback_button_pressed() -> void:
 	_user_feedback_gui.show()
+
+
+func _on_crash_with_null_dereference_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with null dereference...")
+	SentrySDK.bad_code.crash_with_null_dereference()
+
+
+func _on_crash_with_stack_overflow_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with stack overflow...")
+	SentrySDK.bad_code.crash_with_stack_overflow()
+
+
+func _on_crash_with_abort_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with abort...")
+	SentrySDK.bad_code.crash_with_abort()
+
+
+func _on_crash_with_div_by_zero_button_pressed() -> void:
+	DemoOutput.print_info("Crashing app with division by zero...")
+	SentrySDK.bad_code.crash_with_division_by_zero()

--- a/project/views/capture_events.tscn
+++ b/project/views/capture_events.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://bxi26vu5tlqas"]
+[gd_scene format=3 uid="uid://bxi26vu5tlqas"]
 
 [ext_resource type="Script" uid="uid://kjyxrvgox014" path="res://views/capture_events.gd" id="1_ldmgx"]
 
-[node name="CaptureEvents" type="VBoxContainer"]
+[node name="CaptureEvents" type="VBoxContainer" unique_id=1737353851]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -14,131 +14,148 @@ size_flags_horizontal = 3
 script = ExtResource("1_ldmgx")
 metadata/_tab_index = 0
 
-[node name="Header - User Info" type="Label" parent="."]
+[node name="Header - User Info" type="Label" parent="." unique_id=1714086838]
 custom_minimum_size = Vector2(0, 40.505)
 layout_mode = 2
 text = "USER INFO"
 horizontal_alignment = 1
 vertical_alignment = 2
 
-[node name="User info" type="HBoxContainer" parent="."]
+[node name="User info" type="HBoxContainer" parent="." unique_id=1903641773]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="User info"]
+[node name="Label" type="Label" parent="User info" unique_id=2103305956]
 layout_mode = 2
 text = "User ID: "
 
-[node name="UserID" type="LineEdit" parent="User info"]
+[node name="UserID" type="LineEdit" parent="User info" unique_id=511249781]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "ID"
 
-[node name="InferIP" type="CheckBox" parent="User info"]
+[node name="InferIP" type="CheckBox" parent="User info" unique_id=1549270712]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Infer IP"
 
-[node name="User info (continued)" type="HBoxContainer" parent="."]
+[node name="User info (continued)" type="HBoxContainer" parent="." unique_id=1555838471]
 layout_mode = 2
 
-[node name="Username" type="LineEdit" parent="User info (continued)"]
+[node name="Username" type="LineEdit" parent="User info (continued)" unique_id=810343024]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Username"
 
-[node name="Email" type="LineEdit" parent="User info (continued)"]
+[node name="Email" type="LineEdit" parent="User info (continued)" unique_id=447304647]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Email"
 
-[node name="SetUserButton" type="Button" parent="."]
+[node name="SetUserButton" type="Button" parent="." unique_id=1517860827]
 layout_mode = 2
 text = "Set User"
 
-[node name="Header - Generate Errors" type="Label" parent="."]
+[node name="Header - Generate Errors" type="Label" parent="." unique_id=2024969049]
 custom_minimum_size = Vector2(0, 40.505)
 layout_mode = 2
 text = "GENERATE ERRORS"
 horizontal_alignment = 1
 vertical_alignment = 2
 
-[node name="GenerateErrors" type="HBoxContainer" parent="."]
+[node name="GenerateErrors" type="HBoxContainer" parent="." unique_id=58584500]
 layout_mode = 2
 
-[node name="GenScriptError" type="Button" parent="GenerateErrors"]
+[node name="GenScriptError" type="Button" parent="GenerateErrors" unique_id=1616799821]
 layout_mode = 2
 text = "GDScript error"
 
-[node name="GenScriptErrorFromThread" type="Button" parent="GenerateErrors"]
+[node name="GenScriptErrorFromThread" type="Button" parent="GenerateErrors" unique_id=509246838]
 layout_mode = 2
 text = "GDScript error from thread"
 
-[node name="GenNativeError" type="Button" parent="GenerateErrors"]
+[node name="GenNativeError" type="Button" parent="GenerateErrors" unique_id=1222936885]
 layout_mode = 2
 text = "C++ error"
 
-[node name="Header - Capture" type="Label" parent="."]
+[node name="Header - Generate Crashes" type="Label" parent="." unique_id=1135154084]
+custom_minimum_size = Vector2(0, 40.505)
+layout_mode = 2
+text = "GENERATE CRASHES"
+horizontal_alignment = 1
+vertical_alignment = 2
+
+[node name="GenerateCrashes" type="HFlowContainer" parent="." unique_id=1092125422]
+layout_mode = 2
+
+[node name="CrashWithNullDereferenceButton" type="Button" parent="GenerateCrashes" unique_id=346573043]
+layout_mode = 2
+text = "NULL DEREFERENCE"
+
+[node name="CrashWithStackOverflowButton" type="Button" parent="GenerateCrashes" unique_id=255689501]
+layout_mode = 2
+text = "STACK OVERFLOW"
+
+[node name="CrashWithAbortButton" type="Button" parent="GenerateCrashes" unique_id=1379694065]
+layout_mode = 2
+text = "ABORT"
+
+[node name="CrashWithDivByZeroButton" type="Button" parent="GenerateCrashes" unique_id=1429534935]
+layout_mode = 2
+text = "DIV BY ZERO"
+
+[node name="Header - Capture" type="Label" parent="." unique_id=783736141]
 custom_minimum_size = Vector2(0, 40.505)
 layout_mode = 2
 text = "CAPTURE EVENTS"
 horizontal_alignment = 1
 vertical_alignment = 2
 
-[node name="UserFeedback" type="HBoxContainer" parent="."]
+[node name="UserFeedback" type="HBoxContainer" parent="." unique_id=1118227952]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="UserFeedback"]
+[node name="Label" type="Label" parent="UserFeedback" unique_id=1664370003]
 layout_mode = 2
 text = "User feedback:"
 
-[node name="UserFeedbackButton" type="Button" parent="UserFeedback"]
+[node name="UserFeedbackButton" type="Button" parent="UserFeedback" unique_id=1465731614]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "Show User Feedback Form"
 
-[node name="MessageEvent" type="HBoxContainer" parent="."]
+[node name="MessageEvent" type="HBoxContainer" parent="." unique_id=1342184205]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MessageEvent"]
+[node name="Label" type="Label" parent="MessageEvent" unique_id=587830529]
 layout_mode = 2
 text = "Message: "
 
-[node name="MessageEdit" type="LineEdit" parent="MessageEvent"]
+[node name="MessageEdit" type="LineEdit" parent="MessageEvent" unique_id=503159704]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Enter message"
 
-[node name="LevelChoice" type="MenuButton" parent="MessageEvent"]
+[node name="LevelChoice" type="MenuButton" parent="MessageEvent" unique_id=860208883]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 text = "WARNING"
 flat = false
 
-[node name="CaptureButton" type="Button" parent="MessageEvent"]
+[node name="CaptureButton" type="Button" parent="MessageEvent" unique_id=1593586317]
 layout_mode = 2
 text = "Capture Event"
-
-[node name="Crash" type="HBoxContainer" parent="."]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="Crash"]
-layout_mode = 2
-text = "Crash program: "
-
-[node name="CrashButton" type="Button" parent="Crash"]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "CRASH!"
 
 [connection signal="pressed" from="SetUserButton" to="." method="_on_set_user_button_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenScriptError" to="." method="_on_gen_script_error_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenScriptErrorFromThread" to="." method="_on_gen_script_error_from_thread_pressed"]
 [connection signal="pressed" from="GenerateErrors/GenNativeError" to="." method="_on_gen_native_error_pressed"]
+[connection signal="pressed" from="GenerateCrashes/CrashWithNullDereferenceButton" to="." method="_on_crash_with_null_dereference_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/CrashWithStackOverflowButton" to="." method="_on_crash_with_stack_overflow_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/CrashWithAbortButton" to="." method="_on_crash_with_abort_button_pressed"]
+[connection signal="pressed" from="GenerateCrashes/CrashWithDivByZeroButton" to="." method="_on_crash_with_div_by_zero_button_pressed"]
 [connection signal="pressed" from="UserFeedback/UserFeedbackButton" to="." method="_on_user_feedback_button_pressed"]
 [connection signal="pressed" from="MessageEvent/CaptureButton" to="." method="_on_capture_button_pressed"]
-[connection signal="pressed" from="Crash/CrashButton" to="." method="_on_crash_button_pressed"]

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -7,6 +7,7 @@
 #include "sentry/processing/view_hierarchy_processor.h"
 #include "sentry/runtime_config.h"
 #include "sentry/sentry_attachment.h"
+#include "sentry/sentry_bad_code.h"
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_event.h"
 #include "sentry/sentry_feedback.h"
@@ -79,6 +80,7 @@ void register_runtime_classes() {
 	GDREGISTER_CLASS(SentryTimestamp);
 	GDREGISTER_CLASS(SentryLogger);
 	GDREGISTER_CLASS(SentryMetrics);
+	GDREGISTER_CLASS(SentryBadCode);
 	GDREGISTER_CLASS(SentryUnit);
 	GDREGISTER_CLASS(SentryFeedback);
 	GDREGISTER_CLASS(SentrySDK);

--- a/src/sentry/sentry_bad_code.cpp
+++ b/src/sentry/sentry_bad_code.cpp
@@ -1,0 +1,38 @@
+#include "sentry_bad_code.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+#include <cstdlib>
+
+namespace sentry {
+
+void SentryBadCode::crash_with_null_dereference() {
+	volatile int *ptr = nullptr;
+	*ptr = 0;
+}
+
+void SentryBadCode::crash_with_stack_overflow() {
+	volatile int arr[1024];
+	crash_with_stack_overflow();
+	arr[0] = 0;
+}
+
+void SentryBadCode::crash_with_abort() {
+	std::abort();
+}
+
+void SentryBadCode::crash_with_division_by_zero() {
+	volatile int a = 1;
+	volatile int b = 0;
+	volatile int c = a / b;
+	(void)c;
+}
+
+void SentryBadCode::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("crash_with_null_dereference"), &SentryBadCode::crash_with_null_dereference);
+	ClassDB::bind_method(D_METHOD("crash_with_stack_overflow"), &SentryBadCode::crash_with_stack_overflow);
+	ClassDB::bind_method(D_METHOD("crash_with_abort"), &SentryBadCode::crash_with_abort);
+	ClassDB::bind_method(D_METHOD("crash_with_division_by_zero"), &SentryBadCode::crash_with_division_by_zero);
+}
+
+} // namespace sentry

--- a/src/sentry/sentry_bad_code.h
+++ b/src/sentry/sentry_bad_code.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <godot_cpp/classes/object.hpp>
+
+using namespace godot;
+
+namespace sentry {
+
+// Deliberately crashes the application to test crash reporting.
+class SentryBadCode : public Object {
+	GDCLASS(SentryBadCode, Object);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void crash_with_null_dereference();
+	void crash_with_stack_overflow();
+	void crash_with_abort();
+	void crash_with_division_by_zero();
+
+	SentryBadCode() = default;
+};
+
+} // namespace sentry

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -426,11 +426,6 @@ void SentrySDK::_auto_initialize() {
 	is_auto_initializing = false;
 }
 
-void SentrySDK::_demo_helper_crash_app() {
-	char *ptr = (char *)1;
-	sentry::logging::print_fatal("Crash by access violation ", ptr); // this is going to crash the app
-}
-
 void SentrySDK::prepare_and_auto_initialize() {
 	// Set library path env var before .NET runtime starts.
 	// C# reads this to register DllImportResolver for interop.
@@ -531,7 +526,6 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_before_send", "callable"), &SentrySDK::set_before_send);
 	ClassDB::bind_method(D_METHOD("_unset_before_send"), &SentrySDK::unset_before_send);
 	ClassDB::bind_method(D_METHOD("_get_before_send"), &SentrySDK::get_before_send);
-	ClassDB::bind_method(D_METHOD("_demo_helper_crash_app"), &SentrySDK::_demo_helper_crash_app);
 
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "logger", PROPERTY_HINT_TYPE_STRING, "SentryLogger", PROPERTY_USAGE_NONE), get_logger);
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "metrics", PROPERTY_HINT_TYPE_STRING, "SentryMetrics", PROPERTY_USAGE_NONE), get_metrics);

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -535,6 +535,7 @@ void SentrySDK::_bind_methods() {
 
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "logger", PROPERTY_HINT_TYPE_STRING, "SentryLogger", PROPERTY_USAGE_NONE), get_logger);
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "metrics", PROPERTY_HINT_TYPE_STRING, "SentryMetrics", PROPERTY_USAGE_NONE), get_metrics);
+	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "bad_code", PROPERTY_HINT_TYPE_STRING, "SentryBadCode", PROPERTY_USAGE_NONE), get_bad_code);
 }
 
 SentrySDK::SentrySDK() {
@@ -543,6 +544,7 @@ SentrySDK::SentrySDK() {
 	options = SentryOptions::create_from_project_settings();
 	logger = memnew(SentryLogger);
 	metrics = memnew(SentryMetrics);
+	bad_code = memnew(SentryBadCode);
 	internal_sdk = std::make_unique<DisabledSDK>();
 }
 
@@ -555,6 +557,8 @@ SentrySDK::~SentrySDK() {
 	logger = nullptr;
 	memdelete(metrics);
 	metrics = nullptr;
+	memdelete(bad_code);
+	bad_code = nullptr;
 }
 
 } // namespace sentry

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -57,7 +57,6 @@ private:
 	void _init_user();
 	Vector<Ref<SentryAttachment>> _get_default_attachments();
 	void _auto_initialize();
-	void _demo_helper_crash_app();
 
 protected:
 	static void _bind_methods();

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -5,6 +5,7 @@
 #include "sentry/logging/sentry_godot_logger.h"
 #include "sentry/runtime_config.h"
 #include "sentry/sentry_attachment.h"
+#include "sentry/sentry_bad_code.h"
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_event.h"
 #include "sentry/sentry_logger.h"
@@ -47,9 +48,10 @@ private:
 
 	TraceContext trace_context;
 
-	// Public API for logs and metrics
+	// Public API objects exposed as nested SentrySDK properties.
 	SentryLogger *logger = nullptr;
 	SentryMetrics *metrics = nullptr;
+	SentryBadCode *bad_code = nullptr;
 
 	void _init_contexts();
 	void _init_user();
@@ -89,6 +91,7 @@ public:
 
 	_FORCE_INLINE_ SentryLogger *get_logger() const { return logger; }
 	_FORCE_INLINE_ SentryMetrics *get_metrics() const { return metrics; }
+	_FORCE_INLINE_ SentryBadCode *get_bad_code() const { return bad_code; }
 
 	String capture_message(const String &p_message, sentry::Level p_level = sentry::LEVEL_INFO);
 	String get_last_event_id() const;


### PR DESCRIPTION
This PR adds `SentryBadCode`, a small public API for deliberately crashing the application, accessible through `SentrySDK.bad_code`. It exposes four crash types (null pointer dereference, stack overflow, abort(), and integer division by zero), giving users a one-line way to confirm that crash reporting and native stack traces work in their own project, and it backs the crash buttons in the demo project. This functionality will also be utilized in the sandbox demo.

- Supersedes #513
- Closes #510

**Usage**:
```gdscript
SentrySDK.bad_code.crash_with_null_dereference()
```
