### PR TITLE
test(web): Fix web test runner should run isolated tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,7 +297,7 @@ Web tests run the same GDScript suite and isolated tests in a headless Chromium 
 
 #### Building the libraries
 
-Web tests need two GDExtension builds: the web library that runs in the browser, and an editor library for your own platform, which provides the export plugin that copies the JavaScript bundle into the export. Repeat these only when the C++ or JavaScript bridge sources change.
+Web tests need two GDExtension builds: the web library that runs in the browser, and an editor library for your own platform, which provides export plugins. Repeat these only when the C++ or JavaScript bridge sources change.
 
 The generated godot-cpp bindings are specific to one architecture and are not regenerated automatically when you switch, so each build is preceded by a clean.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,11 +272,12 @@ The script regenerates the `*.received.txt` file, promotes it over the existing 
 
 Web tests run the same GDScript suite and isolated tests in a headless Chromium browser using Playwright. They require a Godot web export.
 
-#### Prerequisites
+#### First-time setup
 
-1. Build the GDExtension library and JS bundle. The "Web Tests" preset exports in debug mode with thread support, so build the debug, threaded variant:
+1. Install the JavaScript bridge dependencies, if you have not already (see [Web](#web) above):
     ```bash
-    scons platform=web target=editor arch=wasm32 threads=yes generate_js_bundle=yes
+    cd src/sentry/javascript/bridge
+    npm install
     ```
 2. Copy the export preset into the project. Godot reads `project/export_presets.cfg`, but that path is gitignored and the preset is versioned under `exports/`:
     ```bash
@@ -287,21 +288,37 @@ Web tests run the same GDScript suite and isolated tests in a headless Chromium 
     mkdir -p exports/templates
     cp <godot-export-templates>/web_dlink_debug.zip <godot-export-templates>/web_dlink_release.zip exports/templates/
     ```
-4. Export the project using the "Web Tests" preset:
-    ```bash
-    mkdir -p exports/web
-    godot --headless --path project --export-debug "Web Tests" ../exports/web/index.html
-    ```
-5. Install test dependencies (first time only):
+4. Install the test dependencies:
     ```bash
     cd tests/web
     npm install
     npx playwright install chromium
     ```
 
+#### Building the libraries
+
+Web tests need two GDExtension builds: the web library that runs in the browser, and an editor library for your own platform, which provides the export plugin that copies the JavaScript bundle into the export. Repeat these only when the C++ or JavaScript bridge sources change.
+
+The generated godot-cpp bindings are specific to one architecture and are not regenerated automatically when you switch, so each build is preceded by a clean.
+
+1. Build the web library and the JavaScript bundle. The "Web Tests" preset exports in debug mode with thread support, so build the debug, threaded variant:
+    ```bash
+    scons platform=web target=editor arch=wasm32 threads=yes generate_js_bundle=yes --clean
+    scons platform=web target=editor arch=wasm32 threads=yes generate_js_bundle=yes
+    ```
+2. Build the editor library for your own platform:
+    ```bash
+    scons target=editor debug_symbols=yes --clean
+    scons target=editor debug_symbols=yes
+    ```
+
 #### Running Tests
 
+Re-export the project after any change to the libraries or to anything under `project/`, then run the tests:
+
 ```bash
+mkdir -p exports/web
+godot --headless --path project --export-debug "Web Tests" ../exports/web/index.html
 cd tests/web
 npx playwright test
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,15 +274,25 @@ Web tests run the same GDScript suite and isolated tests in a headless Chromium 
 
 #### Prerequisites
 
-1. Build the GDExtension library and JS bundle:
+1. Build the GDExtension library and JS bundle. The "Web Tests" preset exports in debug mode with thread support, so build the debug, threaded variant:
     ```bash
-    scons target=template_release platform=web generate_js_bundle=yes
+    scons platform=web target=editor arch=wasm32 threads=yes generate_js_bundle=yes
     ```
-2. Export the project using the "Web Tests" preset:
+2. Copy the export preset into the project. Godot reads `project/export_presets.cfg`, but that path is gitignored and the preset is versioned under `exports/`:
     ```bash
+    cp exports/export_presets.cfg project/export_presets.cfg
+    ```
+3. Place the `dlink` web export templates for your Godot version in `exports/templates/`, where the preset expects them:
+    ```bash
+    mkdir -p exports/templates
+    cp <godot-export-templates>/web_dlink_debug.zip <godot-export-templates>/web_dlink_release.zip exports/templates/
+    ```
+4. Export the project using the "Web Tests" preset:
+    ```bash
+    mkdir -p exports/web
     godot --headless --path project --export-debug "Web Tests" ../exports/web/index.html
     ```
-3. Install test dependencies (first time only):
+5. Install test dependencies (first time only):
     ```bash
     cd tests/web
     npm install

--- a/tests/web/web.test.ts
+++ b/tests/web/web.test.ts
@@ -3,22 +3,21 @@ import fs from "node:fs";
 import path from "node:path";
 
 const COMPLETION_MARKER = ">>> Test run complete with code: ";
-const PROJECT_DIR = path.resolve(import.meta.dirname, "../project");
+const PROJECT_DIR = path.resolve(import.meta.dirname, "../../project");
 
 // Discover test paths: suite tests first, then each isolated test file.
 // Mirrors the pattern in scripts/run-android-tests.sh.
 function discoverTestPaths(): string[] {
-  const paths = ["res://test/suites/"];
   const isolatedDir = path.join(PROJECT_DIR, "test/isolated");
-  if (fs.existsSync(isolatedDir)) {
-    const files = fs
-      .readdirSync(isolatedDir)
-      .filter((f) => f.startsWith("test_") && f.endsWith(".gd"))
-      .sort()
-      .map((f) => `res://test/isolated/${f}`);
-    paths.push(...files);
+  const isolatedPaths = fs
+    .readdirSync(isolatedDir)
+    .filter((f) => f.startsWith("test_") && f.endsWith(".gd"))
+    .sort()
+    .map((f) => `res://test/isolated/${f}`);
+  if (isolatedPaths.length === 0) {
+    throw new Error(`No isolated test files found in ${isolatedDir}`);
   }
-  return paths;
+  return ["res://test/suites/", ...isolatedPaths];
 }
 
 // Start the Godot engine with the given test path and wait for completion.


### PR DESCRIPTION
The Web test runner only ran the suite tests, so the isolated tests under `project/test/isolated/` have never run on Web. It's a regression since the harness moved into `tests/web` directory. The runner's path to the project directory was wrong, and a guard turned that into an empty list instead of an error, so the problem was silent. This fixes the path and makes a missing directory fail loudly, and Playwright now runs 22 tests instead of 1.

Also, updated `CONTRIBUTING.md` as well, since following the old steps could not produce a working export: they omitted the editor library that is needed for exporting, and the section is now split into first-time setup, library builds, and the per-iteration test loop.
