### PR TITLE
ref(cocoa): Replace workaround with internal API for debug images lookup

### DIFF
--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -1,6 +1,6 @@
 #include "cocoa_debug_images.h"
 
-#include "cocoa_includes.h"
+#include "sentry/cocoa/cocoa_includes.h"
 #include "sentry/cocoa/cocoa_util.h"
 
 namespace sentry::cocoa {

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -1,30 +1,7 @@
 #include "cocoa_debug_images.h"
 
 #include "cocoa_includes.h"
-
-// WORKAROUND: The SentryObjC SDK has no public or internal API to look up binary images by address,
-// which we need to symbolicate .NET exceptions.
-// The types that do this are still inside the framework binary, just not declared in any header.
-// We redeclare the few bits we call here so the code compiles and links against them.
-// Remove once the SDK exposes an official API.
-// Upstream issue: https://github.com/getsentry/sentry-cocoa/issues/8039
-
-@interface SentryBinaryImageInfo : NSObject
-@property(nonatomic, readonly) NSString *name;
-@property(nonatomic, readonly) NSString *uuid;
-@property(nonatomic, readonly) uint64_t address;
-@property(nonatomic, readonly) uint64_t size;
-@end
-
-@interface SentryBinaryImageCache : NSObject
-- (SentryBinaryImageInfo *)imageByAddress:(uint64_t)address;
-@end
-
-@interface SentryDependencies : NSObject
-@property(class, nonatomic, readonly) SentryBinaryImageCache *binaryImageCache;
-@end
-
-// END OF WORKAROUND
+#include "sentry/cocoa/cocoa_util.h"
 
 namespace sentry::cocoa {
 
@@ -34,22 +11,18 @@ Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addres
 		return images;
 	}
 
-	SentryBinaryImageCache *cache = SentryDependencies.binaryImageCache;
-	if (cache == nil) {
-		return images;
+	NSMutableArray<NSNumber *> *addresses = [NSMutableArray arrayWithCapacity:p_addresses_count];
+	for (int32_t i = 0; i < p_addresses_count; ++i) {
+		[addresses addObject:@(p_addresses[i])];
 	}
 
-	for (int32_t i = 0; i < p_addresses_count; ++i) {
-		SentryBinaryImageInfo *info = [cache imageByAddress:(uint64_t)p_addresses[i]];
-		if (info == nil) {
-			continue;
-		}
-
+	NSArray<SentryObjCDebugMeta *> *objc_images = [SentryObjCSDK.internal.debug imagesForAddresses:addresses];
+	for (SentryObjCDebugMeta *info in objc_images) {
 		DebugImage image;
-		image.code_file = String::utf8([info.name UTF8String]); // info.name is nonnull
-		image.debug_id = info.uuid ? String::utf8([info.uuid UTF8String]) : String();
-		image.image_address = static_cast<int64_t>(info.address);
-		image.image_size = static_cast<int64_t>(info.size);
+		image.code_file = string_from_objc(info.codeFile);
+		image.debug_id = string_from_objc(info.debugID);
+		image.image_address = static_cast<int64_t>(info.imageAddressRaw);
+		image.image_size = info.imageSize.longLongValue;
 		images.push_back(image);
 	}
 	return images;

--- a/src/sentry/cocoa/cocoa_debug_images.mm
+++ b/src/sentry/cocoa/cocoa_debug_images.mm
@@ -13,7 +13,7 @@ Vector<DebugImage> get_debug_images(const int64_t *p_addresses, int32_t p_addres
 
 	NSMutableArray<NSNumber *> *addresses = [NSMutableArray arrayWithCapacity:p_addresses_count];
 	for (int32_t i = 0; i < p_addresses_count; ++i) {
-		[addresses addObject:@(p_addresses[i])];
+		[addresses addObject:uint64_to_objc(p_addresses[i])];
 	}
 
 	NSArray<SentryObjCDebugMeta *> *objc_images = [SentryObjCSDK.internal.debug imagesForAddresses:addresses];


### PR DESCRIPTION
Replace current workaround for debug image lookup in Cocoa backend with internal API.

- Refs #788