### PR TITLE
feat(scopes): Add scopes and SentrySDK.with_scope() on Windows & Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Features
 
-- Add current scopes to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
+- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ## 2.1.1
 
+### Features
+
+- Add local scopes to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
+  - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
+  - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
+
 ### Fixes
 
 - Fixed missing line numbers in GDScript frames on Android with Godot 4.6 and later ([#826](https://github.com/getsentry/sentry-godot/pull/826))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Features
+
+- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
+  - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
+  - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
+
 ### Dependencies
 
 - Bump Sentry Android from v8.51.0 to v8.52.0 ([#855](https://github.com/getsentry/sentry-godot/pull/855))
@@ -9,12 +15,6 @@
   - [diff](https://github.com/getsentry/sentry-java/compare/8.51.0...8.52.0)
 
 ## 2.1.1
-
-### Features
-
-- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
-  - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
-  - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Features
 
-- Add local scopes to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
+- Add current scopes to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -393,12 +393,6 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureMessage(message: String, level: Int): String {
-        val id = Sentry.captureMessage(message, level.toSentryLevel())
-        return id.toString()
-    }
-
-    @UsedByGodot
     fun getLastEventId(): String {
         return Sentry.getLastEventId().toString()
     }

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -72,6 +72,13 @@
 				Creates a new [SentryEvent] object. You can capture the event with [method SentrySDK.capture_event].
 			</description>
 		</method>
+		<method name="get_current_scope" qualifiers="const">
+			<return type="SentryScope" />
+			<description>
+				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
+				Current scope is never shared between threads, so data written to the returned scope enriches only the telemetry captured on the calling thread. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
+			</description>
+		</method>
 		<method name="get_last_event_id" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -175,6 +182,33 @@
 			<param index="0" name="user" type="SentryUser" />
 			<description>
 				Assigns user data. See [SentryUser].
+			</description>
+		</method>
+		<method name="with_scope">
+			<return type="Variant" />
+			<param index="0" name="callable" type="Callable" />
+			<description>
+				Forks the current scope, calls [param callable] with the forked scope, and returns the value that [param callable] returned. Data written to the forked scope enriches only the telemetry captured inside the callable. The fork is discarded once the callable returns, and the parent scope becomes current again.
+				[codeblock]
+				SentrySDK.with_scope(func(scope: SentryScope) -&gt; void:
+					# Errors raised during generation carry what is needed to reproduce them.
+					scope.set_context("chunk", {
+						"x": chunk_x,
+						"y": chunk_y,
+						"seed": world_seed
+					})
+					var crumb := SentryBreadcrumb.create("Generating chunk")
+					crumb.category = "worldgen"
+					scope.add_breadcrumb(crumb)
+
+					generate_chunk(chunk_x, chunk_y)
+				)
+				[/codeblock]
+				The fork inherits everything the parent scope holds at the moment [method SentrySDK.with_scope] is called. The two are independent from then on: writes to the fork never reach the parent, and writes made to the parent afterwards never reach the fork. Nesting [method SentrySDK.with_scope] forks the enclosing scope the same way, so an inner scope starts with the data of the outer one and its own writes stay inside.
+				Writes made through [SentrySDK] methods such as [method SentrySDK.set_tag] still apply globally, even when called inside the callable.
+				For more information, see [SentryScope] class.
+				[b]Note:[/b] The fork covers the synchronous part of [param callable] only. If the callable awaits, the fork is discarded at the first [code]await[/code] and a warning is printed.
+				[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the current scope data is discarded, and a warning is printed.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -77,7 +77,7 @@
 			<description>
 				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
 				Current scope is never shared between threads, so data written to the returned scope enriches only the telemetry captured on the calling thread. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
-				[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the data written to the returned scope is discarded.
+				[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the returned scope.
 			</description>
 		</method>
 		<method name="get_last_event_id" qualifiers="const">
@@ -209,7 +209,7 @@
 				Writes made through [SentrySDK] methods such as [method SentrySDK.set_tag] still apply globally, even when called inside the callable.
 				For more information, see [SentryScope] class.
 				[b]Note:[/b] The fork covers the synchronous part of [param callable] only. If the callable awaits, the fork is discarded at the first [code]await[/code] and a warning is printed.
-				[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the current scope data is discarded, and a warning is printed.
+				[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -76,7 +76,7 @@
 			<return type="SentryScope" />
 			<description>
 				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
-				Current scope is never shared between threads, so data written to the returned scope enriches only the telemetry captured on the calling thread. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
+				The returned scope belongs to the calling thread. Data written to it enriches only the telemetry captured on that thread, and modifying it from another thread is not supported. See [SentryScope] for details. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
 				[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the returned scope.
 			</description>
 		</method>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -77,6 +77,7 @@
 			<description>
 				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
 				Current scope is never shared between threads, so data written to the returned scope enriches only the telemetry captured on the calling thread. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
+				[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the data written to the returned scope is discarded.
 			</description>
 		</method>
 		<method name="get_last_event_id" qualifiers="const">

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -13,6 +13,7 @@
 			save_game()
 		)
 		[/codeblock]
+		[b]Note:[/b] A scope is thread-local. Modify a scope only from the thread that created it. If a scope is modified from another thread, the SDK rejects the call with an error and discards the data. To enrich telemetry captured on another thread, get that thread's current scope with [method SentrySDK.get_current_scope], or use [SentrySDK] methods such as [method SentrySDK.set_tag] to enrich telemetry captured on all threads.
 		[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the scope.
 	</description>
 	<tutorials>

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -13,6 +13,7 @@
 			save_game()
 		)
 		[/codeblock]
+		[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the data written to the scope is discarded.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="SentryScope" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Holds contextual data that enriches the telemetry captured while it is in effect.
+	</brief_description>
+	<description>
+		A scope carries the same kinds of data as the global context set through [SentrySDK] methods such as [method SentrySDK.set_tag], but applies it only to the telemetry captured while the scope is in effect. Scope data is layered on top of the global data, so captured events keep everything set globally and add whatever the scope defines.
+		Everything captured while a scope is in effect picks up its data: [method SentrySDK.capture_event], [method SentrySDK.capture_message] and [method SentrySDK.capture_feedback], the structured logs and metrics, and the errors and warnings that Sentry captures automatically from Godot's logging. An error captured automatically is enriched by the scope in effect on the thread that raised it.
+		Use [method SentrySDK.get_current_scope] to reach the current scope in effect, or [method SentrySDK.with_scope] to run a callable with a forked scope that is discarded afterwards:
+		[codeblock]
+		SentrySDK.with_scope(func(scope: SentryScope) -&gt; void:
+			scope.set_tag("subsystem", "savegame")
+			save_game()
+		)
+		[/codeblock]
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_breadcrumb">
+			<return type="void" />
+			<param index="0" name="breadcrumb" type="SentryBreadcrumb" />
+			<description>
+				Adds a breadcrumb to the events captured within this scope. You can create a [SentryBreadcrumb] object using the static [method SentryBreadcrumb.create] method.
+				See [method SentrySDK.add_breadcrumb] for adding a breadcrumb globally to all future events.
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				Removes all data previously written to this scope. Data set globally through [SentrySDK] is not affected, and the scope stays usable afterwards.
+			</description>
+		</method>
+		<method name="set_attribute">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Sets an attribute with the specified [param name] and [param value] on the structured logs and metrics captured within this scope. Supported value types are [bool], [int], [float], and [String]. Other types will be stringified.
+				Scope attributes take precedence over the global attributes set with [method SentrySDK.set_attribute], and an attribute set on an individual log or metric takes precedence over both.
+			</description>
+		</method>
+		<method name="set_context">
+			<return type="void" />
+			<param index="0" name="key" type="String" />
+			<param index="1" name="value" type="Dictionary" />
+			<description>
+				Sets a context with the specified [param key] and [param value] on the events captured within this scope. The [param value] should be a dictionary with string keys and can have multiple levels of nesting.
+				See [method SentrySDK.set_context] for setting a context globally.
+			</description>
+		</method>
+		<method name="set_fingerprint">
+			<return type="void" />
+			<param index="0" name="fingerprint" type="PackedStringArray" />
+			<description>
+				Overrides the grouping fingerprint for the events captured within this scope. Sentry uses the fingerprint to group similar events into a single issue. Pass an empty array to clear the fingerprint and restore the default grouping.
+				To learn more, visit [url=https://docs.sentry.io/concepts/data-management/event-grouping/]Issue Grouping documentation[/url].
+			</description>
+		</method>
+		<method name="set_level">
+			<return type="void" />
+			<param index="0" name="level" type="int" enum="SentrySDK.Level" />
+			<description>
+				Sets the severity level of the events captured within this scope.
+			</description>
+		</method>
+		<method name="set_tag">
+			<return type="void" />
+			<param index="0" name="key" type="String" />
+			<param index="1" name="value" type="String" />
+			<description>
+				Assigns a tag with the specified [param key] and [param value] to the events captured within this scope.
+				See [method SentrySDK.set_tag] for assigning a tag globally.
+			</description>
+		</method>
+		<method name="set_user">
+			<return type="void" />
+			<param index="0" name="user" type="SentryUser" />
+			<description>
+				Assigns user data to the events captured within this scope. See [SentryUser].
+				See [method SentrySDK.set_user] for assigning user data globally.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -13,7 +13,7 @@
 			save_game()
 		)
 		[/codeblock]
-		[b]Note:[/b] Scopes are not supported on every platform yet. Where support is missing, telemetry is still captured but the data written to the scope is discarded.
+		[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the scope.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -167,3 +167,38 @@ func test_before_send_metric_discard() -> void:
 	SentrySDK.metrics.count("discarded_metric")
 	await assert_signal(monitor).is_not_emitted("metric_processed")
 	_discard_metric = false
+
+
+# TODO: remove skip when implemented on other platforms
+func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux"]) -> void:
+	SentrySDK.set_attribute("from_global", "global")
+	SentrySDK.set_attribute("scope_over_global", "global")
+	SentrySDK.set_attribute("metric_over_all", "global")
+
+	SentrySDK.with_scope(func(scope: SentryScope):
+		scope.set_attribute("from_scope", "scope")
+		scope.set_attribute("scope_over_global", "scope")
+		scope.set_attribute("metric_over_all", "scope")
+
+		metric_processed.connect(func(metric: SentryMetric):
+			# Each source contributes the attributes only it has...
+			assert_str(metric.get_attribute("from_global")).is_equal("global")
+			assert_str(metric.get_attribute("from_scope")).is_equal("scope")
+			assert_str(metric.get_attribute("from_metric")).is_equal("metric")
+			# ...and the most specific source wins the ones they share.
+			assert_str(metric.get_attribute("scope_over_global")).is_equal("scope")
+			assert_str(metric.get_attribute("metric_over_all")).is_equal("metric")
+		, CONNECT_ONE_SHOT)
+
+		SentrySDK.metrics.count("scoped_metric", 1, {
+			"from_metric": "metric",
+			"metric_over_all": "metric",
+		})
+	)
+
+	# Scope attributes are gone once the scope is popped.
+	metric_processed.connect(func(metric: SentryMetric):
+		assert_that(metric.get_attribute("from_scope")).is_null()
+		assert_str(metric.get_attribute("scope_over_global")).is_equal("global")
+	, CONNECT_ONE_SHOT)
+	SentrySDK.metrics.count("metric_after_scope")

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -196,3 +196,38 @@ func test_structured_logs_with_global_attributes(_do_skip = OS.get_name() == "We
 	SentrySDK.set_attribute("deleted_attribute", "SHOULD NOT BE PRESENT")
 	SentrySDK.remove_attribute("deleted_attribute")
 	SentrySDK.logger.info("Test with global attributes")
+
+
+# TODO: remove skip when implemented on other platforms
+func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux"]) -> void:
+	SentrySDK.set_attribute("from_global", "global")
+	SentrySDK.set_attribute("scope_over_global", "global")
+	SentrySDK.set_attribute("log_over_all", "global")
+
+	SentrySDK.with_scope(func(scope: SentryScope):
+		scope.set_attribute("from_scope", "scope")
+		scope.set_attribute("scope_over_global", "scope")
+		scope.set_attribute("log_over_all", "scope")
+
+		log_processed.connect(func(entry: SentryLog):
+			# Each source contributes the attributes only it has...
+			assert_str(entry.get_attribute("from_global")).is_equal("global")
+			assert_str(entry.get_attribute("from_scope")).is_equal("scope")
+			assert_str(entry.get_attribute("from_log")).is_equal("log")
+			# ...and the most specific source wins the ones they share.
+			assert_str(entry.get_attribute("scope_over_global")).is_equal("scope")
+			assert_str(entry.get_attribute("log_over_all")).is_equal("log")
+		, CONNECT_ONE_SHOT)
+
+		SentrySDK.logger.info("Test with scope attributes", [], {
+			"from_log": "log",
+			"log_over_all": "log",
+		})
+	)
+
+	# Scope attributes are gone once the scope is popped.
+	log_processed.connect(func(entry: SentryLog):
+		assert_that(entry.get_attribute("from_scope")).is_null()
+		assert_str(entry.get_attribute("scope_over_global")).is_equal("global")
+	, CONNECT_ONE_SHOT)
+	SentrySDK.logger.info("Test after scope is popped")

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -224,9 +224,8 @@ func test_nested_with_scope() -> void:
 		SentrySDK.capture_event(SentrySDK.create_event())
 		)
 
-	await wait_for_captured_event_json()
-	var json_inner: String = captured_events[0]
-	var json_outer: String = captured_events[1]
+	var json_inner: String = await wait_for_captured_event_json()
+	var json_outer: String = await wait_for_captured_event_json()
 
 	assert_json(json_inner).describe("nested scope inherits the outer scope's data") \
 		.at("/tags") \

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -8,7 +8,7 @@ extends SentryTestSuite
 
 # TODO: widen the platform list as scopes are implemented on other backends.
 func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
-		_skip_reason = "Scopes are implemented on the native backend only.") -> void:
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 
 

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -348,3 +348,24 @@ func test_with_scope_on_thread_inherits_global() -> void:
 		.must_contain("global_for_worker", "global") \
 		.must_contain("worker_tag", "worker") \
 		.verify()
+
+
+## Resumes the coroutine parked by test_with_scope_does_not_leak_while_parked().
+signal resume_parked_coroutine
+
+
+func test_with_scope_does_not_leak_while_parked() -> void:
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("parked_tag", "in_parked_scope")
+		await resume_parked_coroutine
+		)
+
+	var json_while_parked: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	resume_parked_coroutine.emit()
+
+	assert_json(json_while_parked).describe("event captured while a with_scope() coroutine is parked does not carry the parked scope's tag") \
+		.at("/tags") \
+		.must_not_contain("parked_tag") \
+		.verify()

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -1,9 +1,5 @@
 extends SentryTestSuite
 ## Verifies scope isolation for `SentrySDK.with_scope()`.
-##
-## A write to the local scope must only affect events captured inside the block,
-## must not leak back into the global scope afterwards, and top-level writes must
-## still reach the global scope even when made from inside the block.
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -1,0 +1,277 @@
+extends SentryTestSuite
+## Verifies scope isolation for `SentrySDK.with_scope()`.
+##
+## A write to the local scope must only affect events captured inside the block,
+## must not leak back into the global scope afterwards, and top-level writes must
+## still reach the global scope even when made from inside the block.
+
+
+# TODO: widen the platform list as scopes are implemented on other backends.
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
+		_skip_reason = "Scopes are implemented on the native backend only.") -> void:
+	super()
+
+
+func test_scoped_set_context() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_context("scene", {"name": "Dungeon", "depth": 3})
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("set_context() reaches the in-scope event") \
+		.at("/contexts/scene") \
+		.is_object() \
+		.must_contain("name", "Dungeon") \
+		.must_contain("depth", 3) \
+		.verify()
+
+	assert_json(json_after).describe("set_context() does not leak past with_scope") \
+		.at("/") \
+		.must_not_contain("/contexts/scene") \
+		.verify()
+
+
+func test_scoped_set_tag() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("scoped", "in_scope")
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("set_tag() reaches the in-scope event") \
+		.at("/tags") \
+		.must_contain("scoped", "in_scope") \
+		.verify()
+
+	assert_json(json_after).describe("set_tag() does not leak past with_scope") \
+		.at("/tags") \
+		.must_not_contain("scoped") \
+		.verify()
+
+
+func test_scoped_set_user() -> void:
+	var scoped_user := SentryUser.new()
+	scoped_user.id = "player_scope"
+	scoped_user.username = "ScopedPlayer"
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_user(scoped_user)
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("set_user() reaches the in-scope event") \
+		.at("/user") \
+		.is_object() \
+		.must_contain("id", "player_scope") \
+		.must_contain("username", "ScopedPlayer") \
+		.verify()
+
+	assert_json(json_after).describe("set_user() does not leak past with_scope") \
+		.at("/") \
+		.must_not_contain("/user/id", "player_scope") \
+		.verify()
+
+
+func test_scoped_set_level() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_level(SentrySDK.LEVEL_WARNING)
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("set_level() reaches the in-scope event") \
+		.at("/") \
+		.must_contain("level", "warning") \
+		.verify()
+
+	assert_json(json_after).describe("set_level() does not leak past with_scope") \
+		.at("/") \
+		.must_not_contain("/level", "warning") \
+		.verify()
+
+
+func test_scoped_set_fingerprint() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_fingerprint(PackedStringArray(["scope-group", "scope-key"]))
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("set_fingerprint() reaches the in-scope event") \
+		.at("/fingerprint") \
+		.is_array() \
+		.has_size(2) \
+		.must_contain("/0", "scope-group") \
+		.must_contain("/1", "scope-key") \
+		.verify()
+
+	assert_json(json_after).describe("set_fingerprint() does not leak past with_scope") \
+		.at("/") \
+		.must_not_contain("/fingerprint/0", "scope-group") \
+		.verify()
+
+
+func test_scoped_add_breadcrumb() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.add_breadcrumb(SentryBreadcrumb.create("scoped crumb"))
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("add_breadcrumb() reaches the in-scope event") \
+		.at("/breadcrumbs/") \
+		.is_array() \
+		.with_objects() \
+		.containing("message", "scoped crumb") \
+		.exactly(1)
+
+	assert_json(json_after).describe("add_breadcrumb() does not leak past with_scope") \
+		.either() \
+			.at("/") \
+			.must_not_contain("/breadcrumbs") \
+		.or_else() \
+			.at("/breadcrumbs") \
+			.is_null() \
+		.or_else() \
+			.at("/breadcrumbs/") \
+			.with_objects() \
+			.containing("message", "scoped crumb") \
+			.must_selected(0) \
+		.end() \
+		.verify()
+
+
+func test_scope_clear() -> void:
+	SentrySDK.set_tag("global_tag", "global")
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("before_clear", "value")
+		scope.clear()
+		scope.set_tag("after_clear", "value")
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json: String = await wait_for_captured_event_json()
+
+	assert_json(json).describe("clear() drops local scope data written before it") \
+		.at("/tags") \
+		.must_not_contain("before_clear") \
+		.verify()
+
+	assert_json(json).describe("scope stays usable after clear()") \
+		.at("/tags") \
+		.must_contain("after_clear", "value") \
+		.verify()
+
+	assert_json(json).describe("clear() leaves the global scope intact") \
+		.at("/tags") \
+		.must_contain("global_tag", "global") \
+		.verify()
+
+
+func test_scoped_capture_message() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("scoped", "in_scope")
+		SentrySDK.capture_message("scoped message", SentrySDK.LEVEL_WARNING)
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	SentrySDK.capture_message("global message", SentrySDK.LEVEL_WARNING)
+	var json_after: String = await wait_for_captured_event_json()
+
+	assert_json(json_in_scope).describe("Top-level capture_message() goes through current scope") \
+		.at("/tags") \
+		.must_contain("scoped", "in_scope") \
+		.verify()
+
+	assert_json(json_after).describe("capture_message() does not carry the popped scope") \
+		.at("/tags") \
+		.must_not_contain("scoped") \
+		.verify()
+
+
+func test_with_scope_top_level_write() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		SentrySDK.set_tag("global_inside", "inside")
+		)
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_after).describe("top-level write from inside with_scope reaches the global scope") \
+		.at("/tags") \
+		.must_contain("global_inside", "inside") \
+		.verify()
+
+
+func test_nested_with_scope() -> void:
+	SentrySDK.with_scope(func(outer: SentryScope) -> void:
+		outer.set_tag("outer_tag", "outer")
+
+		SentrySDK.with_scope(func(inner: SentryScope) -> void:
+			inner.set_tag("inner_tag", "inner")
+			SentrySDK.capture_event(SentrySDK.create_event())
+			)
+
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+
+	await wait_for_captured_event_json()
+	var json_inner: String = captured_events[0]
+	var json_outer: String = captured_events[1]
+
+	assert_json(json_inner).describe("nested scope inherits the outer scope's data") \
+		.at("/tags") \
+		.must_contain("outer_tag", "outer") \
+		.verify()
+
+	assert_json(json_inner).describe("nested scope carries its own writes") \
+		.at("/tags") \
+		.must_contain("inner_tag", "inner") \
+		.verify()
+
+	assert_json(json_outer).describe("nested writes don't leak back to the outer scope") \
+		.at("/tags") \
+		.must_not_contain("inner_tag") \
+		.verify()
+
+	assert_json(json_outer).describe("outer scope keeps its own data") \
+		.at("/tags") \
+		.must_contain("outer_tag", "outer") \
+		.verify()
+
+
+func test_get_current_scope_not_null() -> void:
+	assert_object(SentrySDK.get_current_scope()) \
+		.override_failure_message("get_current_scope() returns a non-null current scope outside any with_scope block") \
+		.is_not_null()
+
+
+func test_get_current_scope_with_nesting() -> void:
+	var initial: SentryScope = SentrySDK.get_current_scope()
+
+	SentrySDK.with_scope(func(outer: SentryScope) -> void:
+		assert_object(SentrySDK.get_current_scope()).is_same(outer)
+		assert_object(SentrySDK.get_current_scope()).is_not_same(initial)
+
+		SentrySDK.with_scope(func(inner: SentryScope) -> void:
+			assert_object(SentrySDK.get_current_scope()).is_same(inner)
+			assert_object(SentrySDK.get_current_scope()).is_not_same(outer)
+			)
+
+		assert_object(SentrySDK.get_current_scope()).is_same(outer)
+		)
+
+	assert_object(SentrySDK.get_current_scope()).is_same(initial)

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -300,6 +300,26 @@ func test_get_current_scope_is_thread_local() -> void:
 		.is_not_same(main_scope)
 
 
+func test_get_current_scope_enriches_later_events() -> void:
+	SentrySDK.get_current_scope().set_tag("current_tag", "current")
+
+	var json_first: String = await capture_event_and_get_json(SentrySDK.create_event())
+	var json_second: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	# The current scope outlives the test, so leave it as it was found.
+	SentrySDK.get_current_scope().clear()
+
+	assert_json(json_first).describe("current scope enriches an event captured after the write") \
+		.at("/tags") \
+		.must_contain("current_tag", "current") \
+		.verify()
+
+	assert_json(json_second).describe("current scope stays in effect for later events on the same thread") \
+		.at("/tags") \
+		.must_contain("current_tag", "current") \
+		.verify()
+
+
 func test_with_scope_on_thread_excludes_main_scope() -> void:
 	var main_in_scope := Semaphore.new()
 	var worker_captured := Semaphore.new()

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -212,6 +212,16 @@ func test_with_scope_top_level_write() -> void:
 		.verify()
 
 
+func test_with_scope_returns_callable_result() -> void:
+	var result: Variant = SentrySDK.with_scope(func(_scope: SentryScope) -> String:
+		return "callable result"
+		)
+
+	assert_str(result) \
+		.override_failure_message("with_scope() hands back what the callable returned") \
+		.is_equal("callable result")
+
+
 func test_nested_with_scope() -> void:
 	SentrySDK.with_scope(func(outer: SentryScope) -> void:
 		outer.set_tag("outer_tag", "outer")

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -271,3 +271,80 @@ func test_get_current_scope_with_nesting() -> void:
 		)
 
 	assert_object(SentrySDK.get_current_scope()).is_same(initial)
+
+
+func test_get_current_scope_is_thread_local() -> void:
+	var main_scope: SentryScope = SentrySDK.get_current_scope()
+
+	var thread := Thread.new()
+	thread.start(func() -> SentryScope:
+		return SentrySDK.get_current_scope()
+		)
+	var worker_scope: SentryScope = thread.wait_to_finish()
+
+	assert_object(worker_scope) \
+		.override_failure_message("worker thread gets a current scope of its own") \
+		.is_not_null()
+
+	assert_object(worker_scope) \
+		.override_failure_message("worker thread doesn't share the main thread's current scope") \
+		.is_not_same(main_scope)
+
+
+func test_with_scope_does_not_cross_threads() -> void:
+	var worker_may_capture := Semaphore.new()
+	var worker_captured := Semaphore.new()
+
+	var thread := Thread.new()
+	thread.start(func() -> void:
+		worker_may_capture.wait()
+		SentrySDK.with_scope(func(scope: SentryScope) -> void:
+			scope.set_tag("worker_tag", "worker")
+			SentrySDK.capture_event(SentrySDK.create_event())
+			)
+		worker_captured.post()
+		)
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("main_tag", "main")
+		worker_may_capture.post()
+		worker_captured.wait()
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+
+	thread.wait_to_finish()
+
+	var json_main: String = await wait_for_captured_event_json()
+	var json_worker: String = await wait_for_captured_event_json()
+
+	assert_json(json_worker).describe("worker event carries the worker scope, not the main thread's") \
+		.at("/tags") \
+		.must_contain("worker_tag", "worker") \
+		.must_not_contain("main_tag") \
+		.verify()
+
+	assert_json(json_main).describe("main event carries the main scope, not the worker thread's") \
+		.at("/tags") \
+		.must_contain("main_tag", "main") \
+		.must_not_contain("worker_tag") \
+		.verify()
+
+
+func test_with_scope_on_thread_inherits_global() -> void:
+	SentrySDK.set_tag("global_for_worker", "global")
+
+	var thread := Thread.new()
+	thread.start(func() -> void:
+		SentrySDK.with_scope(func(scope: SentryScope) -> void:
+			scope.set_tag("worker_tag", "worker")
+			SentrySDK.capture_event(SentrySDK.create_event())
+			)
+		)
+	thread.wait_to_finish()
+	var json: String = await wait_for_captured_event_json()
+
+	assert_json(json).describe("worker thread scope layers over the global scope") \
+		.at("/tags") \
+		.must_contain("global_for_worker", "global") \
+		.must_contain("worker_tag", "worker") \
+		.verify()

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -291,13 +291,13 @@ func test_get_current_scope_is_thread_local() -> void:
 		.is_not_same(main_scope)
 
 
-func test_with_scope_does_not_cross_threads() -> void:
-	var worker_may_capture := Semaphore.new()
+func test_with_scope_on_thread_excludes_main_scope() -> void:
+	var main_in_scope := Semaphore.new()
 	var worker_captured := Semaphore.new()
 
 	var thread := Thread.new()
 	thread.start(func() -> void:
-		worker_may_capture.wait()
+		main_in_scope.wait()
 		SentrySDK.with_scope(func(scope: SentryScope) -> void:
 			scope.set_tag("worker_tag", "worker")
 			SentrySDK.capture_event(SentrySDK.create_event())
@@ -307,14 +307,11 @@ func test_with_scope_does_not_cross_threads() -> void:
 
 	SentrySDK.with_scope(func(scope: SentryScope) -> void:
 		scope.set_tag("main_tag", "main")
-		worker_may_capture.post()
+		main_in_scope.post()
 		worker_captured.wait()
-		SentrySDK.capture_event(SentrySDK.create_event())
 		)
-
 	thread.wait_to_finish()
 
-	var json_main: String = await wait_for_captured_event_json()
 	var json_worker: String = await wait_for_captured_event_json()
 
 	assert_json(json_worker).describe("worker event carries the worker scope, not the main thread's") \
@@ -322,6 +319,30 @@ func test_with_scope_does_not_cross_threads() -> void:
 		.must_contain("worker_tag", "worker") \
 		.must_not_contain("main_tag") \
 		.verify()
+
+
+func test_with_scope_on_main_excludes_thread_scope() -> void:
+	var worker_in_scope := Semaphore.new()
+	var main_captured := Semaphore.new()
+
+	var thread := Thread.new()
+	thread.start(func() -> void:
+		SentrySDK.with_scope(func(scope: SentryScope) -> void:
+			scope.set_tag("worker_tag", "worker")
+			worker_in_scope.post()
+			main_captured.wait()
+			)
+		)
+
+	worker_in_scope.wait()
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("main_tag", "main")
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	main_captured.post()
+	thread.wait_to_finish()
+
+	var json_main: String = await wait_for_captured_event_json()
 
 	assert_json(json_main).describe("main event carries the main scope, not the worker thread's") \
 		.at("/tags") \

--- a/project/test/suites/test_scope.gd.uid
+++ b/project/test/suites/test_scope.gd.uid
@@ -1,0 +1,1 @@
+uid://c2ed3hfu2ydpr

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -1,0 +1,61 @@
+extends SentryTestSuite
+## Verifies telemetry stays on a single trace across scope operations.
+
+
+# TODO: widen the platform list as scopes are implemented on other backends.
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
+		_skip_reason = "Scopes are implemented on the native backend only.") -> void:
+	super()
+
+
+func _trace_id(json: String) -> Variant:
+	var data: Variant = JSON.parse_string(json)
+	return data.get("contexts", {}).get("trace", {}).get("trace_id")
+
+
+func test_scoped_event_shares_trace() -> void:
+	var json_outside: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	SentrySDK.with_scope(func(_scope: SentryScope) -> void:
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	assert_json(json_in_scope).describe("event captured in with_scope shares the trace of one captured outside") \
+		.at("/contexts/trace/trace_id") \
+		.is_equal(_trace_id(json_outside)) \
+		.verify()
+
+
+func test_nested_with_scope_keeps_trace() -> void:
+	SentrySDK.with_scope(func(_outer: SentryScope) -> void:
+		SentrySDK.capture_event(SentrySDK.create_event())
+
+		SentrySDK.with_scope(func(_inner: SentryScope) -> void:
+			SentrySDK.capture_event(SentrySDK.create_event())
+			)
+		)
+
+	await wait_for_captured_event_json()
+	var json_outer: String = captured_events[0]
+	var json_inner: String = captured_events[1]
+
+	assert_json(json_inner).describe("nested with_scope stays on the outer scope's trace") \
+		.at("/contexts/trace/trace_id") \
+		.is_equal(_trace_id(json_outer)) \
+		.verify()
+
+
+func test_scope_clear_keeps_trace() -> void:
+	var json_before: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.clear()
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_after_clear: String = await wait_for_captured_event_json()
+
+	assert_json(json_after_clear).describe("clear() does not change the trace") \
+		.at("/contexts/trace/trace_id") \
+		.is_equal(_trace_id(json_before)) \
+		.verify()

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -4,7 +4,7 @@ extends SentryTestSuite
 
 # TODO: widen the platform list as scopes are implemented on other backends.
 func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
-		_skip_reason = "Scopes are implemented on the native backend only.") -> void:
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 
 

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -36,9 +36,8 @@ func test_nested_with_scope_keeps_trace() -> void:
 			)
 		)
 
-	await wait_for_captured_event_json()
-	var json_outer: String = captured_events[0]
-	var json_inner: String = captured_events[1]
+	var json_outer: String = await wait_for_captured_event_json()
+	var json_inner: String = await wait_for_captured_event_json()
 
 	assert_json(json_inner).describe("nested with_scope stays on the outer scope's trace") \
 		.at("/contexts/trace/trace_id") \

--- a/project/test/suites/test_trace.gd.uid
+++ b/project/test/suites/test_trace.gd.uid
@@ -1,0 +1,1 @@
+uid://cxkhtddduanb7

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -18,6 +18,7 @@
 #include "sentry/sentry_metric.h"
 #include "sentry/sentry_metrics.h"
 #include "sentry/sentry_options.h"
+#include "sentry/sentry_scope.h"
 #include "sentry/sentry_scope_observer.h"
 #include "sentry/sentry_sdk.h"
 #include "sentry/sentry_unit.h"
@@ -94,6 +95,7 @@ void register_runtime_classes() {
 	GDREGISTER_ABSTRACT_CLASS(SentryBreadcrumb);
 	GDREGISTER_ABSTRACT_CLASS(SentryLog);
 	GDREGISTER_ABSTRACT_CLASS(SentryMetric);
+	GDREGISTER_CLASS(SentryScope);
 	GDREGISTER_INTERNAL_CLASS(DisabledEvent);
 	GDREGISTER_INTERNAL_CLASS(SentryEventProcessor);
 	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -95,7 +95,7 @@ void register_runtime_classes() {
 	GDREGISTER_ABSTRACT_CLASS(SentryBreadcrumb);
 	GDREGISTER_ABSTRACT_CLASS(SentryLog);
 	GDREGISTER_ABSTRACT_CLASS(SentryMetric);
-	GDREGISTER_CLASS(SentryScope);
+	GDREGISTER_ABSTRACT_CLASS(SentryScope);
 	GDREGISTER_INTERNAL_CLASS(DisabledEvent);
 	GDREGISTER_INTERNAL_CLASS(SentryEventProcessor);
 	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -196,7 +196,7 @@ Ref<SentryEvent> AndroidSDK::create_event() {
 	return event;
 }
 
-String AndroidSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
+String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL_V(android_plugin, String());
 	ERR_FAIL_COND_V(p_event.is_null(), String());

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -7,6 +7,7 @@
 #include "android_string_names.h"
 #include "android_util.h"
 #include "sentry/common_defs.h"
+#include "sentry/disabled/disabled_scope.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
 #include "sentry/processing/process_log.h"
@@ -170,7 +171,7 @@ void AndroidSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	android_plugin->call(ANDROID_SN(addBreadcrumb), crumb->get_handle());
 }
 
-void AndroidSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
+void AndroidSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
 
@@ -179,12 +180,6 @@ void AndroidSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p
 	}
 
 	android_plugin->call(ANDROID_SN(log), p_level, p_body, _sanitize_attributes(p_attributes));
-}
-
-String AndroidSDK::capture_message(const String &p_message, Level p_level) {
-	Object *android_plugin = _get_android_plugin();
-	ERR_FAIL_NULL_V(android_plugin, String());
-	return android_plugin->call(ANDROID_SN(captureMessage), p_message, p_level);
 }
 
 String AndroidSDK::get_last_event_id() {
@@ -201,7 +196,7 @@ Ref<SentryEvent> AndroidSDK::create_event() {
 	return event;
 }
 
-String AndroidSDK::capture_event(const Ref<SentryEvent> &p_event) {
+String AndroidSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL_V(android_plugin, String());
 	ERR_FAIL_COND_V(p_event.is_null(), String());
@@ -211,7 +206,7 @@ String AndroidSDK::capture_event(const Ref<SentryEvent> &p_event) {
 	return android_plugin->call(ANDROID_SN(captureEvent), handle);
 }
 
-void AndroidSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
+void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
@@ -249,7 +244,7 @@ void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	}
 }
 
-void AndroidSDK::metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
+void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
 
@@ -257,7 +252,7 @@ void AndroidSDK::metrics_add_count(const String &p_name, int64_t p_value, const 
 			p_name, p_value, _sanitize_attributes(p_attributes));
 }
 
-void AndroidSDK::metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
 
@@ -265,7 +260,7 @@ void AndroidSDK::metrics_add_gauge(const String &p_name, double p_value, const S
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 
-void AndroidSDK::metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void AndroidSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
 
@@ -301,6 +296,10 @@ void AndroidSDK::remove_attribute(const String &p_name) {
 	ERR_FAIL_NULL(android_plugin);
 
 	android_plugin->call(ANDROID_SN(removeAttribute), p_name);
+}
+
+SentryScopeImpl *AndroidSDK::create_scope() {
+	return memnew(DisabledScope);
 }
 
 void AndroidSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -76,25 +76,26 @@ public:
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event) override;
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) override;
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear_attachments() override;
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
+
+	virtual SentryScopeImpl *create_scope() override;
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -81,7 +81,7 @@ public:
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) override;
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -26,7 +26,6 @@ AndroidStringNames::AndroidStringNames() {
 	removeUser = StringName("removeUser");
 	addBreadcrumb = StringName("addBreadcrumb");
 	log = StringName("log");
-	captureMessage = StringName("captureMessage");
 	getLastEventId = StringName("getLastEventId");
 	captureError = StringName("captureError");
 	createEvent = StringName("createEvent");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -37,7 +37,6 @@ public:
 	StringName removeUser;
 	StringName addBreadcrumb;
 	StringName log;
-	StringName captureMessage;
 	StringName getLastEventId;
 	StringName captureError;
 	StringName createEvent;

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -27,25 +27,26 @@ public:
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event) override;
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) override;
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear_attachments() override;
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
+
+	virtual SentryScopeImpl *create_scope() override;
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -32,7 +32,7 @@ public:
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) override;
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -215,7 +215,7 @@ Ref<SentryEvent> CocoaSDK::create_event() {
 	return memnew(CocoaEvent(cocoa_event));
 }
 
-String CocoaSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
+String CocoaSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	CocoaEvent *typed_event = Object::cast_to<CocoaEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(typed_event, String());

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -8,6 +8,7 @@
 #include "cocoa_util.h"
 #include "gen/sdk_version.gen.h"
 #include "sentry/common_defs.h"
+#include "sentry/disabled/disabled_scope.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
 #include "sentry/processing/process_log.h"
@@ -133,7 +134,7 @@ void CocoaSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	[SentryObjCSDK addBreadcrumb:crumb->get_cocoa_breadcrumb()];
 }
 
-void CocoaSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
+void CocoaSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	if (p_body.is_empty()) {
 		return;
 	}
@@ -204,15 +205,6 @@ void CocoaSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_a
 	}
 }
 
