### PR TITLE
ref(options): Enable App Hang Tracking by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Align App Hang Tracking options with other gaming SDKs ([#753](https://github.com/getsentry/sentry-godot/pull/753))
   - Renamed `SentryOptions.app_hang_tracking` to `SentryOptions.enable_app_hang_tracking`; the old name remains as a deprecated alias.
   - Renamed `SentryOptions.app_hang_timeout_sec` to `SentryOptions.app_hang_timeout_ms`, now configured in milliseconds; the old name remains as a deprecated alias, and existing Project Settings are migrated automatically.
+- App Hang Tracking is now enabled by default; set `SentryOptions.enable_app_hang_tracking` to `false` to opt out ([#773](https://github.com/getsentry/sentry-godot/pull/773))
 - Group Godot logger options under `SentryOptions.godot_logger` ([#759](https://github.com/getsentry/sentry-godot/pull/759))
   - Moved the `SentryOptions.logger_*` options under `SentryOptions.godot_logger` (for example, `logger_event_mask` becomes `godot_logger.event_mask`); the old names remain as deprecated aliases.
   - Renamed `logger_include_source` to `godot_logger.include_source_context` as part of the move.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -22,7 +22,7 @@
 		<member name="app_hang_timeout_sec" type="float" setter="deprecated_set_app_hang_timeout_sec" getter="deprecated_get_app_hang_timeout_sec" default="5.0" deprecated="Use [member app_hang_timeout_ms] instead.">
 			Specifies the timeout duration in seconds after which the application is considered to have hanged.
 		</member>
-		<member name="app_hang_tracking" type="bool" setter="deprecated_set_app_hang_tracking" getter="deprecated_get_app_hang_tracking" default="false" deprecated="Use [member enable_app_hang_tracking] instead.">
+		<member name="app_hang_tracking" type="bool" setter="deprecated_set_app_hang_tracking" getter="deprecated_get_app_hang_tracking" default="true" deprecated="Use [member enable_app_hang_tracking] instead.">
 			If [code]true[/code], enables automatic detection and reporting of application hangs.
 		</member>
 		<member name="attach_log" type="bool" setter="set_attach_log" getter="is_attach_log_enabled" default="true">
@@ -85,7 +85,7 @@
 		<member name="dsn" type="String" setter="set_dsn" getter="get_dsn" default="&quot;&quot;">
 			Data Source Name (DSN): Specifies where the SDK should send the events. If this value is not provided, the SDK will try to read it from the [code]SENTRY_DSN[/code] environment variable. If that variable also does not exist, the SDK will just not send any events.
 		</member>
-		<member name="enable_app_hang_tracking" type="bool" setter="set_app_hang_tracking_enabled" getter="is_app_hang_tracking_enabled" default="false">
+		<member name="enable_app_hang_tracking" type="bool" setter="set_app_hang_tracking_enabled" getter="is_app_hang_tracking_enabled" default="true">
 			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_ms]. This helps identify performance issues where the application becomes frozen or unresponsive.
 			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -59,7 +59,7 @@ public sealed class SentryGodotOptions : SentryOptions
     /// This feature applies to iOS and macOS only. On Android, <see cref="Android"/> configures
     /// ANR (Application Not Responding) detection instead.
     /// </remarks>
-    public bool EnableAppHangTracking { get; set; } = false;
+    public bool EnableAppHangTracking { get; set; } = true;
 
     /// <summary>
     /// Duration after which the application is considered to have hanged.

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -128,7 +128,7 @@ private:
 	bool enable_logs = true;
 	Callable before_send_log;
 
-	bool enable_app_hang_tracking = false;
+	bool enable_app_hang_tracking = true;
 	int app_hang_timeout_ms = 5000;
 
 	Ref<SentryExperimental> experimental;


### PR DESCRIPTION
This PR flips "App Hang Tracking" option to be enabled by default starting with version 2.0.0. Currently, this option only affects Apple platforms, but we plan to expand this feature to PCs too.

- Refs https://github.com/getsentry/team-gdx/issues/166
- Docs https://github.com/getsentry/sentry-docs/pull/18297