### PR TITLE
feat: Expand event object API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `set_context()`, `set_user()`, and `set_fingerprint()` to the `SentryEvent` API ([#808](https://github.com/getsentry/sentry-godot/pull/808))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v9.19.0 to v9.21.0 ([#795](https://github.com/getsentry/sentry-godot/pull/795), [#801](https://github.com/getsentry/sentry-godot/pull/801), [#806](https://github.com/getsentry/sentry-godot/pull/806))

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -548,6 +548,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun eventSetContext(eventHandle: Int, key: String, value: Dictionary) {
+        val event = getEvent(eventHandle) ?: return
+        event.contexts[key] = value
+    }
+
+    @UsedByGodot
     fun eventMergeContext(eventHandle: Int, key: String, value: Dictionary) {
         val event = getEvent(eventHandle) ?: return
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -548,6 +548,30 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun eventSetUser(eventHandle: Int, id: String, userName: String, email: String, ipAddress: String) {
+        val event = getEvent(eventHandle) ?: return
+        val user = User()
+        if (id.isNotEmpty()) {
+            user.id = id
+        }
+        if (userName.isNotEmpty()) {
+            user.username = userName
+        }
+        if (email.isNotEmpty()) {
+            user.email = email
+        }
+        if (ipAddress.isNotEmpty()) {
+            user.ipAddress = ipAddress
+        }
+        event.user = user
+    }
+
+    @UsedByGodot
+    fun eventRemoveUser(eventHandle: Int) {
+        getEvent(eventHandle)?.user = null
+    }
+
+    @UsedByGodot
     fun eventSetContext(eventHandle: Int, key: String, value: Dictionary) {
         val event = getEvent(eventHandle) ?: return
         event.contexts[key] = value

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -572,6 +572,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun eventSetFingerprint(eventHandle: Int, fingerprint: Array<String>) {
+        val event = getEvent(eventHandle) ?: return
+        event.fingerprints = if (fingerprint.isEmpty()) null else fingerprint.toList()
+    }
+
+    @UsedByGodot
     fun eventSetContext(eventHandle: Int, key: String, value: Dictionary) {
         val event = getEvent(eventHandle) ?: return
         event.contexts[key] = value

--- a/doc_classes/SentryEvent.xml
+++ b/doc_classes/SentryEvent.xml
@@ -80,7 +80,7 @@
 			<return type="void" />
 			<param index="0" name="user" type="SentryUser" />
 			<description>
-				Assigns user data. See [SentryUser].
+				Assigns user data. See [SentryUser]. Pass [code]null[/code] to remove user data from the event.
 			</description>
 		</method>
 		<method name="to_json" qualifiers="const">

--- a/doc_classes/SentryEvent.xml
+++ b/doc_classes/SentryEvent.xml
@@ -43,6 +43,15 @@
 				Removes the tag with the specified [param key].
 			</description>
 		</method>
+		<method name="set_context">
+			<return type="void" />
+			<param index="0" name="key" type="String" />
+			<param index="1" name="value" type="Dictionary" />
+			<description>
+				Sets a context with the specified [param key] and [param value]. The [param value] should be a dictionary with string keys and can have multiple levels of nesting.
+				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/context/]Context documentation[/url].
+			</description>
+		</method>
 		<method name="set_exception_value">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
@@ -51,12 +60,27 @@
 				Sets the value of the exception at the specified [param index].
 			</description>
 		</method>
+		<method name="set_fingerprint">
+			<return type="void" />
+			<param index="0" name="fingerprint" type="PackedStringArray" />
+			<description>
+				Overrides the grouping fingerprint for this event. Sentry uses the fingerprint to group similar events into a single issue. Pass an empty array to clear the fingerprint and restore the default grouping.
+				To learn more, visit [url=https://docs.sentry.io/concepts/data-management/event-grouping/]Issue Grouping documentation[/url].
+			</description>
+		</method>
 		<method name="set_tag">
 			<return type="void" />
 			<param index="0" name="key" type="String" />
 			<param index="1" name="value" type="String" />
 			<description>
 				Sets a tag with the specified [param key] to the given [param value].
+			</description>
+		</method>
+		<method name="set_user">
+			<return type="void" />
+			<param index="0" name="user" type="SentryUser" />
+			<description>
+				Assigns user data. See [SentryUser].
 			</description>
 		</method>
 		<method name="to_json" qualifiers="const">

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -157,7 +157,7 @@
 			<param index="0" name="key" type="String" />
 			<param index="1" name="value" type="Dictionary" />
 			<description>
-				Adds a custom context with the specified [param key] and [param value]. The [param value] should be a dictionary with string keys and can have multiple levels of nesting.
+				Sets a context with the specified [param key] and [param value]. The [param value] should be a dictionary with string keys and can have multiple levels of nesting.
 				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/context/]Context documentation[/url].
 			</description>
 		</method>

--- a/project/test/suites/test_event_json.gd
+++ b/project/test/suites/test_event_json.gd
@@ -167,6 +167,107 @@ func test_event_json_with_global_tags() -> void:
 		.verify()
 
 
+## SentryEvent.set_context() should attach the context to the event object.
+func test_event_json_with_event_context() -> void:
+	var event := SentrySDK.create_event()
+	event.set_context("character", {
+		"name": "Mighty Fighter",
+		"age": 19,
+		"resistances": {
+			"fire": true,
+			"cold": false,
+		},
+	})
+
+	# Inspect the event object directly; on capture, scope processing merges extra contexts into it.
+	var json := event.to_json()
+
+	assert_json(json).describe("Event contains the context set via set_context()") \
+		.at("/contexts/character") \
+		.is_object() \
+		.must_contain("name", "Mighty Fighter") \
+		.must_contain("age", 19) \
+		.verify()
+
+	assert_json(json).describe("Nested context values are preserved") \
+		.at("/contexts/character/resistances") \
+		.is_object() \
+		.must_contain("fire", true) \
+		.must_contain("cold", false) \
+		.verify()
+
+
+## SentryEvent.set_fingerprint() should set the grouping fingerprint on the event.
+func test_event_json_with_event_fingerprint() -> void:
+	var event := SentrySDK.create_event()
+	event.set_fingerprint(PackedStringArray(["my-grouping", "custom-key"]))
+
+	var json := event.to_json()
+
+	assert_json(json).describe("Fingerprint is stored as an ordered array") \
+		.at("/fingerprint") \
+		.is_array() \
+		.has_size(2) \
+		.must_contain("/0", "my-grouping") \
+		.must_contain("/1", "custom-key") \
+		.verify()
+
+
+## SentryEvent.set_fingerprint() with an empty array should clear the fingerprint.
+func test_event_fingerprint_cleared_with_empty_array() -> void:
+	var event := SentrySDK.create_event()
+	event.set_fingerprint(PackedStringArray(["temporary"]))
+	event.set_fingerprint(PackedStringArray())
+
+	var json := event.to_json()
+
+	assert_json(json).describe("Fingerprint is removed when cleared") \
+		.at("/") \
+		.must_not_contain("fingerprint") \
+		.verify()
+
+
+## SentryEvent.set_user() should attach user data to the event object.
+func test_event_json_with_event_user() -> void:
+	var user := SentryUser.new()
+	user.id = "player_12345"
+	user.username = "TestPlayer"
+	user.email = "testplayer@game.com"
+	user.ip_address = "{{auto}}"
+
+	var event := SentrySDK.create_event()
+	event.set_user(user)
+
+	# Inspect the event object directly; on capture, the active scope's user would override this one.
+	var json := event.to_json()
+
+	assert_json(json).describe("Event contains the user data set via set_user()") \
+		.at("/user") \
+		.is_object() \
+		.must_contain("id", "player_12345") \
+		.must_contain("username", "TestPlayer") \
+		.must_contain("email", "testplayer@game.com") \
+		.must_contain("ip_address", "{{auto}}") \
+		.verify()
+
+
+## SentryEvent.set_user() with null should remove user data from the event.
+func test_event_user_removed_with_null() -> void:
+	var user := SentryUser.new()
+	user.id = "player_12345"
+
+	var event := SentrySDK.create_event()
+	event.set_user(user)
+	event.set_user(null)
+
+	var json := event.to_json()
+
+	assert_json(json).describe("User data is removed when set to null") \
+		.at("/") \
+		.must_not_contain("user") \
+		.verify()
+
+
 func test_event_json_attributes_with_utf8_encoding() -> void:
 	var event := SentrySDK.create_event()
 	event.message = "Hello 世界! 👋"

--- a/project/test/suites/test_event_json.gd
+++ b/project/test/suites/test_event_json.gd
@@ -179,7 +179,6 @@ func test_event_json_with_event_context() -> void:
 		},
 	})
 
-	# Inspect the event object directly; on capture, scope processing merges extra contexts into it.
 	var json := event.to_json()
 
 	assert_json(json).describe("Event contains the context set via set_context()") \
@@ -238,7 +237,6 @@ func test_event_json_with_event_user() -> void:
 	var event := SentrySDK.create_event()
 	event.set_user(user)
 
-	# Inspect the event object directly; on capture, the active scope's user would override this one.
 	var json := event.to_json()
 
 	assert_json(json).describe("Event contains the user data set via set_user()") \

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -106,6 +106,13 @@ String AndroidEvent::get_tag(const String &p_key) {
 	return android_plugin->call(ANDROID_SN(eventGetTag), event_handle, p_key);
 }
 
+void AndroidEvent::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(eventSetContext),
+			event_handle, p_key, sanitize_variant(p_value));
+}
+
 void AndroidEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't merge context with an empty key.");
 	android_plugin->call(ANDROID_SN(eventMergeContext),

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -106,6 +106,20 @@ String AndroidEvent::get_tag(const String &p_key) {
 	return android_plugin->call(ANDROID_SN(eventGetTag), event_handle, p_key);
 }
 
+void AndroidEvent::set_user(const Ref<SentryUser> &p_user) {
+	ERR_FAIL_NULL(android_plugin);
+	if (p_user.is_valid()) {
+		android_plugin->call(ANDROID_SN(eventSetUser),
+				event_handle,
+				p_user->get_id(),
+				p_user->get_username(),
+				p_user->get_email(),
+				p_user->get_ip_address());
+	} else {
+		android_plugin->call(ANDROID_SN(eventRemoveUser), event_handle);
+	}
+}
+
 void AndroidEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_NULL(android_plugin);

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -120,6 +120,11 @@ void AndroidEvent::set_user(const Ref<SentryUser> &p_user) {
 	}
 }
 