-String CocoaSDK::capture_message(const String &p_message, Level p_level) {
-	SentryObjCId *event_id = [SentryObjCSDK captureMessage:string_to_objc(p_message)
-											withScopeBlock:^(SentryObjCScope *scope) {
-												scope.level = sentry_level_to_objc(p_level);
-											}];
-
-	return event_id ? string_from_objc(event_id.sentryIdString) : String();
-}
-
 String CocoaSDK::get_last_event_id() {
 	MutexLock lock(*last_event_id_mutex.ptr());
 	return last_event_id;
@@ -223,7 +215,7 @@ Ref<SentryEvent> CocoaSDK::create_event() {
 	return memnew(CocoaEvent(cocoa_event));
 }
 
-String CocoaSDK::capture_event(const Ref<SentryEvent> &p_event) {
+String CocoaSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	CocoaEvent *typed_event = Object::cast_to<CocoaEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(typed_event, String());
@@ -232,7 +224,7 @@ String CocoaSDK::capture_event(const Ref<SentryEvent> &p_event) {
 	return event_id ? string_from_objc(event_id.sentryIdString) : String();
 }
 
-void CocoaSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
+void CocoaSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
 
@@ -293,7 +285,7 @@ void CocoaSDK::clear_attachments() {
 	}];
 }
 
