### PR TITLE
chore: Pin Godot Android lib to 4.5.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,6 +8,7 @@ from enum import Enum
 # *** Settings.
 
 VERSION = "2.1.0"
+# NOTE: When bumping this, update the godot-lib pin in android_lib/build.gradle.kts to match.
 COMPATIBILITY_MINIMUM = "4.5"
 IOS_MIN_VERSION = "15.0"
 MACOS_DEPLOYMENT_TARGET = "10.14"

--- a/android_lib/build.gradle.kts
+++ b/android_lib/build.gradle.kts
@@ -34,7 +34,9 @@ android {
 }
 
 dependencies {
-    implementation("org.godotengine:godot:4.4.0.stable")
+    // Godot is provided by the Android export template at runtime.
+    // Keep this pinned to the minimum supported engine version so newer Godot APIs don't slip in.
+    compileOnly("org.godotengine:godot:4.5.0.stable")
     testImplementation("junit:junit:4.13.2")
 
     // NOTE: All dependencies below must be also updated in sentry_editor_export_plugin.cpp.

--- a/android_lib/build.gradle.kts
+++ b/android_lib/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     // Godot is provided by the Android export template at runtime.
-    // Keep this pinned to the minimum supported engine version so newer Godot APIs don't slip in.
+    // NOTE: Must match COMPATIBILITY_MINIMUM in SConstruct, so that newer Godot APIs don't slip in.
     compileOnly("org.godotengine:godot:4.5.0.stable")
     testImplementation("junit:junit:4.13.2")
 


### PR DESCRIPTION
Pins godot-lib to 4.5.0 instead of 4.4.0, matching the minimum engine version the addon supports, and marks the pin `compileOnly` because the Godot export template supplies that library at runtime. The built AARs are byte-identical, so nothing changes for users.