+void AndroidEvent::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(eventSetFingerprint), event_handle, p_fingerprint);
+}
+
 void AndroidEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_NULL(android_plugin);

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -50,6 +50,8 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -52,6 +52,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -50,6 +50,7 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
 	virtual void add_exception(const Exception &p_exception) override;

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -58,6 +58,7 @@ AndroidStringNames::AndroidStringNames() {
 	eventSetTag = StringName("eventSetTag");
 	eventRemoveTag = StringName("eventRemoveTag");
 	eventGetTag = StringName("eventGetTag");
+	eventSetContext = StringName("eventSetContext");
 	eventMergeContext = StringName("eventMergeContext");
 	eventIsCrash = StringName("eventIsCrash");
 	eventToJson = StringName("eventToJson");

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -58,6 +58,8 @@ AndroidStringNames::AndroidStringNames() {
 	eventSetTag = StringName("eventSetTag");
 	eventRemoveTag = StringName("eventRemoveTag");
 	eventGetTag = StringName("eventGetTag");
+	eventSetUser = StringName("eventSetUser");
+	eventRemoveUser = StringName("eventRemoveUser");
 	eventSetContext = StringName("eventSetContext");
 	eventMergeContext = StringName("eventMergeContext");
 	eventIsCrash = StringName("eventIsCrash");

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -60,6 +60,7 @@ AndroidStringNames::AndroidStringNames() {
 	eventGetTag = StringName("eventGetTag");
 	eventSetUser = StringName("eventSetUser");
 	eventRemoveUser = StringName("eventRemoveUser");
+	eventSetFingerprint = StringName("eventSetFingerprint");
 	eventSetContext = StringName("eventSetContext");
 	eventMergeContext = StringName("eventMergeContext");
 	eventIsCrash = StringName("eventIsCrash");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -69,6 +69,7 @@ public:
 	StringName eventSetTag;
 	StringName eventRemoveTag;
 	StringName eventGetTag;
+	StringName eventSetContext;
 	StringName eventMergeContext;
 	StringName eventIsCrash;
 	StringName eventToJson;

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -69,6 +69,8 @@ public:
 	StringName eventSetTag;
 	StringName eventRemoveTag;
 	StringName eventGetTag;
+	StringName eventSetUser;
+	StringName eventRemoveUser;
 	StringName eventSetContext;
 	StringName eventMergeContext;
 	StringName eventIsCrash;

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -71,6 +71,7 @@ public:
 	StringName eventGetTag;
 	StringName eventSetUser;
 	StringName eventRemoveUser;
+	StringName eventSetFingerprint;
 	StringName eventSetContext;
 	StringName eventMergeContext;
 	StringName eventIsCrash;

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -46,6 +46,8 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -46,6 +46,7 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
 	virtual void add_exception(const Exception &p_exception) override;

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -48,6 +48,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -159,6 +159,15 @@ String CocoaEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void CocoaEvent::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
+	ERR_FAIL_NULL(cocoa_event);
+
+	NSMutableDictionary *mut_contexts = [cocoa_event.context mutableCopy] ?: [NSMutableDictionary dictionary];
+	mut_contexts[string_to_objc(p_key)] = dictionary_to_objc(p_value);
+	cocoa_event.context = mut_contexts;
+}
+
 void CocoaEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't merge context with an empty key.");
 

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -159,6 +159,22 @@ String CocoaEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void CocoaEvent::set_user(const Ref<SentryUser> &p_user) {
+	ERR_FAIL_NULL(cocoa_event);
+
+	if (p_user.is_null()) {
+		cocoa_event.user = nil;
+		return;
+	}
+
+	SentryObjCUser *user = [[SentryObjCUser alloc] init];
+	user.userId = string_to_objc_or_nil_if_empty(p_user->get_id());
+	user.username = string_to_objc_or_nil_if_empty(p_user->get_username());
+	user.email = string_to_objc_or_nil_if_empty(p_user->get_email());
+	user.ipAddress = string_to_objc_or_nil_if_empty(p_user->get_ip_address());
+	cocoa_event.user = user;
+}
+
 void CocoaEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_NULL(cocoa_event);

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -175,6 +175,17 @@ void CocoaEvent::set_user(const Ref<SentryUser> &p_user) {
 	cocoa_event.user = user;
 }
 
+void CocoaEvent::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_FAIL_NULL(cocoa_event);
+
+	if (p_fingerprint.is_empty()) {
+		cocoa_event.fingerprint = nil;
+		return;
+	}
+
+	cocoa_event.fingerprint = string_array_to_objc(p_fingerprint);
+}
+
 void CocoaEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_NULL(cocoa_event);

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -50,6 +50,7 @@ public:
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override {}
 
 	virtual void add_exception(const Exception &p_exception) override {}

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -16,8 +16,6 @@ private:
 	String release;
 	String dist;
 	String environment;
-	Ref<SentryUser> user;
-	PackedStringArray fingerprint;
 
 protected:
 	static void _bind_methods() {}
@@ -52,9 +50,9 @@ public:
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
 
-	virtual void set_user(const Ref<SentryUser> &p_user) override { user = p_user; }
+	virtual void set_user(const Ref<SentryUser> &p_user) override {}
 
-	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override { fingerprint = p_fingerprint; }
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override {}
 
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override {}

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -17,6 +17,7 @@ private:
 	String dist;
 	String environment;
 	Ref<SentryUser> user;
+	PackedStringArray fingerprint;
 
 protected:
 	static void _bind_methods() {}
@@ -52,6 +53,8 @@ public:
 	virtual String get_tag(const String &p_key) override { return ""; }
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override { user = p_user; }
+
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override { fingerprint = p_fingerprint; }
 
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override {}

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -16,6 +16,7 @@ private:
 	String release;
 	String dist;
 	String environment;
+	Ref<SentryUser> user;
 
 protected:
 	static void _bind_methods() {}
@@ -49,6 +50,8 @@ public:
 	virtual void set_tag(const String &p_key, const String &p_value) override {}
 	virtual void remove_tag(const String &p_key) override {}
 	virtual String get_tag(const String &p_key) override { return ""; }
+
+	virtual void set_user(const Ref<SentryUser> &p_user) override { user = p_user; }
 
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override {}

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -54,6 +54,25 @@ function safeParseJSON<T = any>(json: string, fallback: T): T {
   }
 }
 