-void CocoaSDK::metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
+void CocoaSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	NSUInteger value = (NSUInteger)MAX(p_value, (int64_t)0);
 	if (p_attributes.is_empty()) {
 		[[SentryObjCSDK metrics] countWithKey:string_to_objc(p_name) value:value];
@@ -304,7 +296,7 @@ void CocoaSDK::metrics_add_count(const String &p_name, int64_t p_value, const Di
 	}
 }
 
-void CocoaSDK::metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void CocoaSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	SentryObjCUnit *unit = p_unit.is_empty()
 			? nil
 			: [[SentryObjCUnit alloc] initWithRawValue:string_to_objc(p_unit)];
@@ -320,7 +312,7 @@ void CocoaSDK::metrics_add_gauge(const String &p_name, double p_value, const Str
 	}
 }
 
-void CocoaSDK::metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void CocoaSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	SentryObjCUnit *unit = p_unit.is_empty()
 			? nil
 			: [[SentryObjCUnit alloc] initWithRawValue:string_to_objc(p_unit)];
@@ -347,6 +339,10 @@ void CocoaSDK::remove_attribute(const String &p_name) {
 	[SentryObjCSDK configureScope:^(SentryObjCScope *scope) {
 		[scope removeAttributeForKey:string_to_objc(p_name)];
 	}];
+}
+
+SentryScopeImpl *CocoaSDK::create_scope() {
+	return memnew(DisabledScope);
 }
 
 void CocoaSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/disabled/disabled_scope.h
