### PR TITLE
test(integration): Remove global DebugPreference setting

### DIFF
--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -12,7 +12,6 @@
 
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
-$global:DebugPreference = "Continue"
 
 . $PSScriptRoot/../../modules/app-runner/import-modules.ps1
 . $PSScriptRoot/CommonTestCases.ps1

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -11,7 +11,6 @@
 
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
-$global:DebugPreference = "Continue"
 
 # Import app-runner modules
 . $PSScriptRoot/../../modules/app-runner/import-modules.ps1


### PR DESCRIPTION
Tests are super flaky with Sauce Labs. I noticed that debug output now tries to dump the whole executable content with web request. I think it's a recent change in PowerShell. That executable is like 200Mb of console dump... 😵
Let's disable debug output for the time being.