+function makeUser(id: string, username: string, email: string, ip: string): User {
+  const user: User = {};
+
+  if (id !== "") {
+    user.id = id;
+  }
+  if (username !== "") {
+    user.username = username;
+  }
+  if (email !== "") {
+    user.email = email;
+  }
+  if (ip !== "") {
+    user.ip_address = ip;
+  }
+
+  return user;
+}
+
 // *** SentryBridge
 
 class SentryBridge {
@@ -257,26 +276,15 @@ class SentryBridge {
   }
 
   public setUser(id: string, username: string, email: string, ip: string): void {
-    const user: User = {};
-
-    if (id !== "") {
-      user.id = id;
-    }
-    if (username !== "") {
-      user.username = username;
-    }
-    if (email !== "") {
-      user.email = email;
-    }
-    if (ip !== "") {
-      user.ip_address = ip;
-    }
-
-    Sentry.setUser(user);
+    Sentry.setUser(makeUser(id, username, email, ip));
   }
 
   public removeUser(): void {
     Sentry.setUser(null);
+  }
+
+  public eventSetUser(event: Sentry.Event, id: string, username: string, email: string, ip: string): void {
+    event.user = makeUser(id, username, email, ip);
   }
 
   public logTrace(message: string, attributesJson?: string): void {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -54,6 +54,7 @@ try {
 			"removeTag",
 			"setUser",
 			"removeUser",
+			"eventSetUser",
 			"logTrace",
 			"logDebug",
 			"logInfo",
@@ -135,6 +136,18 @@ try {
 
 		runTest("removeUser()", () => {
 			bridge.removeUser();
+		});
+
+		runTest("eventSetUser()", () => {
+			const event = {};
+			bridge.eventSetUser(event, "user123", "testuser", "test@example.com", "127.0.0.1");
+			assertEqual(event.user.id, "user123", "eventSetUser should set user id on event");
+			assertEqual(event.user.username, "testuser", "eventSetUser should set username on event");
+			assertEqual(event.user.email, "test@example.com", "eventSetUser should set email on event");
+			assertEqual(event.user.ip_address, "127.0.0.1", "eventSetUser should set ip_address on event");
+			const event2 = {};
+			bridge.eventSetUser(event2, "", "", "", "");
+			assertEqual(Object.keys(event2.user).length, 0, "eventSetUser should skip empty fields");
 		});
 
 		runTest("logTrace()", () => {

--- a/src/sentry/javascript/javascript_event.cpp
+++ b/src/sentry/javascript/javascript_event.cpp
@@ -184,6 +184,14 @@ String JavaScriptEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void JavaScriptEvent::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND(!js_obj);
+	JSObjectPtr all_contexts_jso = js_obj->get_or_create_object_property("contexts");
+	if (all_contexts_jso) {
+		all_contexts_jso->set_property_from_json(p_key.utf8(), JSON::stringify(p_value).utf8());
+	}
+}
+
 void JavaScriptEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND(!js_obj);
 	JSObjectPtr all_contexts_jso = js_obj->get_or_create_object_property("contexts");

--- a/src/sentry/javascript/javascript_event.cpp
+++ b/src/sentry/javascript/javascript_event.cpp
@@ -184,6 +184,22 @@ String JavaScriptEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void JavaScriptEvent::set_user(const Ref<SentryUser> &p_user) {
+	ERR_FAIL_COND(!js_obj);
+
+	if (p_user.is_null()) {
+		js_obj->delete_property("user");
+		return;
+	}
+
+	js_bridge()->call("eventSetUser",
+			js_obj,
+			p_user->get_id().utf8(),
+			p_user->get_username().utf8(),
+			p_user->get_email().utf8(),
+			p_user->get_ip_address().utf8());
+}
+
 void JavaScriptEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND(!js_obj);
 	JSObjectPtr all_contexts_jso = js_obj->get_or_create_object_property("contexts");

--- a/src/sentry/javascript/javascript_event.cpp
+++ b/src/sentry/javascript/javascript_event.cpp
@@ -212,6 +212,7 @@ void JavaScriptEvent::set_fingerprint(const PackedStringArray &p_fingerprint) {
 }
 
 void JavaScriptEvent::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_COND(!js_obj);
 	JSObjectPtr all_contexts_jso = js_obj->get_or_create_object_property("contexts");
 	if (all_contexts_jso) {

--- a/src/sentry/javascript/javascript_event.cpp
+++ b/src/sentry/javascript/javascript_event.cpp
@@ -200,6 +200,17 @@ void JavaScriptEvent::set_user(const Ref<SentryUser> &p_user) {
 			p_user->get_ip_address().utf8());
 }
 
+void JavaScriptEvent::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_FAIL_COND(!js_obj);
+
+	if (p_fingerprint.is_empty()) {
+		js_obj->delete_property("fingerprint");
+		return;
+	}
+
+	js_obj->set_property_from_json("fingerprint", JSON::stringify(p_fingerprint).utf8());
+}
+
 void JavaScriptEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND(!js_obj);
 	JSObjectPtr all_contexts_jso = js_obj->get_or_create_object_property("contexts");

--- a/src/sentry/javascript/javascript_event.h
+++ b/src/sentry/javascript/javascript_event.h
@@ -50,6 +50,8 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/javascript/javascript_event.h
+++ b/src/sentry/javascript/javascript_event.h
@@ -52,6 +52,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/javascript/javascript_event.h
+++ b/src/sentry/javascript/javascript_event.h
@@ -50,6 +50,7 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
 	virtual void add_exception(const Exception &p_exception) override;

--- a/src/sentry/javascript/javascript_interop.cpp
+++ b/src/sentry/javascript/javascript_interop.cpp
@@ -281,6 +281,26 @@ int32_t object_merge_properties_from_json(int32_t p_object_id, const char *p_jso
 	}, p_object_id, p_json);
 }
 
+// Parses a value from a JSON string and assigns it to an object property, returning 0 on success or negative number on error.
+int32_t object_set_property_from_json(int32_t p_object_id, const char *p_property, const char *p_json) {
+	return MAIN_THREAD_EM_ASM_INT({
+		try {
+			const bridge = window.SentryBridge;
+			const obj = bridge.getObject($0);
+			if (obj === null || obj === undefined) {
+				return -1;
+			}
+			const prop = UTF8ToString($1);
+			const json = UTF8ToString($2);
+			obj[prop] = JSON.parse(json);
+		} catch (e) {
+			console.error("Sentry JS interop: object_set_property_from_json() failed:", e);
+			return -2;
+		}
+		return 0;
+	}, p_object_id, p_property, p_json);
+}
+
 // Parses object from JSON string and adds it to an array, returning 0 on success or negative number on error.
 int32_t object_push_element_from_json(int32_t p_object_id, const char *p_json) {
 	return MAIN_THREAD_EM_ASM_INT({
@@ -573,6 +593,13 @@ void JSObject::merge_properties_from_json(const char *p_json) {
 	int32_t result = em_js::object_merge_properties_from_json(id, p_json);
 	if (result < 0) {
 		sentry::logging::print_error("JS interop: Failed merging properties from JSON.");
+	}
+}
+
+void JSObject::set_property_from_json(const char *p_property, const char *p_json) {
+	int32_t result = em_js::object_set_property_from_json(id, p_property, p_json);
+	if (result < 0) {
+		sentry::logging::print_error("JS interop: Failed setting \"", p_property, "\" property from JSON.");
 	}
 }
 

--- a/src/sentry/javascript/javascript_interop.h
+++ b/src/sentry/javascript/javascript_interop.h
@@ -279,6 +279,9 @@ public:
 	// Parse a JSON string into an object and merge its properties into this JavaScript object.
 	void merge_properties_from_json(const char *p_json);
 
+	// Parse a JSON string and assign the resulting value to the given property, replacing any existing value.
+	void set_property_from_json(const char *p_property, const char *p_json);
+
 	// Parse the provided JSON string, reconstruct it as a JavaScript value, and push it onto this object,
 	// assuming this object represents a JavaScript array.
 	void push_element_from_json(const char *p_json);

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -175,6 +175,16 @@ String NativeEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void NativeEvent::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
+	sentry_value_t contexts = sentry_value_get_by_key(native_event, "contexts");
+	if (sentry_value_is_null(contexts)) {
+		contexts = sentry_value_new_object();
+		sentry_value_set_by_key(native_event, "contexts", contexts);
+	}
+	sentry_value_set_by_key(contexts, p_key.utf8(), sentry::native::variant_to_sentry_value(p_value));
+}
+
 void NativeEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't merge context with an empty key.");
 	sentry_event_merge_context(native_event, p_key.utf8(), p_value);

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -201,6 +201,14 @@ void NativeEvent::set_user(const Ref<SentryUser> &p_user) {
 	sentry_value_set_by_key(native_event, "user", user_data);
 }
 
+void NativeEvent::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	if (p_fingerprint.is_empty()) {
+		sentry_value_remove_by_key(native_event, "fingerprint");
+	} else {
+		sentry_value_set_by_key(native_event, "fingerprint", sentry::native::strings_to_sentry_list(p_fingerprint));
+	}
+}
+
 void NativeEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	sentry_value_t contexts = sentry_value_get_by_key(native_event, "contexts");

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -175,6 +175,32 @@ String NativeEvent::get_tag(const String &p_key) {
 	return String();
 }
 
+void NativeEvent::set_user(const Ref<SentryUser> &p_user) {
+	if (p_user.is_null()) {
+		sentry_value_remove_by_key(native_event, "user");
+		return;
+	}
+
+	sentry_value_t user_data = sentry_value_new_object();
+	if (!p_user->get_id().is_empty()) {
+		sentry_value_set_by_key(user_data, "id",
+				sentry_value_new_string(p_user->get_id().utf8()));
+	}
+	if (!p_user->get_username().is_empty()) {
+		sentry_value_set_by_key(user_data, "username",
+				sentry_value_new_string(p_user->get_username().utf8()));
+	}
+	if (!p_user->get_email().is_empty()) {
+		sentry_value_set_by_key(user_data, "email",
+				sentry_value_new_string(p_user->get_email().utf8()));
+	}
+	if (!p_user->get_ip_address().is_empty()) {
+		sentry_value_set_by_key(user_data, "ip_address",
+				sentry_value_new_string(p_user->get_ip_address().utf8()));
+	}
+	sentry_value_set_by_key(native_event, "user", user_data);
+}
+
 void NativeEvent::set_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	sentry_value_t contexts = sentry_value_get_by_key(native_event, "contexts");

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -49,6 +49,7 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
 	virtual void add_exception(const Exception &p_exception) override;

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -49,6 +49,8 @@ public:
 	virtual void remove_tag(const String &p_key) override;
 	virtual String get_tag(const String &p_key) override;
 
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -51,6 +51,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -26,6 +26,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tag", "key", "value"), &SentryEvent::set_tag);
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentryEvent::remove_tag);
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
+	ClassDB::bind_method(D_METHOD("set_context"), &SentryEvent::set_context);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);
 

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -27,6 +27,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentryEvent::remove_tag);
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
 	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentryEvent::set_user);