+++ b/src/sentry/disabled/disabled_scope.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "sentry/sentry_scope_impl.h"
+
+namespace sentry {
+
+class DisabledScope : public SentryScopeImpl {
+public:
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
+	virtual void set_tag(const String &p_key, const String &p_value) override {}
+	virtual void set_user(const Ref<SentryUser> &p_user) override {}
+	virtual void set_level(sentry::Level p_level) override {}
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override {}
+	virtual void set_attribute(const String &p_name, const Variant &p_value) override {}
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override {}
+	virtual void clear() override {}
+	virtual SentryScopeImpl *clone() const override { return memnew(DisabledScope); }
+};
+
+} //namespace sentry

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -2,6 +2,7 @@
 
 #include "disabled_breadcrumb.h"
 #include "disabled_event.h"
+#include "disabled_scope.h"
 #include "sentry/internal_sdk.h"
 
 namespace sentry {
@@ -20,25 +21,29 @@ class DisabledSDK : public InternalSDK {
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override { return memnew(DisabledBreadcrumb); }
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override {}
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override {}
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override {}
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override { return ""; }
 	virtual String get_last_event_id() override { return ""; }
 
 	virtual Ref<SentryEvent> create_event() override { return memnew(DisabledEvent); }
-	virtual String capture_event(const Ref<SentryEvent> &p_event) override { return ""; }
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override { return ""; }
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) override {}
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override {}
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override {}
 	virtual void clear_attachments() override {}
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) override {}
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override {}
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override {}
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) override {}
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override {}
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override {}
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override {}
 	virtual void remove_attribute(const String &p_name) override {}
+
+	virtual SentryScopeImpl *create_scope() override { return memnew(DisabledScope); }
+
+	// Nothing is captured, so nothing is lost by discarding scope writes.
+	virtual bool supports_scopes() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override {}
 

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -26,7 +26,7 @@ class DisabledSDK : public InternalSDK {
 	virtual String get_last_event_id() override { return ""; }
 
 	virtual Ref<SentryEvent> create_event() override { return memnew(DisabledEvent); }
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override { return ""; }
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) override { return ""; }
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override {}
 

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -37,7 +37,7 @@ public:
 
 	virtual Ref<SentryEvent> create_event() = 0;
 
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) = 0;
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) = 0;
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) = 0;
 

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -6,6 +6,7 @@
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_event.h"
 #include "sentry/sentry_feedback.h"
+#include "sentry/sentry_scope.h"
 #include "sentry/sentry_user.h"
 
 #include <godot_cpp/variant/dictionary.hpp>
@@ -30,25 +31,32 @@ public:
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() = 0;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) = 0;
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) = 0;
 
-	virtual String capture_message(const String &p_message, Level p_level) = 0;
 	virtual String get_last_event_id() = 0;
 
 	virtual Ref<SentryEvent> create_event() = 0;
-	virtual String capture_event(const Ref<SentryEvent> &p_event) = 0;
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) = 0;
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) = 0;
+
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) = 0;
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) = 0;
 	virtual void clear_attachments() = 0;
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) = 0;
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) = 0;
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) = 0;
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) = 0;
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) = 0;
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) = 0;
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) = 0;
 	virtual void remove_attribute(const String &p_name) = 0;
+
+	virtual SentryScopeImpl *create_scope() = 0;
+
+	// Whether local scopes are as capable as the rest of this backend.
+	// False means the backend captures events but silently discards scope
+	// writes, which is a platform gap worth warning about.
+	virtual bool supports_scopes() const { return false; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) = 0;
 

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -201,7 +201,7 @@ Ref<SentryEvent> JavaScriptSDK::create_event() {
 	return memnew(JavaScriptEvent);
 }
 
-String JavaScriptSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
+String JavaScriptSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V(!js_bridge(), String());
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	JavaScriptEvent *ev = Object::cast_to<JavaScriptEvent>(p_event.ptr());

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -1,5 +1,6 @@
 #include "javascript_sdk.h"
 
+#include "sentry/disabled/disabled_scope.h"
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/javascript/javascript_event.h"
 #include "sentry/javascript/javascript_interop.h"
@@ -164,7 +165,7 @@ void JavaScriptSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	js_bridge()->call("addBreadcrumb", crumb->get_js_object());
 }
 
-void JavaScriptSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
+void JavaScriptSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 
 	String attr_value = attributes_to_json(p_attributes);
@@ -191,12 +192,6 @@ void JavaScriptSDK::log(LogLevel p_level, const String &p_body, const Dictionary
 	}
 }
 
-String JavaScriptSDK::capture_message(const String &p_message, Level p_level) {
-	ERR_FAIL_COND_V(!js_bridge(), String());
-	String uuid = js_bridge()->call("captureMessage", p_message.utf8(), level_as_string(p_level).utf8()).as_string();
-	return uuid;
-}
-
 String JavaScriptSDK::get_last_event_id() {
 	ERR_FAIL_COND_V(!js_bridge(), String());
 	return js_bridge()->call("lastEventId").as_string();
@@ -206,7 +201,7 @@ Ref<SentryEvent> JavaScriptSDK::create_event() {
 	return memnew(JavaScriptEvent);
 }
 
-String JavaScriptSDK::capture_event(const Ref<SentryEvent> &p_event) {
+String JavaScriptSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
 	ERR_FAIL_COND_V(!js_bridge(), String());
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	JavaScriptEvent *ev = Object::cast_to<JavaScriptEvent>(p_event.ptr());
@@ -214,7 +209,7 @@ String JavaScriptSDK::capture_event(const Ref<SentryEvent> &p_event) {
 	return js_bridge()->call("captureEvent", ev->get_js_object()).as_string();
 }
 
-void JavaScriptSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
+void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	ERR_FAIL_COND(!js_bridge());
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
@@ -252,19 +247,19 @@ void JavaScriptSDK::clear_attachments() {
 	js_bridge()->call("clearAttachments");
 }
 
-void JavaScriptSDK::metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
+void JavaScriptSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
 	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8());
 }
 
-void JavaScriptSDK::metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void JavaScriptSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
 	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8());
 }
 
-void JavaScriptSDK::metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+void JavaScriptSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
 	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8());
@@ -294,6 +289,10 @@ void JavaScriptSDK::set_attribute(const String &p_name, const Variant &p_value) 
 void JavaScriptSDK::remove_attribute(const String &p_name) {
 	ERR_FAIL_COND(!js_bridge());
 	js_bridge()->call("removeAttribute", p_name.utf8());
+}
+
+SentryScopeImpl *JavaScriptSDK::create_scope() {
+	return memnew(DisabledScope);
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -25,25 +25,26 @@ public:
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event) override;
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) override;
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear_attachments() override;
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
+
+	virtual SentryScopeImpl *create_scope() override;
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -30,7 +30,7 @@ public:
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) override;
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 

--- a/src/sentry/logging/sentry_godot_logger.cpp
+++ b/src/sentry/logging/sentry_godot_logger.cpp
@@ -437,7 +437,7 @@ void SentryGodotLogger::_log_error(const String &p_function, const String &p_fil
 			attributes["error.rationale"] = p_rationale;
 		}
 
-		SentrySDK::get_singleton()->get_internal_sdk()->log(log_level, body, attributes);
+		INTERNAL_SDK()->capture_log(SentrySDK::get_singleton()->get_current_scope(), log_level, body, attributes);
 	}
 }
 
@@ -479,7 +479,7 @@ void SentryGodotLogger::_log_message(const String &p_message, bool p_error) {
 
 	if (as_log) {
 		sentry::LogLevel level = p_error ? LOG_LEVEL_ERROR : LOG_LEVEL_INFO;
-		SentrySDK::get_singleton()->get_internal_sdk()->log(level, processed_message, log_attributes);
+		INTERNAL_SDK()->capture_log(SentrySDK::get_singleton()->get_current_scope(), level, processed_message, log_attributes);
 	}
 
 	if (as_breadcrumb) {

--- a/src/sentry/native/native_scope.cpp
+++ b/src/sentry/native/native_scope.cpp
@@ -1,0 +1,67 @@
+#include "native_scope.h"
+
+#include "sentry/native/native_breadcrumb.h"
+#include "sentry/native/native_util.h"
+
+namespace sentry::native {
+
+// NOTE: Input validations are performed by Godot-facing SentryScope.
+
+void NativeScope::set_context(const String &p_key, const Dictionary &p_value) {
+	sentry_scope_set_context(_scope, p_key.utf8(), variant_to_sentry_value(p_value));
+}
+
+void NativeScope::set_tag(const String &p_key, const String &p_value) {
+	sentry_scope_set_tag(_scope, p_key.utf8(), p_value.utf8());
+}
+
+void NativeScope::set_user(const Ref<SentryUser> &p_user) {
+	if (p_user.is_valid()) {
+		sentry_scope_set_user(_scope, user_to_sentry_value(p_user));
+	} else {
+		sentry_scope_set_user(_scope, sentry_value_new_null());
+	}
+}
+
+void NativeScope::set_level(sentry::Level p_level) {
+	sentry_scope_set_level(_scope, level_to_native(p_level));
+}
+
+void NativeScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	sentry_scope_set_fingerprints(_scope, strings_to_sentry_list(p_fingerprint));
+}
+
+void NativeScope::set_attribute(const String &p_name, const Variant &p_value) {
+	sentry_scope_set_attribute(_scope, p_name.utf8(), variant_to_attribute(p_value));
+}
+
+void NativeScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	NativeBreadcrumb *native_crumb = Object::cast_to<NativeBreadcrumb>(p_breadcrumb.ptr());
+	if (native_crumb) {
+		sentry_value_t crumb_value = native_crumb->get_native_breadcrumb();
+		sentry_value_incref(crumb_value); // Scope takes ownership.
+		sentry_scope_add_breadcrumb(_scope, crumb_value);
+	}
+}
+
+void NativeScope::clear() {
+	sentry_scope_clear(_scope);
+}
+
+SentryScopeImpl *NativeScope::clone() const {
+	return memnew(NativeScope(sentry_scope_clone(_scope)));
+}
+
+NativeScope::NativeScope() {
+	_scope = sentry_scope_new();
+}
+
+NativeScope::NativeScope(sentry_scope_t *_scope) :
+		_scope(_scope) {
+}
+
+NativeScope::~NativeScope() {
+	sentry_scope_free(_scope);
+}
+
+} // namespace sentry::native

