### PR TITLE
fix(android): Missing GDScript frame lineno on Android in Godot 4.6+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fixed missing line numbers in GDScript frames on Android with Godot 4.6 and later ([#826](https://github.com/getsentry/sentry-godot/pull/826))
+
 ### Dependencies
 
 - Bump Sentry JavaScript from v10.65.0 to v10.67.0 ([#816](https://github.com/getsentry/sentry-godot/pull/816), [#819](https://github.com/getsentry/sentry-godot/pull/819))

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -178,7 +178,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val release = optionsData["release"] as String
             val dist = optionsData["dist"] as String
             val environment = optionsData["environment"] as String
-            val sampleRate = optionsData["sample_rate"] as Double
+            val sampleRate = optionsData["sample_rate"].toDoubleOrThrow()
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
             val enableLogs = optionsData["enable_logs"] as Boolean
             val enableMetrics = optionsData["enable_metrics"] as Boolean

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -643,7 +643,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val frame = SentryStackFrame().apply {
                 filename = frameData["filename"] as? String
                 function = frameData["function"] as? String
-                lineno = frameData["lineno"] as? Int
+                lineno = frameData["lineno"].toIntOrNull()
                 isInApp = frameData["in_app"] as? Boolean
                 platform = frameData["platform"] as? String
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
@@ -4,6 +4,8 @@ import io.sentry.SentryLevel
 import io.sentry.SentryLogLevel
 import java.util.Date
 import java.time.Instant
+import kotlin.text.toIntOrNull as parseIntOrNull
+import kotlin.text.toLongOrNull as parseLongOrNull
 
 fun Int.toSentryLevel(): SentryLevel =
     when (this) {
@@ -88,7 +90,7 @@ fun Any?.toIntOrNull(): Int? =
         is Short -> this.toInt()
         is Byte -> this.toInt()
         is Number -> this.toInt()
-        is String -> this.toIntOrNull()
+        is String -> this.parseIntOrNull()
         else -> null
 }
 
@@ -99,6 +101,6 @@ fun Any?.toLongOrNull(): Long? =
         is Short -> this.toLong()
         is Byte -> this.toLong()
         is Number -> this.toLong()
-        is String -> this.toLongOrNull()
+        is String -> this.parseLongOrNull()
         else -> null
 }

--- a/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
@@ -72,6 +72,15 @@ fun Any?.toLongOrThrow(): Long =
         else -> throw IllegalArgumentException("Expected Int or Long, got ${this?.let { it::class } ?: "null"}")
     }
 
+fun Any?.toDoubleOrThrow(): Double =
+    when (this) {
+        is Double -> this
+        is Float -> this.toDouble()
+        is Int -> this.toDouble()
+        is Long -> this.toDouble()
+        else -> throw IllegalArgumentException("Expected a number, got ${this?.let { it::class } ?: "null"}")
+    }
+
 fun Any?.toIntOrNull(): Int? =
     when (this) {
         is Int -> this

--- a/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/UtilityFunctions.kt
@@ -55,6 +55,9 @@ fun Date.toMicros(): Long {
     return date.time * 1000
 }
 
+// NOTE: Godot 4.6+ boxes Variant ints as java.lang.Long, older versions as java.lang.Integer.
+//       Use these conversion helpers to normalize.
+
 fun Any?.toIntOrThrow(): Int =
     when (this) {
         is Int -> this
@@ -68,6 +71,17 @@ fun Any?.toLongOrThrow(): Long =
         is Long -> this
         else -> throw IllegalArgumentException("Expected Int or Long, got ${this?.let { it::class } ?: "null"}")
     }
+
+fun Any?.toIntOrNull(): Int? =
+    when (this) {
+        is Int -> this
+        is Long -> this.toInt()
+        is Short -> this.toInt()
+        is Byte -> this.toInt()
+        is Number -> this.toInt()
+        is String -> this.toIntOrNull()
+        else -> null
+}
 
 fun Any?.toLongOrNull(): Long? =
     when (this) {

--- a/android_lib/src/test/java/io/sentry/godotplugin/UtilityFunctionsTest.kt
+++ b/android_lib/src/test/java/io/sentry/godotplugin/UtilityFunctionsTest.kt
@@ -2,6 +2,8 @@ package io.sentry.godotplugin
 
 import io.sentry.SentryLevel
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import java.util.Date
 import kotlin.math.abs
@@ -125,5 +127,105 @@ class UtilityFunctionsTest {
             val backToInt = sentryLevel.toInt()
             assertEquals("Conversion should be symmetric for value $i", i, backToInt)
         }
+    }
+
+    @Test
+    fun toIntOrThrow_acceptsIntegerAndLongBoxing() {
+        val fromInteger: Any? = 42
+        val fromLong: Any? = 42L
+
+        assertEquals(42, fromInteger.toIntOrThrow())
+        assertEquals(42, fromLong.toIntOrThrow())
+    }
+
+    @Test
+    fun toIntOrThrow_throwsForNonIntegerValues() {
+        assertThrows(IllegalArgumentException::class.java) { (null as Any?).toIntOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { ("42" as Any?).toIntOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { (4.2 as Any?).toIntOrThrow() }
+    }
+
+    @Test
+    fun toLongOrThrow_acceptsIntegerAndLongBoxing() {
+        val fromInteger: Any? = 42
+        val fromLong: Any? = 42L
+
+        assertEquals(42L, fromInteger.toLongOrThrow())
+        assertEquals(42L, fromLong.toLongOrThrow())
+    }
+
+    @Test
+    fun toLongOrThrow_throwsForNonIntegerValues() {
+        assertThrows(IllegalArgumentException::class.java) { (null as Any?).toLongOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { ("42" as Any?).toLongOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { (4.2 as Any?).toLongOrThrow() }
+    }
+
+    @Test
+    fun toDoubleOrThrow_acceptsEveryNumericBoxing() {
+        val fromDouble: Any? = 0.25
+        val fromFloat: Any? = 0.25f
+        val fromInteger: Any? = 3
+        val fromLong: Any? = 3L
+
+        assertEquals(0.25, fromDouble.toDoubleOrThrow(), 0.0)
+        assertEquals(0.25, fromFloat.toDoubleOrThrow(), 0.0)
+        assertEquals(3.0, fromInteger.toDoubleOrThrow(), 0.0)
+        assertEquals(3.0, fromLong.toDoubleOrThrow(), 0.0)
+    }
+
+    @Test
+    fun toDoubleOrThrow_throwsForNonNumericValues() {
+        assertThrows(IllegalArgumentException::class.java) { (null as Any?).toDoubleOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { ("0.25" as Any?).toDoubleOrThrow() }
+        assertThrows(IllegalArgumentException::class.java) { (true as Any?).toDoubleOrThrow() }
+    }
+
+    @Test
+    fun toIntOrNull_acceptsEveryNumericBoxingAndNumericStrings() {
+        val fromInteger: Any? = 42
+        val fromLong: Any? = 42L
+        val fromShort: Any? = 42.toShort()
+        val fromByte: Any? = 42.toByte()
+        val fromDouble: Any? = 42.9
+        val fromString: Any? = "42"
+
+        assertEquals(42, fromInteger.toIntOrNull())
+        assertEquals(42, fromLong.toIntOrNull())
+        assertEquals(42, fromShort.toIntOrNull())
+        assertEquals(42, fromByte.toIntOrNull())
+        assertEquals(42, fromDouble.toIntOrNull())
+        assertEquals(42, fromString.toIntOrNull())
+    }
+
+    @Test
+    fun toIntOrNull_returnsNullForNonNumericValues() {
+        assertNull((null as Any?).toIntOrNull())
+        assertNull(("abc" as Any?).toIntOrNull())
+        assertNull((true as Any?).toIntOrNull())
+    }
+
+    @Test
+    fun toLongOrNull_acceptsEveryNumericBoxingAndNumericStrings() {
+        val fromInteger: Any? = 42
+        val fromLong: Any? = 42L
+        val fromShort: Any? = 42.toShort()
+        val fromByte: Any? = 42.toByte()
+        val fromDouble: Any? = 42.9
+        val fromString: Any? = "42"
+
+        assertEquals(42L, fromInteger.toLongOrNull())
+        assertEquals(42L, fromLong.toLongOrNull())
+        assertEquals(42L, fromShort.toLongOrNull())
+        assertEquals(42L, fromByte.toLongOrNull())
+        assertEquals(42L, fromDouble.toLongOrNull())
+        assertEquals(42L, fromString.toLongOrNull())
+    }
+
+    @Test
+    fun toLongOrNull_returnsNullForNonNumericValues() {
+        assertNull((null as Any?).toLongOrNull())
+        assertNull(("abc" as Any?).toLongOrNull())
+        assertNull((true as Any?).toLongOrNull())
     }
 }


### PR DESCRIPTION
Fixes missing line numbers in GDScript frames on Android with Godot 4.6 and later. Flagged by new testing added in #825.

<details>
<summary>Test failure</summary>
<img width="1282" height="323" alt="2026-07-24_14-09-03" src="https://github.com/user-attachments/assets/8168237c-c731-484d-ad93-39dea496cdad" />
</details>

Root cause: Godot 4.6 changed how `Variant::INT` is boxed when it crosses into Java. See commit [`b0cb297cde`](https://github.com/godotengine/godot/commit/b0cb297cde). We cannot rely on direct casts anymore.

This PR also hardens another place for potential failure, fixes a bug in the bridge-layer conversion methods and adds corresponding unit tests.