### PR TITLE
fix(processing): Prevent secondary crash from cascading errors in event processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Prevent a crash that could occur when an error is raised while another event is being processed ([#789](https://github.com/getsentry/sentry-godot/pull/789))
+
 ### Dependencies
 
 - Bump Sentry JavaScript from v10.61.0 to v10.62.0 ([#786](https://github.com/getsentry/sentry-godot/pull/786))

--- a/src/sentry/logging/sentry_godot_logger.cpp
+++ b/src/sentry/logging/sentry_godot_logger.cpp
@@ -6,6 +6,7 @@
 #include "sentry/sentry_options.h"
 #include "sentry/sentry_sdk.h"
 #include "sentry/util/hash.h"
+#include "sentry/util/recursion_guard.h"
 #include "sentry/util/text.h"
 
 #include <godot_cpp/classes/engine.hpp>
@@ -25,24 +26,6 @@ const char *error_type_as_string[] = {
 	"WARNING",
 	"SCRIPT ERROR",
 	"SHADER ERROR",
-};
-
-// RAII-style recursion guard that prevents entering function recursively more
-// than `max_entries` times.
-class RecursionGuard {
-private:
-	uint32_t *counter_ptr = nullptr;
-	uint32_t max_entries = 0;
-
-public:
-	_FORCE_INLINE_ bool can_enter() const { return *counter_ptr <= max_entries; }
-
-	RecursionGuard(uint32_t *p_counter_ptr, uint32_t p_max_entries) :
-			counter_ptr(p_counter_ptr), max_entries(p_max_entries) {
-		(*counter_ptr)++;
-	}
-
-	~RecursionGuard() { (*counter_ptr)--; }
 };
 
 bool _get_script_context(const String &p_file, int p_line, String &r_context_line, PackedStringArray &r_pre_context, PackedStringArray &r_post_context) {
@@ -311,10 +294,10 @@ void SentryGodotLogger::_log_error(const String &p_function, const String &p_fil
 		}
 	}
 
-	static thread_local uint32_t num_entries = 0;
-	constexpr uint32_t MAX_ENTRIES = 5;
-	RecursionGuard feedback_loop_guard{ &num_entries, MAX_ENTRIES };
-	if (!feedback_loop_guard.can_enter()) {
+	static thread_local uint32_t log_depth = 0;
+	constexpr uint32_t MAX_DEPTH = 5;
+	sentry::util::RecursionGuard feedback_loop_guard{ &log_depth, MAX_DEPTH };
+	if (!feedback_loop_guard.should_proceed()) {
 		ERR_PRINT_ONCE("SentryGodotLogger::_log_error() feedback loop detected.");
 		return;
 	}
@@ -472,10 +455,10 @@ void SentryGodotLogger::_log_message(const String &p_message, bool p_error) {
 		return;
 	}
 
-	static thread_local uint32_t num_entries = 0;
-	constexpr uint32_t MAX_ENTRIES = 5;
-	RecursionGuard feedback_loop_guard{ &num_entries, MAX_ENTRIES };
-	if (!feedback_loop_guard.can_enter()) {
+	static thread_local uint32_t log_depth = 0;
+	constexpr uint32_t MAX_DEPTH = 5;
+	sentry::util::RecursionGuard feedback_loop_guard{ &log_depth, MAX_DEPTH };
+	if (!feedback_loop_guard.should_proceed()) {
 		ERR_PRINT_ONCE("SentryGodotLogger::_log_message() feedback loop detected.");
 		return;
 	}

--- a/src/sentry/processing/process_event.cpp
+++ b/src/sentry/processing/process_event.cpp
@@ -4,6 +4,7 @@
 #include "sentry/logging/print.h"
 #include "sentry/processing/sentry_event_processor.h"
 #include "sentry/sentry_sdk.h"
+#include "sentry/util/recursion_guard.h"
 
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/display_server.hpp>
@@ -15,6 +16,14 @@
 namespace sentry {
 
 Ref<SentryEvent> process_event(const Ref<SentryEvent> &p_event) {
+	static thread_local uint32_t processing_depth = 0;
+	sentry::util::RecursionGuard guard{ &processing_depth };
+	if (!guard.should_proceed()) {
+		// Avoid logger in case it's a triggering path for the cascaded error.
+		sentry::logging::print_no_logger(sentry::LEVEL_WARNING, "Skipping event processing for secondary event triggered while processing another event. Event will still be sent.");
+		return p_event;
+	}
+
 	if (p_event.is_null()) {
 		sentry::logging::print_error("Attempted to process a null event");
 		return nullptr;

--- a/src/sentry/util/recursion_guard.h
+++ b/src/sentry/util/recursion_guard.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "godot_cpp/core/defs.hpp"
+
+namespace sentry::util {
+
+// RAII guard for tracking and limiting recursive re-entry.
+// Uses caller-provided depth storage, which must be initialized to 0.
+// The depth counter must be externally synchronized (e.g. thread_local).
+class RecursionGuard {
+private:
+	uint32_t *_depth_ptr;
+	uint32_t _max_depth = 1;
+
+public:
+	_FORCE_INLINE_ bool should_proceed() const { return (*_depth_ptr) <= _max_depth; }
+
+	RecursionGuard(uint32_t *p_depth_storage, uint32_t p_max_depth = 1) :
+			_depth_ptr(p_depth_storage), _max_depth(p_max_depth) {
+		++(*_depth_ptr);
+	}
+	~RecursionGuard() { --(*_depth_ptr); }
+
+	RecursionGuard(const RecursionGuard &) = delete;
+	RecursionGuard &operator=(const RecursionGuard &) = delete;
+	RecursionGuard(RecursionGuard &&) = delete;
+	RecursionGuard &operator=(RecursionGuard &&) = delete;
+};
+
+} //namespace sentry::util


### PR DESCRIPTION
Adds reentrancy guard in the event processing to avoid triggering cascading errors from the processing pipeline. 

- Closes #472

Before an event is sent, it passes through a processing pipeline that enriches it with context, runs registered event processors, and invokes the user's `before_send` callback. If that processing itself produces a new error that gets captured, the new event re-enters the pipeline while the first event is still being processed, which can cascade into further errors or a secondary crash during error handling. The guard detects this re-entry and skips processing for the nested event. As a trade-off,  the second error is sent without processing.