+	ClassDB::bind_method(D_METHOD("set_fingerprint", "fingerprint"), &SentryEvent::set_fingerprint);
 	ClassDB::bind_method(D_METHOD("set_context"), &SentryEvent::set_context);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -26,6 +26,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tag", "key", "value"), &SentryEvent::set_tag);
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentryEvent::remove_tag);
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
+	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentryEvent::set_user);
 	ClassDB::bind_method(D_METHOD("set_context"), &SentryEvent::set_context);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -28,7 +28,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tag", "key"), &SentryEvent::get_tag);
 	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentryEvent::set_user);
 	ClassDB::bind_method(D_METHOD("set_fingerprint", "fingerprint"), &SentryEvent::set_fingerprint);
-	ClassDB::bind_method(D_METHOD("set_context"), &SentryEvent::set_context);
+	ClassDB::bind_method(D_METHOD("set_context", "key", "value"), &SentryEvent::set_context);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);
 

--- a/src/sentry/sentry_event.h
+++ b/src/sentry/sentry_event.h
@@ -2,6 +2,7 @@
 
 #include "sentry/level.h"
 #include "sentry/sentry_timestamp.h"
+#include "sentry/sentry_user.h"
 
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/templates/pair.hpp>
@@ -68,6 +69,8 @@ public:
 	virtual void set_tag(const String &p_key, const String &p_value) = 0;
 	virtual void remove_tag(const String &p_key) = 0;
 	virtual String get_tag(const String &p_key) = 0;
+
+	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
 
 	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) = 0;

--- a/src/sentry/sentry_event.h
+++ b/src/sentry/sentry_event.h
@@ -72,6 +72,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
 
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) = 0;
+
 	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) = 0;
 

--- a/src/sentry/sentry_event.h
+++ b/src/sentry/sentry_event.h
@@ -69,6 +69,7 @@ public:
 	virtual void remove_tag(const String &p_key) = 0;
 	virtual String get_tag(const String &p_key) = 0;
 
+	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) = 0;
 
 	virtual void add_exception(const Exception &p_exception) = 0;


### PR DESCRIPTION
Add `set_context()`, `set_user()`, `set_fingerprint()` to `SentryEvent` API.
This work was done originally in #799, but since I'm sacking that PR, we can keep the good bits.