--- a/src/sentry/native/native_scope.cpp
+++ b/src/sentry/native/native_scope.cpp
@@ -37,11 +37,10 @@ void NativeScope::set_attribute(const String &p_name, const Variant &p_value) {
 
 void NativeScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	NativeBreadcrumb *native_crumb = Object::cast_to<NativeBreadcrumb>(p_breadcrumb.ptr());
-	if (native_crumb) {
-		sentry_value_t crumb_value = native_crumb->get_native_breadcrumb();
-		sentry_value_incref(crumb_value); // Scope takes ownership.
-		sentry_scope_add_breadcrumb(_scope, crumb_value);
-	}
+	ERR_FAIL_NULL(native_crumb);
+	sentry_value_t crumb_value = native_crumb->get_native_breadcrumb();
+	sentry_value_incref(crumb_value); // Scope takes ownership.
+	sentry_scope_add_breadcrumb(_scope, crumb_value);
 }
 
 void NativeScope::clear() {

--- a/src/sentry/native/native_scope.cpp
+++ b/src/sentry/native/native_scope.cpp
@@ -55,8 +55,8 @@ NativeScope::NativeScope() {
 	_scope = sentry_scope_new();
 }
 
-NativeScope::NativeScope(sentry_scope_t *_scope) :
-		_scope(_scope) {
+NativeScope::NativeScope(sentry_scope_t *p_scope) :
+		_scope(p_scope) {
 }
 
 NativeScope::~NativeScope() {

--- a/src/sentry/native/native_scope.cpp
+++ b/src/sentry/native/native_scope.cpp
@@ -16,11 +16,7 @@ void NativeScope::set_tag(const String &p_key, const String &p_value) {
 }
 
 void NativeScope::set_user(const Ref<SentryUser> &p_user) {
-	if (p_user.is_valid()) {
-		sentry_scope_set_user(_scope, user_to_sentry_value(p_user));
-	} else {
-		sentry_scope_set_user(_scope, sentry_value_new_null());
-	}
+	sentry_scope_set_user(_scope, user_to_sentry_value(p_user));
 }
 
 void NativeScope::set_level(sentry::Level p_level) {

--- a/src/sentry/native/native_scope.h
+++ b/src/sentry/native/native_scope.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "sentry/sentry_scope_impl.h"
+
+#include "sentry.h"
+
+namespace sentry::native {
+
+// Thin wrapper around sentry-native scope used for SentryScope implementation on Windows and Linux.
+class NativeScope : public SentryScopeImpl {
+private:
+	sentry_scope_t *_scope;
+
+public:
+	sentry_scope_t *get_native_scope() const { return _scope; }
+
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
+	virtual void set_tag(const String &p_key, const String &p_value) override;
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+	virtual void set_level(sentry::Level p_level) override;
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void clear() override;
+	virtual SentryScopeImpl *clone() const override;
+
+	NativeScope();
+	NativeScope(sentry_scope_t *_scope);
+	virtual ~NativeScope() override;
+};
+
+} //namespace sentry::native

--- a/src/sentry/native/native_scope.h
+++ b/src/sentry/native/native_scope.h
@@ -25,7 +25,7 @@ public:
 	virtual SentryScopeImpl *clone() const override;
 
 	NativeScope();
-	NativeScope(sentry_scope_t *_scope);
+	NativeScope(sentry_scope_t *p_scope);
 	virtual ~NativeScope() override;
 };
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -8,6 +8,7 @@
 #include "sentry/native/native_event.h"
 #include "sentry/native/native_log.h"
 #include "sentry/native/native_metric.h"
+#include "sentry/native/native_scope.h"
 #include "sentry/native/native_util.h"
 #include "sentry/native/platform_detection.h"
 #include "sentry/processing/process_event.h"
@@ -199,25 +200,7 @@ void NativeSDK::remove_tag(const String &p_key) {
 
 void NativeSDK::set_user(const Ref<SentryUser> &p_user) {
 	if (p_user.is_valid()) {
-		sentry_value_t user_data = sentry_value_new_object();
-
-		if (!p_user->get_id().is_empty()) {
-			sentry_value_set_by_key(user_data, "id",
-					sentry_value_new_string(p_user->get_id().utf8()));
-		}
-		if (!p_user->get_username().is_empty()) {
-			sentry_value_set_by_key(user_data, "username",
-					sentry_value_new_string(p_user->get_username().utf8()));
-		}
-		if (!p_user->get_email().is_empty()) {
-			sentry_value_set_by_key(user_data, "email",
-					sentry_value_new_string(p_user->get_email().utf8()));
-		}
-		if (!p_user->get_ip_address().is_empty()) {
-			sentry_value_set_by_key(user_data, "ip_address",
-					sentry_value_new_string(p_user->get_ip_address().utf8()));
-		}
-		sentry_set_user(user_data);
+		sentry_set_user(user_to_sentry_value(p_user));
 	} else {
 		remove_user();
 	}
@@ -240,26 +223,17 @@ void NativeSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	sentry_add_breadcrumb(native_crumb);
 }
 
-void NativeSDK::log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
+void NativeSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	if (p_body.is_empty()) {
 		return;
 	}
-	sentry_log(_log_level_to_native(p_level), p_body.utf8(), dictionary_to_attributes(p_attributes));
-}
 
-String NativeSDK::capture_message(const String &p_message, Level p_level) {
-	sentry_value_t event = sentry_value_new_message_event(
-			native::level_to_native(p_level),
-			"", // logger
-			p_message.utf8().get_data());
+	ERR_FAIL_COND(p_scope.is_null());
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
 
-	sentry_uuid_t uuid = sentry_capture_event(event);
-
-	last_uuid_mutex->lock();
-	last_uuid = uuid;
-	last_uuid_mutex->unlock();
-
-	return _uuid_as_string(uuid);
+	sentry_scope_capture_log(native_scope->get_native_scope(), _log_level_to_native(p_level),
+			p_body.utf8(), dictionary_to_attributes(p_attributes));
 }
 
 String NativeSDK::get_last_event_id() {
@@ -276,13 +250,19 @@ Ref<SentryEvent> NativeSDK::create_event() {
 	return event;
 }
 
-String NativeSDK::capture_event(const Ref<SentryEvent> &p_event) {
+String NativeSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), _uuid_as_string(sentry_uuid_nil()), "Sentry: Can't capture event - event object is null.");
+
 	NativeEvent *native_event = Object::cast_to<NativeEvent>(p_event.ptr());
-	ERR_FAIL_NULL_V(native_event, _uuid_as_string(sentry_uuid_nil())); // Sanity check - this should never happen.
+	ERR_FAIL_NULL_V(native_event, _uuid_as_string(sentry_uuid_nil()));
 	sentry_value_t event = native_event->get_native_value();
 	sentry_value_incref(event); // Keep ownership.
-	sentry_uuid_t uuid = sentry_capture_event(event);
+
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL_V(native_scope, _uuid_as_string(sentry_uuid_nil()));
+	sentry_scope_t *scope = native_scope->get_native_scope();
+
+	sentry_uuid_t uuid = sentry_scope_capture_event(scope, event);
 
 	last_uuid_mutex->lock();
 	last_uuid = uuid;
@@ -291,7 +271,7 @@ String NativeSDK::capture_event(const Ref<SentryEvent> &p_event) {
 	return _uuid_as_string(uuid);
 }
 
-void NativeSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
+void NativeSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
 
@@ -313,7 +293,11 @@ void NativeSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
 				sentry_value_new_string(p_feedback->get_associated_event_id().ascii()));
 	}
 
-	sentry_capture_feedback(feedback);
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
+	sentry_scope_t *scope = native_scope->get_native_scope();
+
+	sentry_scope_capture_feedback(scope, feedback, nullptr);
 }
 
 void NativeSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -362,16 +346,31 @@ void NativeSDK::clear_attachments() {
 	user_attachments.clear();
 }
 
-void NativeSDK::metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
-	sentry_metrics_count(p_name.utf8(), p_value, dictionary_to_attributes(p_attributes));
+void NativeSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
+	ERR_FAIL_COND(p_scope.is_null());
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
+
+	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_COUNT,
+			p_name.utf8(), sentry_value_new_int64(p_value), nullptr, dictionary_to_attributes(p_attributes));
 }
 
-void NativeSDK::metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
-	sentry_metrics_gauge(p_name.utf8(), p_value, p_unit.utf8(), dictionary_to_attributes(p_attributes));
+void NativeSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+	ERR_FAIL_COND(p_scope.is_null());
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
+
+	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_GAUGE,
+			p_name.utf8(), sentry_value_new_double(p_value), p_unit.utf8(), dictionary_to_attributes(p_attributes));
 }
 
-void NativeSDK::metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
-	sentry_metrics_distribution(p_name.utf8(), p_value, p_unit.utf8(), dictionary_to_attributes(p_attributes));
+void NativeSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
+	ERR_FAIL_COND(p_scope.is_null());
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
+
+	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_DISTRIBUTION,
+			p_name.utf8(), sentry_value_new_double(p_value), p_unit.utf8(), dictionary_to_attributes(p_attributes));
 }
 
 void NativeSDK::set_attribute(const String &p_name, const Variant &p_value) {
@@ -380,6 +379,11 @@ void NativeSDK::set_attribute(const String &p_name, const Variant &p_value) {
 
 void NativeSDK::remove_attribute(const String &p_name) {
 	sentry_remove_attribute(p_name.utf8());
+}
+
+SentryScopeImpl *NativeSDK::create_scope() {
+	SentryScopeImpl *scope = memnew(NativeScope);
+	return scope;
 }
 
 void NativeSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -253,16 +253,16 @@ Ref<SentryEvent> NativeSDK::create_event() {
 String NativeSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), _uuid_as_string(sentry_uuid_nil()), "Sentry: Can't capture event - event object is null.");
 
+	ERR_FAIL_COND_V(p_scope.is_null(), _uuid_as_string(sentry_uuid_nil()));
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL_V(native_scope, _uuid_as_string(sentry_uuid_nil()));
+
 	NativeEvent *native_event = Object::cast_to<NativeEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(native_event, _uuid_as_string(sentry_uuid_nil()));
 	sentry_value_t event = native_event->get_native_value();
 	sentry_value_incref(event); // Keep ownership.
 
-	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL_V(native_scope, _uuid_as_string(sentry_uuid_nil()));
-	sentry_scope_t *scope = native_scope->get_native_scope();
-
-	sentry_uuid_t uuid = sentry_scope_capture_event(scope, event);
+	sentry_uuid_t uuid = sentry_scope_capture_event(native_scope->get_native_scope(), event);
 
 	last_uuid_mutex->lock();
 	last_uuid = uuid;
@@ -274,6 +274,10 @@ String NativeSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sentr
 void NativeSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
+
+	ERR_FAIL_COND(p_scope.is_null());
+	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL(native_scope);
 
 	sentry_value_t feedback = sentry_value_new_object();
 
@@ -293,11 +297,7 @@ void NativeSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sent
 				sentry_value_new_string(p_feedback->get_associated_event_id().ascii()));
 	}
 
-	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
-	sentry_scope_t *scope = native_scope->get_native_scope();
-
-	sentry_scope_capture_feedback(scope, feedback, nullptr);
+	sentry_scope_capture_feedback(native_scope->get_native_scope(), feedback, nullptr);
 }
 
 void NativeSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -250,7 +250,7 @@ Ref<SentryEvent> NativeSDK::create_event() {
 	return event;
 }
 
