### PR TITLE
ci(tests): Test Android builds against several Godot versions

### DIFF
--- a/.github/actions/prepare-testing/action.yml
+++ b/.github/actions/prepare-testing/action.yml
@@ -5,6 +5,10 @@ inputs:
   arch:
     description: Architecture to use for testing.
     required: true
+  godot-version:
+    description: Godot version tag to test (e.g. "4.6.3-stable").
+    required: false
+    default: ""
   export-platform:
     description: Which export template will be used, lowercase (e.g., android, ios).
     required: false
@@ -63,7 +67,8 @@ runs:
       env:
         ARCH: ${{ inputs.arch }}
         MONO_FLAG: ${{ inputs.dotnet == 'true' && '--mono' || '' }}
-      run: ./scripts/setup-godot.sh --arch "$ARCH" $MONO_FLAG
+        VERSION_FLAG: ${{ inputs.godot-version != '' && format('--version {0}', inputs.godot-version) || '' }}
+      run: ./scripts/setup-godot.sh --arch "$ARCH" $MONO_FLAG $VERSION_FLAG
 
     - name: Set up .NET
       if: inputs.dotnet == 'true'

--- a/.github/workflows/test_android.yml
+++ b/.github/workflows/test_android.yml
@@ -8,8 +8,15 @@ permissions:
 
 jobs:
   test-android:
-    name: Test Android
+    name: Test Android (Godot ${{ matrix.godot-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        godot-version:
+          - 4.5.1-stable
+          - 4.6.3-stable
+          - 4.7.1-stable
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -21,6 +28,7 @@ jobs:
         timeout-minutes: 15
         with:
           arch: x86_64
+          godot-version: ${{ matrix.godot-version }}
           export-platform: "android"
 
       # Needed for Android emulator

--- a/.github/workflows/test_android.yml
+++ b/.github/workflows/test_android.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   test-android:
-    name: Test Android (Godot ${{ matrix.godot-version }})
+    name: Test Godot ${{ matrix.godot-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Run unit tests with Android builds and Godot 4.6 & 4.7 in addition to previously tested 4.5.