### PR TITLE
ref(options): Remove deprecated experimental log options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Moved the `SentryOptions.logger_*` options under `SentryOptions.godot_logger` (for example, `logger_event_mask` becomes `godot_logger.event_mask`); the old names remain as deprecated aliases.
   - Renamed `logger_include_source` to `godot_logger.include_source_context` as part of the move.
   - Existing Project Settings under **Sentry > Logger** are migrated automatically.
+- Remove compatibility support for the deprecated `SentryOptions.experimental.enable_logs` and `experimental.before_send_log` properties; use `SentryOptions.enable_logs` and `SentryOptions.before_send_log` instead ([#766](https://github.com/getsentry/sentry-godot/pull/766))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
   - Moved the `SentryOptions.logger_*` options under `SentryOptions.godot_logger` (for example, `logger_event_mask` becomes `godot_logger.event_mask`); the old names remain as deprecated aliases.
   - Renamed `logger_include_source` to `godot_logger.include_source_context` as part of the move.
   - Existing Project Settings under **Sentry > Logger** are migrated automatically.
-- Remove compatibility support for the deprecated `SentryOptions.experimental.enable_logs` and `experimental.before_send_log` properties; use `SentryOptions.enable_logs` and `SentryOptions.before_send_log` instead ([#766](https://github.com/getsentry/sentry-godot/pull/766))
+- Remove the deprecated `SentryOptions.experimental.enable_logs` and `experimental.before_send_log` properties, which had remained as compatibility forwarders since logs became generally available; use `SentryOptions.enable_logs` and `SentryOptions.before_send_log` instead ([#766](https://github.com/getsentry/sentry-godot/pull/766))
 
 ### Features
 

--- a/doc_classes/SentryExperimental.xml
+++ b/doc_classes/SentryExperimental.xml
@@ -10,20 +10,6 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="before_send_log" type="Callable" setter="set_before_send_log" getter="get_before_send_log" default="Callable()" deprecated="Logs are now generally available. Use [member SentryOptions.before_send_log] instead.">
-			If assigned, this callback will be called before sending a log message to Sentry. It can be used to modify the log message or prevent it from being sent.
-			[codeblock]
-			func _before_send_log(log_entry: SentryLog) -&gt; SentryLog:
-				# Filter junk.
-				if log_entry.body == "Junk message":
-					return null
-				# Remove sensitive information from log messages.
-				log_entry.body = log_entry.body.replace("Bruno", "REDACTED")
-				# Add custom attributes.
-				log_entry.set_attribute("current_scene", current_scene.name)
-				return log_entry
-			[/codeblock]
-		</member>
 		<member name="before_send_metric" type="Callable" setter="set_before_send_metric" getter="get_before_send_metric" default="Callable()">
 			If assigned, this callback will be called before sending a metric to Sentry. It can be used to modify the metric or prevent it from being sent.
 			[codeblock]
@@ -35,9 +21,6 @@
 				metric.set_attribute("current_scene", get_tree().current_scene.name)
 				return metric
 			[/codeblock]
-		</member>
-		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="false" deprecated="Logs are now generally available. Use [member SentryOptions.enable_logs] instead.">
-			Enables Sentry structured logging functionality. When enabled, Godot's log messages are automatically captured and sent to Sentry, and you gain access to the dedicated logging APIs available through [member SentrySDK.logger].
 		</member>
 		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true">
 			Enables Sentry metrics functionality. When enabled, you can emit custom metrics using the [SentryMetrics] API available through [member SentrySDK.metrics].

--- a/doc_classes/SentryLogger.xml
+++ b/doc_classes/SentryLogger.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A dedicated API for logging messages to Sentry's structured logging system. Access this API through [member SentrySDK.logger]. [SentryLogger] provides methods for different log levels ([method trace], [method debug], [method info], [method warn], [method error], [method fatal]) and enables structured data capture with your log messages.
-		[b]Note:[/b] The [member SentryExperimental.enable_logs] option in [member SentryOptions.experimental] must be enabled for logging functionality to work.
+		[b]Note:[/b] The [member SentryOptions.enable_logs] option must be enabled for logging functionality to work.
 		[codeblock]
 		# Simple messages
 		SentrySDK.logger.info("Game session started")

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -180,7 +180,7 @@
 	</methods>
 	<members>
 		<member name="logger" type="SentryLogger" setter="" getter="get_logger">
-			Provides access to Sentry's structured logging API. Use this to send log messages to Sentry when [member SentryExperimental.enable_logs] is enabled. The dedicated logger API offers methods for different log levels and enables you to capture structured data with your log messages.
+			Provides access to Sentry's structured logging API. Use this to send log messages to Sentry when [member SentryOptions.enable_logs] is enabled. The dedicated logger API offers methods for different log levels and enables you to capture structured data with your log messages.
 			See [SentryLogger] for more details.
 		</member>
 		<member name="metrics" type="SentryMetrics" setter="" getter="get_metrics">

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -76,36 +76,9 @@ SentryGodotLoggerOptions::SentryGodotLoggerOptions() {
 
 // *** SentryExperimental
 
-void SentryExperimental::set_enable_logs(bool p_value) {
-	WARN_DEPRECATED_MSG("Sentry Logs are now generally available. This property is deprecated. Use SentryOptions.enable_logs instead.");
-	ERR_FAIL_NULL(owner);
-	owner->set_enable_logs(p_value);
-}
-
-bool SentryExperimental::get_enable_logs() {
-	// DEPRECATED: This accessor is deprecated and will be removed in a future version.
-	return owner ? owner->get_enable_logs() : false;
-}
-
-void SentryExperimental::set_before_send_log(Callable p_value) {
-	WARN_DEPRECATED_MSG("Sentry Logs are now generally available. This property is deprecated. Use SentryOptions.before_send_log instead.");
-	ERR_FAIL_NULL(owner);
-	owner->set_before_send_log(p_value);
-}
-
-Callable SentryExperimental::get_before_send_log() {
-	// DEPRECATED: This accessor is deprecated and will be removed in a future version.
-	return owner ? owner->get_before_send_log() : Callable();
-}
-
 void SentryExperimental::_bind_methods() {
 	BIND_PROPERTY_SIMPLE(SentryExperimental, Variant::BOOL, enable_metrics);
 	BIND_PROPERTY_SIMPLE(SentryExperimental, Variant::CALLABLE, before_send_metric);
-
-	// DEPRECATED: These properties are deprecated and remain for compatibility reasons.
-	// TODO: Remove these after June 2026 or in version 2.0.
-	BIND_PROPERTY_SIMPLE(SentryExperimental, Variant::BOOL, enable_logs);
-	BIND_PROPERTY_SIMPLE(SentryExperimental, Variant::CALLABLE, before_send_log);
 }
 
 // *** SentryAndroidOptions

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -76,12 +76,6 @@ public:
 	void set_before_send_metric(const Callable &p_value) { before_send_metric = p_value; }
 	Callable get_before_send_metric() const { return before_send_metric; }
 
-	// DEPRECATED: The following accessors are deprecated and scheduled for removal.
-	void set_enable_logs(bool p_value);
-	bool get_enable_logs();
-	void set_before_send_log(Callable p_value);
-	Callable get_before_send_log();
-
 protected:
 	static void _bind_methods();
 };

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -62,8 +62,8 @@ class SentryOptions;
 class SentryExperimental : public RefCounted {
 	GDCLASS(SentryExperimental, RefCounted);
 
+	// Keep owner and the friend wiring for future compatibility forwarders.
 	friend class SentryOptions;
-
 	SentryOptions *owner = nullptr;
 
 	bool enable_metrics = true;


### PR DESCRIPTION
Removes the deprecated `SentryExperimental.enable_logs` and `before_send_log` properties, which were forwarders to `SentryOptions` left in place after logs went generally available. They were marked deprecated at that time with a note to remove them after June 2026 / in 2.0, and that window has now passed. This drops the four forwarding accessors and their bindings from `SentryExperimental`, along with the corresponding doc-class members; the canonical `SentryOptions.enable_logs` / `before_send_log` API is unchanged, and the `sentry/experimental/enable_logs` → `sentry/options/enable_logs` project-settings migration stays so existing projects continue to upgrade cleanly.