-String NativeSDK::capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) {
+String NativeSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), _uuid_as_string(sentry_uuid_nil()), "Sentry: Can't capture event - event object is null.");
 
 	NativeEvent *native_event = Object::cast_to<NativeEvent>(p_event.ptr());

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -199,11 +199,7 @@ void NativeSDK::remove_tag(const String &p_key) {
 }
 
 void NativeSDK::set_user(const Ref<SentryUser> &p_user) {
-	if (p_user.is_valid()) {
-		sentry_set_user(user_to_sentry_value(p_user));
-	} else {
-		remove_user();
-	}
+	sentry_set_user(user_to_sentry_value(p_user));
 }
 
 void NativeSDK::remove_user() {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -376,8 +376,7 @@ void NativeSDK::remove_attribute(const String &p_name) {
 }
 
 SentryScopeImpl *NativeSDK::create_scope() {
-	SentryScopeImpl *scope = memnew(NativeScope);
-	return scope;
+	return memnew(NativeScope);
 }
 
 void NativeSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -230,7 +230,6 @@ void NativeSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, c
 
 	ERR_FAIL_COND(p_scope.is_null());
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
 
 	sentry_scope_capture_log(native_scope->get_native_scope(), _log_level_to_native(p_level),
 			p_body.utf8(), dictionary_to_attributes(p_attributes));
@@ -255,7 +254,6 @@ String NativeSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sentr
 
 	ERR_FAIL_COND_V(p_scope.is_null(), _uuid_as_string(sentry_uuid_nil()));
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL_V(native_scope, _uuid_as_string(sentry_uuid_nil()));
 
 	NativeEvent *native_event = Object::cast_to<NativeEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(native_event, _uuid_as_string(sentry_uuid_nil()));
@@ -277,7 +275,6 @@ void NativeSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sent
 
 	ERR_FAIL_COND(p_scope.is_null());
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
 
 	sentry_value_t feedback = sentry_value_new_object();
 
@@ -349,7 +346,6 @@ void NativeSDK::clear_attachments() {
 void NativeSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(p_scope.is_null());
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
 
 	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_COUNT,
 			p_name.utf8(), sentry_value_new_int64(p_value), nullptr, dictionary_to_attributes(p_attributes));
@@ -358,7 +354,6 @@ void NativeSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String 
 void NativeSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(p_scope.is_null());
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
 
 	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_GAUGE,
 			p_name.utf8(), sentry_value_new_double(p_value), p_unit.utf8(), dictionary_to_attributes(p_attributes));
@@ -367,7 +362,6 @@ void NativeSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String 
 void NativeSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(p_scope.is_null());
 	NativeScope *native_scope = static_cast<NativeScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL(native_scope);
 
 	sentry_scope_capture_metric(native_scope->get_native_scope(), SENTRY_METRIC_DISTRIBUTION,
 			p_name.utf8(), sentry_value_new_double(p_value), p_unit.utf8(), dictionary_to_attributes(p_attributes));

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -28,25 +28,27 @@ public:
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 
-	virtual void log(LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
+	virtual void capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes = Dictionary()) override;
 
-	virtual String capture_message(const String &p_message, Level p_level = sentry::LEVEL_INFO) override;
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event) override;
+	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
 
-	virtual void capture_feedback(const Ref<SentryFeedback> &p_feedback) override;
+	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear_attachments() override;
 
-	virtual void metrics_add_count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
-	virtual void metrics_add_gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
-	virtual void metrics_add_distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) override;
+	virtual void metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
+	virtual void metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) override;
 
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void remove_attribute(const String &p_name) override;
+
+	virtual SentryScopeImpl *create_scope() override;
+	virtual bool supports_scopes() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -48,6 +48,7 @@ public:
 	virtual void remove_attribute(const String &p_name) override;
 
 	virtual SentryScopeImpl *create_scope() override;
+
 	virtual bool supports_scopes() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -33,7 +33,7 @@ public:
 	virtual String get_last_event_id() override;
 
 	virtual Ref<SentryEvent> create_event() override;
-	virtual String capture_event(const Ref<SentryEvent> &p_event, const Ref<SentryScope> &p_scope) override;
+	virtual String capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) override;
 
 	virtual void capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) override;
 

--- a/src/sentry/native/native_util.cpp
+++ b/src/sentry/native/native_util.cpp
@@ -78,6 +78,18 @@ sentry_value_t strings_to_sentry_list(const PackedStringArray &p_strings) {
 	return sentry_list;
 }
 
+sentry_value_t user_to_sentry_value(const Ref<SentryUser> &p_user) {
+	sentry_value_t user_data = sentry_value_new_object();
+	if (p_user.is_null()) {
+		return user_data;
+	}
+	sentry_value_set_or_remove_string_by_key(user_data, "id", p_user->get_id());
+	sentry_value_set_or_remove_string_by_key(user_data, "username", p_user->get_username());
+	sentry_value_set_or_remove_string_by_key(user_data, "email", p_user->get_email());
+	sentry_value_set_or_remove_string_by_key(user_data, "ip_address", p_user->get_ip_address());
+	return user_data;
+}
+
 sentry_level_t level_to_native(sentry::Level p_level) {
 	switch (p_level) {
 		case sentry::Level::LEVEL_DEBUG:

--- a/src/sentry/native/native_util.cpp
+++ b/src/sentry/native/native_util.cpp
@@ -79,10 +79,10 @@ sentry_value_t strings_to_sentry_list(const PackedStringArray &p_strings) {
 }
 
 sentry_value_t user_to_sentry_value(const Ref<SentryUser> &p_user) {
-	sentry_value_t user_data = sentry_value_new_object();
 	if (p_user.is_null()) {
-		return user_data;
+		return sentry_value_new_null();
 	}
+	sentry_value_t user_data = sentry_value_new_object();
 	sentry_value_set_or_remove_string_by_key(user_data, "id", p_user->get_id());
 	sentry_value_set_or_remove_string_by_key(user_data, "username", p_user->get_username());
 	sentry_value_set_or_remove_string_by_key(user_data, "email", p_user->get_email());

--- a/src/sentry/native/native_util.h
+++ b/src/sentry/native/native_util.h
@@ -2,6 +2,7 @@
 
 #include "godot_cpp/core/defs.hpp"
 #include "sentry/level.h"
+#include "sentry/sentry_user.h"
 
 #include <sentry.h>
 #include <godot_cpp/variant/char_string.hpp>
@@ -17,6 +18,9 @@ sentry_value_t variant_to_sentry_value(const Variant &p_variant, int p_depth = 0
 
 // Convert PackedStringArray to sentry_value_t (as a list).
 sentry_value_t strings_to_sentry_list(const PackedStringArray &p_strings);
+
+// Convert SentryUser to sentry_value_t user object, omitting empty fields.
+sentry_value_t user_to_sentry_value(const Ref<SentryUser> &p_user);
 
 sentry_level_t level_to_native(Level p_level);
 Level native_to_level(sentry_level_t p_native_level);

--- a/src/sentry/native/native_util.h
+++ b/src/sentry/native/native_util.h
@@ -20,6 +20,7 @@ sentry_value_t variant_to_sentry_value(const Variant &p_variant, int p_depth = 0
 sentry_value_t strings_to_sentry_list(const PackedStringArray &p_strings);
 
 // Convert SentryUser to sentry_value_t user object, omitting empty fields.
+// A null user converts to a null value, removing the user where it is applied.
 sentry_value_t user_to_sentry_value(const Ref<SentryUser> &p_user);
 
 sentry_level_t level_to_native(Level p_level);

--- a/src/sentry/sentry_logger.cpp
+++ b/src/sentry/sentry_logger.cpp
@@ -17,7 +17,7 @@ void SentryLogger::log(LogLevel p_level, const String &p_body, const Array &p_pa
 		}
 		body = p_body % p_params;
 	}
-	INTERNAL_SDK()->log(p_level, body, attributes);
+	INTERNAL_SDK()->capture_log(SentrySDK::get_singleton()->get_current_scope(), p_level, body, attributes);
 }
 
 void SentryLogger::trace(const String &p_body, const Array &p_params, const Dictionary &p_attributes) {

--- a/src/sentry/sentry_metrics.cpp
+++ b/src/sentry/sentry_metrics.cpp
@@ -9,7 +9,7 @@ void SentryMetrics::count(const String &p_name, int64_t p_value, const Dictionar
 	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
 		return;
 	}
-	INTERNAL_SDK()->metrics_add_count(p_name, p_value, p_attributes);
+	INTERNAL_SDK()->metrics_add_count(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_attributes);
 }
 
 void SentryMetrics::gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
@@ -17,7 +17,7 @@ void SentryMetrics::gauge(const String &p_name, double p_value, const String &p_
 	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
 		return;
 	}
-	INTERNAL_SDK()->metrics_add_gauge(p_name, p_value, p_unit, p_attributes);
+	INTERNAL_SDK()->metrics_add_gauge(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_unit, p_attributes);
 }
 
 void SentryMetrics::distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
@@ -25,7 +25,7 @@ void SentryMetrics::distribution(const String &p_name, double p_value, const Str
 	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
 		return;
 	}
-	INTERNAL_SDK()->metrics_add_distribution(p_name, p_value, p_unit, p_attributes);
+	INTERNAL_SDK()->metrics_add_distribution(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_unit, p_attributes);
 }
 
 void SentryMetrics::_bind_methods() {

--- a/src/sentry/sentry_scope.cpp
+++ b/src/sentry/sentry_scope.cpp
@@ -2,45 +2,60 @@
 
 #include "sentry_sdk.h" // Needed for VariantCaster<SentrySDK::Level>
 
+#define WRONG_THREAD_MSG                                               \
+	"Sentry: This scope is bound to the thread that created it. "      \
+	"Call SentrySDK.get_current_scope() on this thread to access its " \
+	"current scope, or use process-wide SentrySDK methods such as "    \
+	"SentrySDK.set_tag() to enrich telemetry across all threads."
+
 namespace sentry {
 
 void SentryScope::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	_impl->set_context(p_key, p_value);
 }
 
 void SentryScope::set_tag(const String &p_key, const String &p_value) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set tag with an empty key.");
 	_impl->set_tag(p_key, p_value);
 }
 
 void SentryScope::set_user(const Ref<SentryUser> &p_user) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	_impl->set_user(p_user);
 }
 
 void SentryScope::set_level(sentry::Level p_level) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	_impl->set_level(p_level);
 }
 
 void SentryScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	_impl->set_fingerprint(p_fingerprint);
 }
 
 void SentryScope::set_attribute(const String &p_name, const Variant &p_value) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	ERR_FAIL_COND_MSG(p_name.is_empty(), "Sentry: Can't set attribute with an empty name.");
 	_impl->set_attribute(p_name, p_value);
 }
 
 void SentryScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	ERR_FAIL_COND_MSG(p_breadcrumb.is_null(), "Sentry: Can't add a null breadcrumb.");
 	_impl->add_breadcrumb(p_breadcrumb);
 }
 
 void SentryScope::clear() {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	_impl->clear();
 }
 
 Ref<SentryScope> SentryScope::clone() const {
+	ERR_SENTRY_THREAD_GUARD_V(Ref<SentryScope>(), WRONG_THREAD_MSG);
 	return Ref<SentryScope>(memnew(SentryScope(_impl->clone())));
 }
 
@@ -68,3 +83,5 @@ SentryScope::~SentryScope() {
 }
 
 } //namespace sentry
+
+#undef WRONG_THREAD_MSG

--- a/src/sentry/sentry_scope.cpp
+++ b/src/sentry/sentry_scope.cpp
@@ -22,7 +22,7 @@ void SentryScope::set_level(sentry::Level p_level) {
 	_impl->set_level(p_level);
 }
 
-void SentryScope::set_fingerprint(PackedStringArray p_fingerprint) {
+void SentryScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
 	_impl->set_fingerprint(p_fingerprint);
 }
 

