### PR TITLE
chore: Demo project settings schema bump

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -58,7 +58,7 @@ textures/vram_compression/import_etc2_astc=true
 
 options/auto_init=false
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
-schema_version=3
+schema_version=4
 options/attach_scene_tree=true
 godot_logger/include_variables=true
 godot_logger/logs=143


### PR DESCRIPTION
The project settings schema version was bumped previously. It's tracked by our settings migration code automatically, I just forgot to commit the change for the demo project.

#skip-changelog