### PR TITLE
ci(packaging): Bundle license into addon and demo packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Other changes
+
+- Include the license file in the released addon and demo-project packages ([#790](https://github.com/getsentry/sentry-godot/pull/790))
+
 ### Dependencies
 
 - Bump Sentry JavaScript from v10.61.0 to v10.62.0 ([#786](https://github.com/getsentry/sentry-godot/pull/786))

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -69,6 +69,20 @@ make_zip() {
     fi
 }
 
+# Usage: stage_file <zipfile> <src-file> <dest-path>
+#   zipfile    archive to append to
+#   src-file   file to add (may live outside $SOURCE)
+#   dest-path  path it is stored under inside the archive
+# Staged via a temp tree so zip records <dest-path> verbatim.
+stage_file() {
+    local zipfile="$1" src="$2" dest="$3"
+    local stage; stage="$(mktemp -d)"
+    mkdir -p "$stage/$(dirname "$dest")"
+    cp "$src" "$stage/$dest"
+    ( cd "$stage" && zip -q "$zipfile" "$dest" )
+    rm -rf "$stage"
+}
+
 # --- Parse arguments ---
 
 SOURCE="project"
@@ -91,13 +105,16 @@ done
 mkdir -p "$OUTPUT"
 OUT_ABS="$(cd "$OUTPUT" && pwd)"
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # --- Resolve version ---
 
 # Default version tag is "<SConstruct VERSION>+<git short sha>".
 if [[ -z "$VERSION" ]]; then
+    sconstruct="$REPO_ROOT/SConstruct"
     ver=""
-    [[ -f SConstruct ]] && ver="$(grep '^VERSION =' SConstruct | cut -d '"' -f 2)"
-    sha="$(git rev-parse --short HEAD 2>/dev/null || true)"
+    [[ -f "$sconstruct" ]] && ver="$(grep '^VERSION =' "$sconstruct" | cut -d '"' -f 2)"
+    sha="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
     if [[ -z "$ver" || -z "$sha" ]]; then
         abort "could not derive version tag; pass --version <version>+<sha>"
     fi
@@ -108,6 +125,12 @@ fi
 
 if [[ ! -d "$SOURCE/addons" ]]; then
     abort "addons not found in source tree: $SOURCE/addons"
+fi
+
+# Bundled into the addon and demo zips.
+LICENSE_ABS="$REPO_ROOT/LICENSE.md"
+if [[ ! -f "$LICENSE_ABS" ]]; then
+    abort "LICENSE not found: $LICENSE_ABS"
 fi
 
 # Fix crashpad_handler permissions;
@@ -126,6 +149,7 @@ echo "Wrote $zipfile"
 
 zipfile="$OUT_ABS/${NAME}-${VERSION}.zip"
 make_zip "$zipfile" addons/sentry -x "${SYMBOL_PATTERNS[@]}"
+stage_file "$zipfile" "$LICENSE_ABS" "addons/sentry/LICENSE.md"
 echo "Wrote $zipfile"
 
 # --- Demo project package ---
@@ -143,4 +167,10 @@ trap 'rm -rf "$tmp"' EXIT
 awk '/^\[editor_plugins\]/ { skip=1; next } /^\[gdunit4\]/ { skip=1; next } /^\[/ { skip=0 } !skip' \
     "$SOURCE/project.godot" | sed '/^options\/dsn=/d' > "$tmp/project.godot"
 ( cd "$tmp" && zip -q "$zipfile" project.godot )
+
+# Include LICENSE.md at the project root for the demo and in addons/sentry/
+# so the addon remains licensed if copied out of the demo project.
+stage_file "$zipfile" "$LICENSE_ABS" "LICENSE.md"
+stage_file "$zipfile" "$LICENSE_ABS" "addons/sentry/LICENSE.md"
+
 echo "Wrote $zipfile"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -79,10 +79,19 @@ make_zip() {
 stage_file() {
     local zipfile="$1" src="$2" dest="$3"
     local stage; stage="$(mktemp -d)"
-    mkdir -p "$stage/$(dirname "$dest")"
-    cp "$src" "$stage/$dest"
-    ( cd "$stage" && zip -q "$zipfile" "$dest" )
+
+    local rc=0
+    {
+        mkdir -p "$stage/$(dirname "$dest")" &&
+            cp "$src" "$stage/$dest" &&
+            ( cd "$stage" && zip -q "$zipfile" "$dest" )
+    } || rc=$?
+
     rm -rf "$stage"
+
+    if [[ $rc -ne 0 ]]; then
+        abort "failed to stage $dest into $zipfile (code $rc)" "$rc"
+    fi
 }
 
 # --- Parse arguments ---

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -58,6 +58,8 @@ abort() {
 }
 
 # Usage: make_zip <zipfile> <items...>
+#   zipfile  archive to create (replacing any existing file)
+#   items    paths and zip flags (e.g. -i/-x globs) passed through to zip
 # Runs from $SOURCE so paths are stored tree-relative. Aborts on zip error.
 make_zip() {
     local zipfile="$1"; shift


### PR DESCRIPTION
The packaging script now bundles the project's `LICENSE.md` into the released archives so every distribution carries its license terms: the addon package gets it under `addons/sentry/`, and the demo-project package gets it both at the archive root and under `addons/sentry/` so the addon stays licensed when it is installed or copied out on its own from the demo project. 