--- a/src/sentry/sentry_scope.cpp
+++ b/src/sentry/sentry_scope.cpp
@@ -1,0 +1,70 @@
+#include "sentry_scope.h"
+
+#include "sentry_sdk.h" // Needed for VariantCaster<SentrySDK::Level>
+
+namespace sentry {
+
+void SentryScope::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
+	_impl->set_context(p_key, p_value);
+}
+
+void SentryScope::set_tag(const String &p_key, const String &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set tag with an empty key.");
+	_impl->set_tag(p_key, p_value);
+}
+
+void SentryScope::set_user(const Ref<SentryUser> &p_user) {
+	_impl->set_user(p_user);
+}
+
+void SentryScope::set_level(sentry::Level p_level) {
+	_impl->set_level(p_level);
+}
+
+void SentryScope::set_fingerprint(PackedStringArray p_fingerprint) {
+	_impl->set_fingerprint(p_fingerprint);
+}
+
+void SentryScope::set_attribute(const String &p_name, const Variant &p_value) {
+	ERR_FAIL_COND_MSG(p_name.is_empty(), "Sentry: Can't set attribute with an empty name.");
+	_impl->set_attribute(p_name, p_value);
+}
+
+void SentryScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	ERR_FAIL_COND_MSG(p_breadcrumb.is_null(), "Sentry: Can't add a null breadcrumb.");
+	_impl->add_breadcrumb(p_breadcrumb);
+}
+
+void SentryScope::clear() {
+	_impl->clear();
+}
+
+Ref<SentryScope> SentryScope::clone() const {
+	return Ref<SentryScope>(memnew(SentryScope(_impl->clone())));
+}
+
+void SentryScope::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_context", "key", "value"), &SentryScope::set_context);
+	ClassDB::bind_method(D_METHOD("set_tag", "key", "value"), &SentryScope::set_tag);
+	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentryScope::set_user);
+	ClassDB::bind_method(D_METHOD("set_level", "level"), &SentryScope::set_level);
+	ClassDB::bind_method(D_METHOD("set_fingerprint", "fingerprint"), &SentryScope::set_fingerprint);
+	ClassDB::bind_method(D_METHOD("set_attribute", "name", "value"), &SentryScope::set_attribute);
+	ClassDB::bind_method(D_METHOD("add_breadcrumb", "breadcrumb"), &SentryScope::add_breadcrumb);
+	ClassDB::bind_method(D_METHOD("clear"), &SentryScope::clear);
+}
+
+SentryScope::SentryScope() {
+	_impl = INTERNAL_SDK()->create_scope();
+}
+
+SentryScope::SentryScope(SentryScopeImpl *p_impl) :
+		_impl(p_impl) {
+}
+
+SentryScope::~SentryScope() {
+	memdelete(_impl);
+}
+
+} //namespace sentry

--- a/src/sentry/sentry_scope.h
+++ b/src/sentry/sentry_scope.h
@@ -4,6 +4,7 @@
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_scope_impl.h"
 #include "sentry/sentry_user.h"
+#include "sentry/util/thread_guard.h"
 
 #include <godot_cpp/classes/ref_counted.hpp>
 #include <godot_cpp/variant/variant.hpp>
@@ -19,6 +20,8 @@ class SentryScope : public RefCounted {
 
 private:
 	SentryScopeImpl *_impl;
+
+	SENTRY_THREAD_OWNER;
 
 protected:
 	static void _bind_methods();

--- a/src/sentry/sentry_scope.h
+++ b/src/sentry/sentry_scope.h
@@ -28,7 +28,7 @@ public:
 	void set_tag(const String &p_key, const String &p_value);
 	void set_user(const Ref<SentryUser> &p_user);
 	void set_level(sentry::Level p_level);
-	void set_fingerprint(PackedStringArray p_fingerprint);
+	void set_fingerprint(const PackedStringArray &p_fingerprint);
 	void set_attribute(const String &p_name, const Variant &p_value);
 	void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
 	void clear();

--- a/src/sentry/sentry_scope.h
+++ b/src/sentry/sentry_scope.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "sentry/level.h"
+#include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_scope_impl.h"
+#include "sentry/sentry_user.h"
+
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+using namespace godot;
+
+namespace sentry {
+
+// Godot-exported representation of a Sentry scope.
+// Platform-specific behavior is provided by SentryScopeImpl subclasses.
+class SentryScope : public RefCounted {
+	GDCLASS(SentryScope, RefCounted);
+
+private:
+	SentryScopeImpl *_impl;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_context(const String &p_key, const Dictionary &p_value);
+	void set_tag(const String &p_key, const String &p_value);
+	void set_user(const Ref<SentryUser> &p_user);
+	void set_level(sentry::Level p_level);
+	void set_fingerprint(PackedStringArray p_fingerprint);
+	void set_attribute(const String &p_name, const Variant &p_value);
+	void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
+	void clear();
+
+	Ref<SentryScope> clone() const;
+
+	SentryScopeImpl *get_implementation() const { return _impl; }
+
+	SentryScope();
+	SentryScope(SentryScopeImpl *p_impl);
+	~SentryScope();
+};
+
+} //namespace sentry

--- a/src/sentry/sentry_scope_impl.h
+++ b/src/sentry/sentry_scope_impl.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "sentry/level.h"
+#include "sentry/sentry_breadcrumb.h"
+#include "sentry/sentry_user.h"
+
+#include <godot_cpp/classes/ref_counted.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+using namespace godot;
+
+namespace sentry {
+
+// Base class for Sentry scope implementations; see Godot-facing SentryScope.
+// Splitting the implementation from SentryScope avoids a factory method
+// (i.e. SentryScope.create() or SentrySDK.create_scope()).
+// Kept as a pure C++ class instead of a Godot class to avoid ClassDB
+// registration and reduce overhead.
+// Lifetime governed by SentryScope.
+class SentryScopeImpl {
+public:
+	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
+	virtual void set_tag(const String &p_key, const String &p_value) = 0;
+	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
+	virtual void set_level(sentry::Level p_level) = 0;
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) = 0;
+	virtual void set_attribute(const String &p_name, const Variant &p_value) = 0;
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
+	virtual void clear() = 0;
+	virtual SentryScopeImpl *clone() const = 0;
+
+	virtual ~SentryScopeImpl() = default;
+};
+
+} //namespace sentry

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -572,6 +572,7 @@ void SentrySDK::_notification(int p_what) {
 				OS::get_singleton()->remove_logger(godot_logger);
 				godot_logger.unref();
 			}
+			_invalidate_scopes();
 		} break;
 	}
 }
@@ -626,7 +627,8 @@ SentrySDK::SentrySDK() {
 }
 
 SentrySDK::~SentrySDK() {
-	_invalidate_scopes();
+	// At extension unload, the script runtime is gone and _on_engine_shutdown() has already called close() and detached
+	// the logger. Any calls into the SDK from other threads at this point are out of contract and indicate a bug.
 
 	internal_sdk.reset();
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -136,7 +136,7 @@ void SentrySDK::destroy_singleton() {
 
 Variant SentrySDK::with_scope(Callable p_callable) {
 	if (unlikely(!internal_sdk->supports_scopes())) {
-		SENTRY_PRINT_ONCE(sentry::LEVEL_WARNING, "Scopes are not supported on this platform yet - writes to the local scope will be discarded.");
+		WARN_PRINT_ONCE("Sentry: Scopes are not supported on this platform yet - writes to the local scope will be discarded.");
 	}
 
 	Ref<SentryScope> scope = _push_scope();

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -118,6 +118,9 @@ SentrySDK *SentrySDK::singleton = nullptr;
 
 thread_local List<Ref<SentryScope>> SentrySDK::current_scopes;
 
+SafeNumeric<uint32_t> SentrySDK::scopes_epoch;
+thread_local uint32_t SentrySDK::local_scopes_epoch = 0;
+
 void SentrySDK::create_singleton() {
 	ERR_FAIL_NULL(Engine::get_singleton());
 	singleton = memnew(SentrySDK);
@@ -132,6 +135,10 @@ void SentrySDK::destroy_singleton() {
 	Engine::get_singleton()->unregister_singleton("SentrySDK");
 	memdelete(singleton);
 	singleton = nullptr;
+}
+
+void SentrySDK::_invalidate_scopes() {
+	scopes_epoch.increment();
 }
 
 Variant SentrySDK::with_scope(Callable p_callable) {
@@ -198,7 +205,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 		options->add_default_attachment(att);
 	}
 
-	current_scopes.clear();
+	_invalidate_scopes();
 
 	sentry::logging::print_debug("Initializing Sentry SDK");
 	internal_sdk->init();
@@ -247,7 +254,7 @@ void SentrySDK::close() {
 			godot_logger.unref();
 		}
 		internal_sdk->close();
-		current_scopes.clear();
+		_invalidate_scopes();
 	}
 }
 
@@ -604,8 +611,8 @@ SentrySDK::SentrySDK() {
 }
 
 SentrySDK::~SentrySDK() {
-	// Release scopes before the internal SDK, as scopes may depend on SDK-owned resources.
 	current_scopes.clear();
+	_invalidate_scopes();
 
 	internal_sdk.reset();
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -252,7 +252,7 @@ String SentrySDK::capture_message(const String &p_message, Level p_level) {
 	Ref<SentryEvent> event = internal_sdk->create_event();
 	event->set_message(p_message);
 	event->set_level(p_level);
-	return internal_sdk->capture_event(event, get_current_scope());
+	return internal_sdk->capture_event(get_current_scope(), event);
 }
 
 void SentrySDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
@@ -273,7 +273,7 @@ Ref<SentryEvent> SentrySDK::create_event() const {
 
 String SentrySDK::capture_event(const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), "", "Sentry: Can't capture event - event object is null.");
-	return internal_sdk->capture_event(p_event, get_current_scope());
+	return internal_sdk->capture_event(get_current_scope(), p_event);
 }
 
 void SentrySDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -116,6 +116,8 @@ namespace sentry {
 
 SentrySDK *SentrySDK::singleton = nullptr;
 
+thread_local List<Ref<SentryScope>> SentrySDK::current_scopes;
+
 void SentrySDK::create_singleton() {
 	ERR_FAIL_NULL(Engine::get_singleton());
 	singleton = memnew(SentrySDK);
@@ -130,6 +132,22 @@ void SentrySDK::destroy_singleton() {
 	Engine::get_singleton()->unregister_singleton("SentrySDK");
 	memdelete(singleton);
 	singleton = nullptr;
+}
+
+Variant SentrySDK::with_scope(Callable p_callable) {
+	if (unlikely(!internal_sdk->supports_scopes())) {
+		SENTRY_PRINT_ONCE(sentry::LEVEL_WARNING, "Scopes are not supported on this platform yet - writes to the local scope will be discarded.");
+	}
+
+	Ref<SentryScope> scope = _push_scope();
+	Variant result = p_callable.call(scope);
+	if (Object *obj = result.get_validated_object();
+			unlikely(obj != nullptr && obj->get_class() == "GDScriptFunctionState")) {
+		obj->connect(SN_COMPLETED, callable_mp(this, &SentrySDK::_pop_scope).bind(scope).unbind(1));
+	} else {
+		_pop_scope(scope);
+	}
+	return result;
 }
 
 void SentrySDK::init(const Callable &p_configuration_callback) {
@@ -176,6 +194,8 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 	for (const Ref<SentryAttachment> &att : _get_default_attachments()) {
 		options->add_default_attachment(att);
 	}
+
+	current_scopes.clear();
 
 	sentry::logging::print_debug("Initializing Sentry SDK");
 	internal_sdk->init();
@@ -224,11 +244,15 @@ void SentrySDK::close() {
 			godot_logger.unref();
 		}
 		internal_sdk->close();
+		current_scopes.clear();
 	}
 }
 
 String SentrySDK::capture_message(const String &p_message, Level p_level) {
-	return internal_sdk->capture_message(p_message, p_level);
+	Ref<SentryEvent> event = internal_sdk->create_event();
+	event->set_message(p_message);
+	event->set_level(p_level);
+	return internal_sdk->capture_event(event, get_current_scope());
 }
 
 void SentrySDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
@@ -249,7 +273,7 @@ Ref<SentryEvent> SentrySDK::create_event() const {
 
 String SentrySDK::capture_event(const Ref<SentryEvent> &p_event) {
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), "", "Sentry: Can't capture event - event object is null.");
-	return internal_sdk->capture_event(p_event);
+	return internal_sdk->capture_event(p_event, get_current_scope());
 }
 
 void SentrySDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
@@ -258,7 +282,7 @@ void SentrySDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {
 	if (p_feedback->get_message().length() > 4096) {
 		WARN_PRINT("Sentry: Feedback message is too long (max 4096 characters).");
 	}
-	return internal_sdk->capture_feedback(p_feedback);
+	return internal_sdk->capture_feedback(get_current_scope(), p_feedback);
 }
 
 void SentrySDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -553,6 +577,9 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_attribute", "name", "value"), &SentrySDK::set_attribute);
 	ClassDB::bind_method(D_METHOD("remove_attribute", "name"), &SentrySDK::remove_attribute);
 
+	ClassDB::bind_method(D_METHOD("get_current_scope"), &SentrySDK::get_current_scope);
+	ClassDB::bind_method(D_METHOD("with_scope", "callable"), &SentrySDK::with_scope);
+
 	// Hidden API methods -- used in testing.
 	ClassDB::bind_method(D_METHOD("_set_before_send", "callable"), &SentrySDK::set_before_send);
 	ClassDB::bind_method(D_METHOD("_unset_before_send"), &SentrySDK::unset_before_send);
@@ -563,7 +590,8 @@ void SentrySDK::_bind_methods() {
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "bad_code", PROPERTY_HINT_TYPE_STRING, "SentryBadCode", PROPERTY_USAGE_NONE), get_bad_code);
 }
 
-SentrySDK::SentrySDK() {
+SentrySDK::SentrySDK() :
+		SN_COMPLETED(StringName("completed")) {
 	ERR_FAIL_NULL(OS::get_singleton());
 
 	options = SentryOptions::create_from_project_settings();
@@ -574,6 +602,9 @@ SentrySDK::SentrySDK() {
 }
 
 SentrySDK::~SentrySDK() {
+	// Release scopes before the internal SDK, as scopes may depend on SDK-owned resources.
+	current_scopes.clear();
+
 	internal_sdk.reset();
 
 	singleton = nullptr;

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -136,17 +136,20 @@ void SentrySDK::destroy_singleton() {
 
 Variant SentrySDK::with_scope(Callable p_callable) {
 	if (unlikely(!internal_sdk->supports_scopes())) {
-		WARN_PRINT_ONCE("Sentry: Scopes are not supported on this platform yet - writes to the local scope will be discarded.");
+		WARN_PRINT_ONCE("Sentry: Scopes are not supported on this platform yet - writes to the scope will be discarded.");
 	}
 
 	Ref<SentryScope> scope = _push_scope();
 	Variant result = p_callable.call(scope);
-	if (Object *obj = result.get_validated_object();
-			unlikely(obj != nullptr && obj->get_class() == "GDScriptFunctionState")) {
-		obj->connect(SN_COMPLETED, callable_mp(this, &SentrySDK::_pop_scope).bind(scope).unbind(1));
-	} else {
-		_pop_scope(scope);
+	static bool first_warning = true;
+	if (first_warning) {
+		if (Object *obj = result.get_validated_object();
+				unlikely(obj != nullptr && obj->get_class() == "GDScriptFunctionState")) {
+			first_warning = false;
+			WARN_PRINT("Sentry: with_scope() does not support await - the scope is only active until the first await.");
+		}
 	}
+	_pop_scope(scope);
 	return result;
 }
 
@@ -590,8 +593,7 @@ void SentrySDK::_bind_methods() {
 	BIND_PROPERTY_READONLY(SentrySDK, PropertyInfo(Variant::OBJECT, "bad_code", PROPERTY_HINT_TYPE_STRING, "SentryBadCode", PROPERTY_USAGE_NONE), get_bad_code);
 }
 
-SentrySDK::SentrySDK() :
-		SN_COMPLETED(StringName("completed")) {
+SentrySDK::SentrySDK() {
 	ERR_FAIL_NULL(OS::get_singleton());
 
 	options = SentryOptions::create_from_project_settings();

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -156,7 +156,7 @@ Ref<SentryScope> SentrySDK::get_current_scope() const {
 	return current_scopes.back()->get();
 }
 
-Variant SentrySDK::with_scope(Callable p_callable) {
+Variant SentrySDK::with_scope(const Callable &p_callable) {
 	if (unlikely(!internal_sdk->supports_scopes())) {
 		WARN_PRINT_ONCE("Sentry: Scopes are not supported on this platform yet - writes to the scope will be discarded.");
 	}

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -139,6 +139,21 @@ void SentrySDK::destroy_singleton() {
 
 void SentrySDK::_invalidate_scopes() {
 	scopes_epoch.increment();
+	current_scopes.clear();
+}
+
+Ref<SentryScope> SentrySDK::get_current_scope() const {
+	uint32_t epoch = scopes_epoch.get();
+	if (unlikely(local_scopes_epoch != epoch)) {
+		current_scopes.clear();
+		local_scopes_epoch = epoch;
+	}
+
+	if (current_scopes.is_empty()) {
+		current_scopes.push_back(Ref<SentryScope>(memnew(SentryScope)));
+	}
+
+	return current_scopes.back()->get();
 }
 
 Variant SentrySDK::with_scope(Callable p_callable) {
@@ -611,7 +626,6 @@ SentrySDK::SentrySDK() {
 }
 
 SentrySDK::~SentrySDK() {
-	current_scopes.clear();
 	_invalidate_scopes();
 
 	internal_sdk.reset();

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -11,6 +11,7 @@
 #include "sentry/sentry_logger.h"
 #include "sentry/sentry_metrics.h"
 #include "sentry/sentry_options.h"
+#include "sentry/sentry_scope.h"
 
 #include <godot_cpp/classes/mutex.hpp>
 #include <godot_cpp/core/object.hpp>
@@ -39,6 +40,10 @@ public:
 private:
 	static SentrySDK *singleton;
 
+	static thread_local List<Ref<SentryScope>> current_scopes;
+
+	const StringName SN_COMPLETED;
+
 	Ref<SentryOptions> options;
 	std::unique_ptr<sentry::InternalSDK> internal_sdk;
 	Ref<RuntimeConfig> runtime_config;
@@ -58,6 +63,9 @@ private:
 	Vector<Ref<SentryAttachment>> _get_default_attachments();
 	void _auto_initialize();
 	void _on_engine_shutdown();
+
+	_FORCE_INLINE_ Ref<SentryScope> _push_scope() { return current_scopes.push_back(Ref<SentryScope>(get_current_scope()->clone()))->get(); }
+	_FORCE_INLINE_ void _pop_scope(const Ref<SentryScope> &p_scope) { current_scopes.erase(p_scope); }
 
 protected:
 	static void _bind_methods();
@@ -108,6 +116,17 @@ public:
 
 	void set_attribute(const String &p_name, const Variant &p_value);
 	void remove_attribute(const String &p_name);
+
+	// * Scopes
+
+	_FORCE_INLINE_ Ref<SentryScope> get_current_scope() const {
+		if (current_scopes.is_empty()) {
+			current_scopes.push_back(Ref<SentryScope>(memnew(SentryScope)));
+		}
+		return current_scopes.back()->get();
+	}
+
+	Variant with_scope(Callable p_callable);
 
 	// * Hidden API methods -- used in testing
 

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -42,8 +42,6 @@ private:
 
 	static thread_local List<Ref<SentryScope>> current_scopes;
 
-	const StringName SN_COMPLETED;
-
 	Ref<SentryOptions> options;
 	std::unique_ptr<sentry::InternalSDK> internal_sdk;
 	Ref<RuntimeConfig> runtime_config;

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -127,19 +127,7 @@ public:
 
 	// * Scopes
 
-	_FORCE_INLINE_ Ref<SentryScope> get_current_scope() const {
-		uint32_t epoch = scopes_epoch.get();
-		if (unlikely(local_scopes_epoch != epoch)) {
-			current_scopes.clear();
-			local_scopes_epoch = epoch;
-		}
-
-		if (current_scopes.is_empty()) {
-			current_scopes.push_back(Ref<SentryScope>(memnew(SentryScope)));
-		}
-
-		return current_scopes.back()->get();
-	}
+	Ref<SentryScope> get_current_scope() const;
 
 	Variant with_scope(Callable p_callable);
 

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -15,6 +15,7 @@
 
 #include <godot_cpp/classes/mutex.hpp>
 #include <godot_cpp/core/object.hpp>
+#include <godot_cpp/templates/safe_refcount.hpp>
 #include <memory>
 
 using namespace godot;
@@ -40,7 +41,13 @@ public:
 private:
 	static SentrySDK *singleton;
 
+	// Scopes are thread-local. _push_scope() scopes are removed by _pop_scope(),
+	// but each thread's lazily-created root scope lives until the thread exits or
+	// the SDK is reinitialized/closed. init() and close() bump a global epoch so
+	// threads can detect and discard stale scope stacks on next access.
 	static thread_local List<Ref<SentryScope>> current_scopes;
+	static SafeNumeric<uint32_t> scopes_epoch;
+	static thread_local uint32_t local_scopes_epoch;
 
 	Ref<SentryOptions> options;
 	std::unique_ptr<sentry::InternalSDK> internal_sdk;
@@ -61,6 +68,9 @@ private:
 	Vector<Ref<SentryAttachment>> _get_default_attachments();
 	void _auto_initialize();
 	void _on_engine_shutdown();
+
+	// Marks every thread's scope stack as stale.
+	void _invalidate_scopes();
 
 	_FORCE_INLINE_ Ref<SentryScope> _push_scope() { return current_scopes.push_back(Ref<SentryScope>(get_current_scope()->clone()))->get(); }
 	_FORCE_INLINE_ void _pop_scope(const Ref<SentryScope> &p_scope) { current_scopes.erase(p_scope); }
@@ -118,9 +128,16 @@ public:
 	// * Scopes
 
 	_FORCE_INLINE_ Ref<SentryScope> get_current_scope() const {
+		uint32_t epoch = scopes_epoch.get();
+		if (unlikely(local_scopes_epoch != epoch)) {
+			current_scopes.clear();
+			local_scopes_epoch = epoch;
+		}
+
 		if (current_scopes.is_empty()) {
 			current_scopes.push_back(Ref<SentryScope>(memnew(SentryScope)));
 		}
+
 		return current_scopes.back()->get();
 	}
 

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -129,7 +129,7 @@ public:
 
 	Ref<SentryScope> get_current_scope() const;
 
-	Variant with_scope(Callable p_callable);
+	Variant with_scope(const Callable &p_callable);
 
 	// * Hidden API methods -- used in testing
 

--- a/src/sentry/util/thread_guard.h
+++ b/src/sentry/util/thread_guard.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/core/error_macros.hpp>
+
+namespace sentry::util {
+
+// Records the constructing thread so methods can reject calls from other threads.
+// Declare with SENTRY_THREAD_OWNER and guard methods with ERR_SENTRY_THREAD_GUARD.
+class ThreadOwner {
+private:
+	uint64_t _owner_tid = ::godot::OS::get_singleton()->get_thread_caller_id();
+
+public:
+	_FORCE_INLINE_ bool is_owner_thread() const {
+		return _owner_tid == ::godot::OS::get_singleton()->get_thread_caller_id();
+	}
+};
+
+} //namespace sentry::util
+
+// Declares the thread-owner member. Add to the private section of the guarded class.
+#define SENTRY_THREAD_OWNER ::sentry::util::ThreadOwner _thread_owner
+
+// Rejects the call with m_msg if it comes from a thread other than the one that
+// constructed the object. Requires SENTRY_THREAD_OWNER in the class.
+#define ERR_SENTRY_THREAD_GUARD(m_msg) ERR_FAIL_COND_MSG(!_thread_owner.is_owner_thread(), m_msg)
+
+// Same as ERR_SENTRY_THREAD_GUARD, but returns m_ret from methods that have a return value.
+#define ERR_SENTRY_THREAD_GUARD_V(m_ret, m_msg) ERR_FAIL_COND_V_MSG(!_thread_owner.is_owner_thread(), m_ret, m_msg)


### PR DESCRIPTION
Add current scope support to the GDScript API, so enrichment can apply only to the telemetry captured while a scope is active. Until now everything set from GDScript was global, and a tag set for one part of a game stayed on every event captured afterwards. `SentrySDK.with_scope()` forks the current scope active on the calling thread, hands the fork to a callable, and discards it when the callable returns, so writes never leak past the block or into another thread. `SentrySDK.get_current_scope()` reaches the currently active scope on the calling thread directly. The new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes. The top-level `SentrySDK.capture_event()`, `capture_message()`, and `capture_feedback()`, along with `SentrySDK.logger` and `SentrySDK.metrics`, take the current scope into account on their own, as do the errors, warnings, and logs the SDK picks up automatically from Godot's logging. Crash reports are the exception, since the out-of-process handler only sees state flushed from the global scope.

```gdscript
SentrySDK.with_scope(func(scope: SentryScope):
	scope.set_context("chunk", {"x": chunk_x, "y": chunk_y, "seed": world_seed})
	generate_chunk(chunk_x, chunk_y)
)
```

- Refs #188
- Stacked follow-ups: 
  - https://github.com/getsentry/sentry-godot/pull/835
  - https://github.com/getsentry/sentry-godot/pull/836
- Cocoa depends on https://github.com/getsentry/sentry-cocoa/issues/8540
- Docs https://github.com/getsentry/sentry-docs/pull/18930
- Supersedes #807

The [Scopes spec](https://develop.sentry.dev/sdk/foundations/state-management/scopes/) defines three layers: global, isolation, and current. This PR implements two of them. The top-level `SentrySDK` setters write to the global scope, which applies to everything the process captures, while `with_scope()` and `get_current_scope()` operate on the current scope, which is per thread and lives only for the capturing block (`with_scope` currently). Both merge into each captured item, so precedence runs like this: telemetry item, then current scope, then global. The spec puts the top-level setters on the isolation scope rather than global, but that layer is deferred for now, since it needs strong support in the underlying SDKs.

Scope support is temporarily a per-backend capability, so this PR implements it for the native backend only, covering Windows and Linux. The other backends keep capturing telemetry, but discard the local scope data, and warn once. Android (#835) and WebAssembly (#836) are stacked on top of this PR, and macOS and iOS wait on getsentry/sentry-cocoa#8540.
