### PR TITLE
feat(scopes): Support scopes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834))
+- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
-  - Only supported on Windows and Linux for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
+  - Only supported on Windows, Linux, and Android for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
 
 ### Dependencies
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -940,7 +940,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
 
     @UsedByGodot
     fun scopeClear(handle: Int) {
-        getScope(handle)?.clear()
+        val scope = getScope(handle) ?: return
+        scope.clear()
+        // WORKAROUND: Scope.clear() leaves contexts in place, so drop them here to match the other platforms.
+        for (key in scope.contexts.entrySet().map { it.key }) {
+            scope.removeContexts(key)
+        }
     }
 
     @UsedByGodot

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -496,7 +496,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureEvent(eventHandle: Int, scopeHandle: Int): String {
+    fun captureEvent(scopeHandle: Int, eventHandle: Int): String {
         val event: SentryEvent = getEvent(eventHandle) ?: run {
             Log.e(TAG, "Failed to capture event: $eventHandle")
             return ""
@@ -507,7 +507,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureFeedback(message: String, contactEmail: String, name: String, associatedEventId: String, scopeHandle: Int) {
+    fun captureFeedback(scopeHandle: Int, message: String, contactEmail: String, name: String, associatedEventId: String) {
         val feedback = Feedback(message)
         feedback.contactEmail = contactEmail.ifEmpty { null }
         feedback.name = name.ifEmpty { null }

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -127,8 +127,9 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     // Returns combined scopes by the given scope handle (scope is owned by C++ layer).
-    // This layers the current scope over the global and isolation scopes,
-    // so scope attributes and trace changes are reflected per capture.
+    // This layers the current scope over the global and isolation scopes, so scope data applies per capture.
+    // The trace is not layered: sentry-java resolves the propagation context through defaultScopeType, which we pin
+    // to GLOBAL, so captures stay on the trace setTrace wrote there and a blank local scope never forks it.
     private fun combinedScopes(scopeHandle: Int): IScopes? {
         if (!Sentry.isEnabled()) {
             return null

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -4,8 +4,13 @@ import android.util.Log
 import io.sentry.Attachment
 import io.sentry.Breadcrumb
 import io.sentry.Hint
+import io.sentry.IScope
+import io.sentry.IScopes
 import io.sentry.ISerializer
 import io.sentry.JsonUnknown
+import io.sentry.Scope
+import io.sentry.ScopeType
+import io.sentry.Scopes
 import io.sentry.Sentry
 import io.sentry.SentryAttributes
 import io.sentry.SentryEvent
@@ -17,7 +22,9 @@ import io.sentry.SentryMetricsEvent
 import io.sentry.SentryOptions
 import io.sentry.android.core.InternalSentrySdk
 import io.sentry.android.core.SentryAndroid
+import io.sentry.logger.ILoggerApi
 import io.sentry.logger.SentryLogParameters
+import io.sentry.metrics.IMetricsApi
 import io.sentry.metrics.SentryMetricsParameters
 import io.sentry.protocol.Feedback
 import io.sentry.protocol.Message
@@ -67,6 +74,18 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         }
     }
 
+    private val scopesByHandle = object : ThreadLocal<MutableMap<Int, IScope>>() {
+        override fun initialValue(): MutableMap<Int, IScope> {
+            return mutableMapOf()
+        }
+    }
+
+    private val combinedScopesByHandle = object : ThreadLocal<MutableMap<Int, IScopes>>() {
+        override fun initialValue(): MutableMap<Int, IScopes> {
+            return mutableMapOf()
+        }
+    }
+
     private fun getEvent(eventHandle: Int): SentryEvent? {
         val event: SentryEvent? = eventsByHandle.get()?.get(eventHandle)
         if (event == null) {
@@ -97,6 +116,39 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             Log.e(TAG, "Internal Error -- SentryMetricsEvent not found: $metricHandle")
         }
         return metricEvent
+    }
+
+    private fun getScope(scopeHandle: Int): IScope? {
+        val scope: IScope? = scopesByHandle.get()?.get(scopeHandle)
+        if (scope == null) {
+            Log.e(TAG, "Internal Error -- Scope not found: $scopeHandle")
+        }
+        return scope
+    }
+
+    // Returns combined scopes by the given scope handle (scope is owned by C++ layer).
+    // This layers the current scope over the global and isolation scopes,
+    // so scope attributes and trace changes are reflected per capture.
+    private fun combinedScopes(scopeHandle: Int): IScopes? {
+        if (!Sentry.isEnabled()) {
+            return null
+        }
+        val local = getScope(scopeHandle) ?: return null
+        val cache = combinedScopesByHandle.get()
+        cache?.get(scopeHandle)?.let { return it }
+        val scopes = Sentry.getCurrentScopes()
+        val combined =
+            Scopes(local, scopes.isolationScope, scopes.globalScope, "SentryAndroidGodotPlugin.combinedScopes")
+        cache?.put(scopeHandle, combined)
+        return combined
+    }
+
+    private fun scopedMetrics(scopeHandle: Int): IMetricsApi {
+        return combinedScopes(scopeHandle)?.metrics() ?: Sentry.metrics()
+    }
+
+    private fun scopedLogger(scopeHandle: Int): ILoggerApi {
+        return combinedScopes(scopeHandle)?.logger() ?: Sentry.logger()
     }
 
     private fun registerEvent(event: SentryEvent): Int {
@@ -159,6 +211,21 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         return handle
     }
 
+    private fun registerScope(scope: IScope): Int {
+        val scopesMap = scopesByHandle.get() ?: run {
+            Log.e(TAG, "Internal Error -- scopesByHandle is null")
+            return 0
+        }
+
+        var handle = Random.nextInt()
+        while (handle == 0 || scopesMap.containsKey(handle)) {
+            handle = Random.nextInt()
+        }
+
+        scopesMap[handle] = scope
+        return handle
+    }
+
     override fun getPluginName(): String {
         return "SentryAndroidGodotPlugin"
     }
@@ -204,6 +271,11 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.isAttachAnrThreadDump = attachAnrThreadDump
                 options.shutdownTimeoutMillis = shutdownTimeoutMs
                 options.isTombstoneEnabled = true
+                // Android top-level API writes to current scope by default.
+                // Re-route it to global scope so Sentry.setTag/setUser/addBreadcrumb and the automatic integration
+                // breadcrumbs land on the process-wide, native-synced global scope. Our layer owns the current slot for
+                // local (with_scope) data, and captures merge global + local.
+                options.defaultScopeType = ScopeType.GLOBAL
                 options.beforeSend =
                     SentryOptions.BeforeSendCallback { event: SentryEvent, hint: Hint ->
                         Log.v(TAG, "beforeSend: ${event.eventId} isCrashed: ${event.isCrashed}")
@@ -323,12 +395,13 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun log(level: Int, body: String, attributes: Dictionary) {
+    fun log(scopeHandle: Int, level: Int, body: String, attributes: Dictionary) {
+        val logger = scopedLogger(scopeHandle)
         if (attributes.isEmpty()) {
-            Sentry.logger().log(level.toSentryLogLevel(), body)
+            logger.log(level.toSentryLogLevel(), body)
         } else {
             val sentryAttributes = SentryAttributes.fromMap(attributes)
-            Sentry.logger().log(
+            logger.log(
                 level.toSentryLogLevel(),
                 SentryLogParameters.create(sentryAttributes),
                 body
@@ -337,33 +410,35 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun metricsAddCount(name: String, value: Long, attributes: Dictionary) {
+    fun metricsAddCount(scopeHandle: Int, name: String, value: Long, attributes: Dictionary) {
+        val metrics = scopedMetrics(scopeHandle)
         if (attributes.isEmpty()) {
-            Sentry.metrics().count(name, value.toDouble())
+            metrics.count(name, value.toDouble())
         } else {
             val sentryAttributes = SentryAttributes.fromMap(attributes)
-            Sentry.metrics().count(name, value.toDouble(), null, SentryMetricsParameters.create(sentryAttributes))
+            metrics.count(name, value.toDouble(), null, SentryMetricsParameters.create(sentryAttributes))
         }
     }
 
     @UsedByGodot
-    fun metricsAddGauge(name: String, value: Double, unit: String, attributes: Dictionary) {
+    fun metricsAddGauge(scopeHandle: Int, name: String, value: Double, unit: String, attributes: Dictionary) {
+        val metrics = scopedMetrics(scopeHandle)
         if (attributes.isEmpty()) {
-            Sentry.metrics().gauge(name, value, unit.ifEmpty { null })
+            metrics.gauge(name, value, unit.ifEmpty { null })
         } else {
             val sentryAttributes = SentryAttributes.fromMap(attributes)
-            Sentry.metrics().gauge(name, value, unit.ifEmpty { null }, SentryMetricsParameters.create(sentryAttributes))
+            metrics.gauge(name, value, unit.ifEmpty { null }, SentryMetricsParameters.create(sentryAttributes))
         }
     }
 
     @UsedByGodot
-    fun metricsAddDistribution(name: String, value: Double, unit: String, attributes: Dictionary) {
+    fun metricsAddDistribution(scopeHandle: Int, name: String, value: Double, unit: String, attributes: Dictionary) {
+        val metrics = scopedMetrics(scopeHandle)
         if (attributes.isEmpty()) {
-            Sentry.metrics().distribution(name, value, unit.ifEmpty { null })
+            metrics.distribution(name, value, unit.ifEmpty { null })
         } else {
             val sentryAttributes = SentryAttributes.fromMap(attributes)
-            Sentry.metrics()
-                .distribution(name, value, unit.ifEmpty { null }, SentryMetricsParameters.create(sentryAttributes))
+            metrics.distribution(name, value, unit.ifEmpty { null }, SentryMetricsParameters.create(sentryAttributes))
         }
     }
 
@@ -420,24 +495,26 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureEvent(eventHandle: Int): String {
+    fun captureEvent(eventHandle: Int, scopeHandle: Int): String {
         val event: SentryEvent = getEvent(eventHandle) ?: run {
             Log.e(TAG, "Failed to capture event: $eventHandle")
             return ""
         }
-        val id = Sentry.captureEvent(event)
+        val scopes = combinedScopes(scopeHandle)
+        val id = scopes?.captureEvent(event) ?: Sentry.captureEvent(event)
         return id.toString()
     }
 
     @UsedByGodot
-    fun captureFeedback(message: String, contactEmail: String, name: String, associatedEventId: String) {
+    fun captureFeedback(message: String, contactEmail: String, name: String, associatedEventId: String, scopeHandle: Int) {
         val feedback = Feedback(message)
         feedback.contactEmail = contactEmail.ifEmpty { null }
         feedback.name = name.ifEmpty { null }
         if (associatedEventId.isNotEmpty()) {
             feedback.setAssociatedEventId(SentryId(associatedEventId))
         }
-        Sentry.feedback().capture(feedback)
+        val feedbackApi = combinedScopes(scopeHandle)?.feedback() ?: Sentry.feedback()
+        feedbackApi.capture(feedback)
     }
 
     @UsedByGodot
@@ -770,6 +847,99 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     fun breadcrumbGetTimestamp(handle: Int): Long {
         val crumb = getBreadcrumb(handle) ?: return 0
         return crumb.timestamp.toMicros()
+    }
+
+    @UsedByGodot
+    fun createScope(): Int {
+        return registerScope(Scope(Sentry.getCurrentScopes().options))
+    }
+
+    @UsedByGodot
+    fun cloneScope(handle: Int): Int {
+        val scope = getScope(handle) ?: return 0
+        return registerScope(scope.clone())
+    }
+
+    @UsedByGodot
+    fun releaseScope(handle: Int) {
+        scopesByHandle.get()?.remove(handle)
+        combinedScopesByHandle.get()?.remove(handle)
+    }
+
+    @UsedByGodot
+    fun scopeSetContext(handle: Int, key: String, value: Dictionary) {
+        getScope(handle)?.setContexts(key, value)
+    }
+
+    @UsedByGodot
+    fun scopeSetTag(handle: Int, key: String, value: String) {
+        getScope(handle)?.setTag(key, value)
+    }
+
+    @UsedByGodot
+    fun scopeSetUser(handle: Int, id: String, userName: String, email: String, ipAddress: String) {
+        val scope = getScope(handle) ?: return
+        val user = User()
+        if (id.isNotEmpty()) {
+            user.id = id
+        }
+        if (userName.isNotEmpty()) {
+            user.username = userName
+        }
+        if (email.isNotEmpty()) {
+            user.email = email
+        }
+        if (ipAddress.isNotEmpty()) {
+            user.ipAddress = ipAddress
+        }
+        scope.user = user
+    }
+
+    @UsedByGodot
+    fun scopeRemoveUser(handle: Int) {
+        getScope(handle)?.user = null
+    }
+
+    @UsedByGodot
+    fun scopeSetLevel(handle: Int, level: Int) {
+        getScope(handle)?.level = level.toSentryLevel()
+    }
+
+    @UsedByGodot
+    fun scopeSetFingerprint(handle: Int, fingerprint: Array<String>) {
+        getScope(handle)?.fingerprint = fingerprint.toList()
+    }
+
+    @UsedByGodot
+    fun scopeSetAttributeBool(handle: Int, name: String, value: Boolean) {
+        getScope(handle)?.setAttribute(name, value)
+    }
+
+    @UsedByGodot
+    fun scopeSetAttributeLong(handle: Int, name: String, value: Long) {
+        getScope(handle)?.setAttribute(name, value)
+    }
+
+    @UsedByGodot
+    fun scopeSetAttributeDouble(handle: Int, name: String, value: Double) {
+        getScope(handle)?.setAttribute(name, value)
+    }
+
+    @UsedByGodot
+    fun scopeSetAttributeString(handle: Int, name: String, value: String) {
+        getScope(handle)?.setAttribute(name, value)
+    }
+
+    @UsedByGodot
+    fun scopeAddBreadcrumb(scopeHandle: Int, crumbHandle: Int) {
+        val scope = getScope(scopeHandle) ?: return
+        val crumb = getBreadcrumb(crumbHandle) ?: return
+        scope.addBreadcrumb(crumb)
+    }
+
+    @UsedByGodot
+    fun scopeClear(handle: Int) {
+        getScope(handle)?.clear()
     }
 
     @UsedByGodot

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -77,7 +77,7 @@
 			<description>
 				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
 				The returned scope belongs to the calling thread. Data written to it enriches only the telemetry captured on that thread, and modifying it from another thread is not supported. See [SentryScope] for details. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
-				[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the returned scope.
+				[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the returned scope.
 			</description>
 		</method>
 		<method name="get_last_event_id" qualifiers="const">
@@ -209,7 +209,7 @@
 				Writes made through [SentrySDK] methods such as [method SentrySDK.set_tag] still apply globally, even when called inside the callable.
 				For more information, see [SentryScope] class.
 				[b]Note:[/b] The fork covers the synchronous part of [param callable] only. If the callable awaits, the fork is discarded at the first [code]await[/code] and a warning is printed.
-				[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
+				[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -14,7 +14,7 @@
 		)
 		[/codeblock]
 		[b]Note:[/b] A scope is thread-local. Modify a scope only from the thread that created it. If a scope is modified from another thread, the SDK rejects the call with an error and discards the data. To enrich telemetry captured on another thread, get that thread's current scope with [method SentrySDK.get_current_scope], or use [SentrySDK] methods such as [method SentrySDK.set_tag] to enrich telemetry captured on all threads.
-		[b]Note:[/b] The SDK supports scopes on Windows and Linux only for now. On the other platforms it still captures telemetry, but discards the data written to the scope.
+		[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the scope.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -170,7 +170,7 @@ func test_before_send_metric_discard() -> void:
 
 
 # TODO: remove skip when implemented on other platforms
-func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux"]) -> void:
+func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.set_attribute("from_global", "global")
 	SentrySDK.set_attribute("scope_over_global", "global")
 	SentrySDK.set_attribute("metric_over_all", "global")

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -202,3 +202,22 @@ func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows
 		assert_str(metric.get_attribute("scope_over_global")).is_equal("global")
 	, CONNECT_ONE_SHOT)
 	SentrySDK.metrics.count("metric_after_scope")
+
+
+# TODO: remove skip when implemented on other platforms
+func test_metric_with_scope_attribute_types(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
+	SentrySDK.with_scope(func(scope: SentryScope):
+		scope.set_attribute("level", "forest")
+		scope.set_attribute("enemy_id", 42)
+		scope.set_attribute("health", 10.5)
+		scope.set_attribute("elite", false)
+
+		metric_processed.connect(func(metric: SentryMetric):
+			assert_str(metric.get_attribute("level")).is_equal("forest")
+			assert_int(metric.get_attribute("enemy_id")).is_equal(42)
+			assert_float(metric.get_attribute("health")).is_equal_approx(10.5, 0.001)
+			assert_bool(metric.get_attribute("elite")).is_equal(false)
+		, CONNECT_ONE_SHOT)
+
+		SentrySDK.metrics.count("scoped_metric_types")
+	)

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -199,7 +199,7 @@ func test_structured_logs_with_global_attributes(_do_skip = OS.get_name() == "We
 
 
 # TODO: remove skip when implemented on other platforms
-func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux"]) -> void:
+func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.set_attribute("from_global", "global")
 	SentrySDK.set_attribute("scope_over_global", "global")
 	SentrySDK.set_attribute("log_over_all", "global")

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -250,3 +250,17 @@ func test_structured_logs_with_scope_attribute_types(_do_skip = OS.get_name() no
 
 		SentrySDK.logger.info("Test with scope attribute types")
 	)
+
+
+# TODO: remove skip when implemented on other platforms
+func test_structured_logs_scope_clear_drops_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
+	SentrySDK.with_scope(func(scope: SentryScope):
+		scope.set_attribute("before_clear", "value")
+		scope.clear()
+
+		log_processed.connect(func(entry: SentryLog):
+			assert_that(entry.get_attribute("before_clear")).is_null()
+		, CONNECT_ONE_SHOT)
+
+		SentrySDK.logger.info("Test after scope clear")
+	)

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -231,3 +231,22 @@ func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in 
 		assert_str(entry.get_attribute("scope_over_global")).is_equal("global")
 	, CONNECT_ONE_SHOT)
 	SentrySDK.logger.info("Test after scope is popped")
+
+
+# TODO: remove skip when implemented on other platforms
+func test_structured_logs_with_scope_attribute_types(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
+	SentrySDK.with_scope(func(scope: SentryScope):
+		scope.set_attribute("level", "forest")
+		scope.set_attribute("enemy_id", 42)
+		scope.set_attribute("health", 10.5)
+		scope.set_attribute("elite", false)
+
+		log_processed.connect(func(entry: SentryLog):
+			assert_str(entry.get_attribute("level")).is_equal("forest")
+			assert_int(entry.get_attribute("enemy_id")).is_equal(42)
+			assert_float(entry.get_attribute("health")).is_equal_approx(10.5, 0.001)
+			assert_bool(entry.get_attribute("elite")).is_equal(false)
+		, CONNECT_ONE_SHOT)
+
+		SentrySDK.logger.info("Test with scope attribute types")
+	)

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -154,17 +154,60 @@ func test_scoped_add_breadcrumb() -> void:
 func test_scope_clear() -> void:
 	SentrySDK.set_tag("global_tag", "global")
 
+	var cleared_user := SentryUser.new()
+	cleared_user.id = "player_cleared"
+
 	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_context("cleared_scene", {"name": "Dungeon"})
 		scope.set_tag("before_clear", "value")
+		scope.set_user(cleared_user)
+		scope.set_level(SentrySDK.LEVEL_WARNING)
+		scope.set_fingerprint(PackedStringArray(["cleared-group"]))
+		scope.add_breadcrumb(SentryBreadcrumb.create("cleared crumb"))
 		scope.clear()
 		scope.set_tag("after_clear", "value")
 		SentrySDK.capture_event(SentrySDK.create_event())
 		)
 	var json: String = await wait_for_captured_event_json()
 
-	assert_json(json).describe("clear() drops local scope data written before it") \
+	assert_json(json).describe("clear() drops the context written before it") \
+		.at("/") \
+		.must_not_contain("/contexts/cleared_scene") \
+		.verify()
+
+	assert_json(json).describe("clear() drops the tag written before it") \
 		.at("/tags") \
 		.must_not_contain("before_clear") \
+		.verify()
+
+	assert_json(json).describe("clear() drops the user written before it") \
+		.at("/") \
+		.must_not_contain("/user/id", "player_cleared") \
+		.verify()
+
+	assert_json(json).describe("clear() drops the level written before it") \
+		.at("/") \
+		.must_not_contain("/level", "warning") \
+		.verify()
+
+	assert_json(json).describe("clear() drops the fingerprint written before it") \
+		.at("/") \
+		.must_not_contain("/fingerprint/0", "cleared-group") \
+		.verify()
+
+	assert_json(json).describe("clear() drops the breadcrumb added before it") \
+		.either() \
+			.at("/") \
+			.must_not_contain("/breadcrumbs") \
+		.or_else() \
+			.at("/breadcrumbs") \
+			.is_null() \
+		.or_else() \
+			.at("/breadcrumbs/") \
+			.with_objects() \
+			.containing("message", "cleared crumb") \
+			.must_selected(0) \
+		.end() \
 		.verify()
 
 	assert_json(json).describe("scope stays usable after clear()") \

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -3,7 +3,7 @@ extends SentryTestSuite
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"],
 		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -3,7 +3,7 @@ extends SentryTestSuite
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"],
 		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 

--- a/src/sentry/android/android_scope.cpp
+++ b/src/sentry/android/android_scope.cpp
@@ -1,0 +1,98 @@
+#include "android_scope.h"
+
+#include "android_breadcrumb.h"
+#include "android_string_names.h"
+#include "android_util.h"
+
+#include <godot_cpp/core/error_macros.hpp>
+
+namespace sentry::android {
+
+void AndroidScope::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(scopeSetContext), handle, p_key, sanitize_variant(p_value));
+}
+
+void AndroidScope::set_tag(const String &p_key, const String &p_value) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(scopeSetTag), handle, p_key, p_value);
+}
+
+void AndroidScope::set_user(const Ref<SentryUser> &p_user) {
+	ERR_FAIL_NULL(android_plugin);
+
+	if (p_user.is_valid()) {
+		android_plugin->call(ANDROID_SN(scopeSetUser), handle,
+				p_user->get_id(),
+				p_user->get_username(),
+				p_user->get_email(),
+				p_user->get_ip_address());
+	} else {
+		android_plugin->call(ANDROID_SN(scopeRemoveUser), handle);
+	}
+}
+
+void AndroidScope::set_level(sentry::Level p_level) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(scopeSetLevel), handle, p_level);
+}
+
+void AndroidScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(scopeSetFingerprint), handle, p_fingerprint);
+}
+
+void AndroidScope::set_attribute(const String &p_name, const Variant &p_value) {
+	ERR_FAIL_NULL(android_plugin);
+
+	// Use a type-specific call path because Godot bindings don't natively support
+	// passing arbitrary object/any values.
+	switch (p_value.get_type()) {
+		case Variant::Type::BOOL: {
+			android_plugin->call(ANDROID_SN(scopeSetAttributeBool), handle, p_name, p_value);
+		} break;
+		case Variant::Type::INT: {
+			android_plugin->call(ANDROID_SN(scopeSetAttributeLong), handle, p_name, p_value);
+		} break;
+		case Variant::Type::FLOAT: {
+			android_plugin->call(ANDROID_SN(scopeSetAttributeDouble), handle, p_name, p_value);
+		} break;
+		case Variant::Type::STRING: {
+			android_plugin->call(ANDROID_SN(scopeSetAttributeString), handle, p_name, p_value);
+		} break;
+		default: {
+			android_plugin->call(ANDROID_SN(scopeSetAttributeString), handle, p_name, p_value.stringify());
+		} break;
+	}
+}
+
+void AndroidScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	ERR_FAIL_NULL(android_plugin);
+	Ref<AndroidBreadcrumb> crumb = p_breadcrumb;
+	ERR_FAIL_COND(crumb.is_null());
+	android_plugin->call(ANDROID_SN(scopeAddBreadcrumb), handle, crumb->get_handle());
+}
+
+void AndroidScope::clear() {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(scopeClear), handle);
+}
+
+SentryScopeImpl *AndroidScope::clone() const {
+	ERR_FAIL_NULL_V(android_plugin, memnew(AndroidScope()));
+	int32_t new_handle = android_plugin->call(ANDROID_SN(cloneScope), handle);
+	return memnew(AndroidScope(android_plugin, new_handle));
+}
+
+AndroidScope::AndroidScope(Object *p_android_plugin, int32_t p_handle) :
+		android_plugin(p_android_plugin), handle(p_handle) {
+	ERR_FAIL_NULL(p_android_plugin);
+}
+
+AndroidScope::~AndroidScope() {
+	if (android_plugin) {
+		android_plugin->call(ANDROID_SN(releaseScope), handle);
+	}
+}
+
+} //namespace sentry::android

--- a/src/sentry/android/android_scope.h
+++ b/src/sentry/android/android_scope.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "sentry/sentry_scope_impl.h"
+
+namespace sentry::android {
+
+class AndroidScope : public SentryScopeImpl {
+private:
+	Object *android_plugin = nullptr;
+	int32_t handle = 0;
+
+public:
+	int32_t get_handle() const { return handle; }
+
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
+	virtual void set_tag(const String &p_key, const String &p_value) override;
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+	virtual void set_level(sentry::Level p_level) override;
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void clear() override;
+	virtual SentryScopeImpl *clone() const override;
+
+	AndroidScope() = default;
+	AndroidScope(Object *p_android_plugin, int32_t p_handle);
+	virtual ~AndroidScope() override;
+};
+
+} //namespace sentry::android

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -181,6 +181,7 @@ void AndroidSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, 
 
 	ERR_FAIL_COND(p_scope.is_null());
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+
 	android_plugin->call(ANDROID_SN(log),
 			android_scope->get_handle(),
 			p_level, p_body, _sanitize_attributes(p_attributes));
@@ -203,10 +204,13 @@ Ref<SentryEvent> AndroidSDK::create_event() {
 String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<SentryEvent> &p_event) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL_V(android_plugin, String());
-	ERR_FAIL_COND_V(p_event.is_null(), String());
+
 	Ref<AndroidEvent> android_event = p_event;
 	ERR_FAIL_COND_V(android_event.is_null(), String());
-	AndroidScope *android_scope = p_scope.is_valid() ? static_cast<AndroidScope *>(p_scope->get_implementation()) : nullptr;
+
+	ERR_FAIL_COND_V(p_scope.is_null(), String());
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+
 	return android_plugin->call(ANDROID_SN(captureEvent),
 			android_event->get_handle(),
 			android_scope ? android_scope->get_handle() : 0);
@@ -215,9 +219,13 @@ String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sent
 void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
+
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
+
+	ERR_FAIL_COND(p_scope.is_null());
 	AndroidScope *android_scope = p_scope.is_valid() ? static_cast<AndroidScope *>(p_scope->get_implementation()) : nullptr;
+
 	android_plugin->call(ANDROID_SN(captureFeedback),
 			p_feedback->get_message(),
 			p_feedback->get_contact_email(),
@@ -255,9 +263,10 @@ void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
-	ERR_FAIL_COND(p_scope.is_null());
 
+	ERR_FAIL_COND(p_scope.is_null());
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+
 	android_plugin->call(ANDROID_SN(metricsAddCount),
 			android_scope->get_handle(),
 			p_name, p_value, _sanitize_attributes(p_attributes));
@@ -266,9 +275,10 @@ void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String
 void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
-	ERR_FAIL_COND(p_scope.is_null());
 
+	ERR_FAIL_COND(p_scope.is_null());
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+
 	android_plugin->call(ANDROID_SN(metricsAddGauge),
 			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
@@ -277,9 +287,10 @@ void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String
 void AndroidSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
-	ERR_FAIL_COND(p_scope.is_null());
 
+	ERR_FAIL_COND(p_scope.is_null());
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+
 	android_plugin->call(ANDROID_SN(metricsAddDistribution),
 			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -23,6 +23,9 @@ using namespace godot;
 
 namespace {
 
+// Sentinel passed in place of a scope handle: the plugin captures with no local scope layered on top.
+constexpr int32_t NO_LOCAL_SCOPE = 0;
+
 inline Variant _as_attribute(const Variant &p_value) {
 	Variant::Type type = p_value.get_type();
 	return (type < Variant::BOOL || type > Variant::STRING) ? (Variant)p_value.stringify() : p_value;
@@ -183,7 +186,7 @@ void AndroidSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, 
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(log),
-			android_scope->get_handle(),
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
 			p_level, p_body, _sanitize_attributes(p_attributes));
 }
 
@@ -213,7 +216,7 @@ String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sent
 
 	return android_plugin->call(ANDROID_SN(captureEvent),
 			android_event->get_handle(),
-			android_scope ? android_scope->get_handle() : 0);
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE);
 }
 
 void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -231,7 +234,7 @@ void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sen
 			p_feedback->get_contact_email(),
 			p_feedback->get_name(),
 			p_feedback->get_associated_event_id(),
-			android_scope ? android_scope->get_handle() : 0);
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE);
 }
 
 void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -268,7 +271,7 @@ void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddCount),
-			android_scope->get_handle(),
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
 			p_name, p_value, _sanitize_attributes(p_attributes));
 }
 
@@ -280,7 +283,7 @@ void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddGauge),
-			android_scope->get_handle(),
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 
@@ -292,7 +295,7 @@ void AndroidSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddDistribution),
-			android_scope->get_handle(),
+			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -4,10 +4,10 @@
 #include "android_event.h"
 #include "android_log.h"
 #include "android_metric.h"
+#include "android_scope.h"
 #include "android_string_names.h"
 #include "android_util.h"
 #include "sentry/common_defs.h"
-#include "sentry/disabled/disabled_scope.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
 #include "sentry/processing/process_log.h"
@@ -179,7 +179,11 @@ void AndroidSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, 
 		return;
 	}
 
-	android_plugin->call(ANDROID_SN(log), p_level, p_body, _sanitize_attributes(p_attributes));
+	ERR_FAIL_COND(p_scope.is_null());
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
+	android_plugin->call(ANDROID_SN(log),
+			android_scope->get_handle(),
+			p_level, p_body, _sanitize_attributes(p_attributes));
 }
 
 String AndroidSDK::get_last_event_id() {
@@ -202,8 +206,10 @@ String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sent
 	ERR_FAIL_COND_V(p_event.is_null(), String());
 	Ref<AndroidEvent> android_event = p_event;
 	ERR_FAIL_COND_V(android_event.is_null(), String());
-	int32_t handle = android_event->get_handle();
-	return android_plugin->call(ANDROID_SN(captureEvent), handle);
+	AndroidScope *android_scope = p_scope.is_valid() ? static_cast<AndroidScope *>(p_scope->get_implementation()) : nullptr;
+	return android_plugin->call(ANDROID_SN(captureEvent),
+			android_event->get_handle(),
+			android_scope ? android_scope->get_handle() : 0);
 }
 
 void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -211,11 +217,13 @@ void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sen
 	ERR_FAIL_NULL(android_plugin);
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
+	AndroidScope *android_scope = p_scope.is_valid() ? static_cast<AndroidScope *>(p_scope->get_implementation()) : nullptr;
 	android_plugin->call(ANDROID_SN(captureFeedback),
 			p_feedback->get_message(),
 			p_feedback->get_contact_email(),
 			p_feedback->get_name(),
-			p_feedback->get_associated_event_id());
+			p_feedback->get_associated_event_id(),
+			android_scope ? android_scope->get_handle() : 0);
 }
 
 void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -247,24 +255,33 @@ void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
+	ERR_FAIL_COND(p_scope.is_null());
 
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 	android_plugin->call(ANDROID_SN(metricsAddCount),
+			android_scope->get_handle(),
 			p_name, p_value, _sanitize_attributes(p_attributes));
 }
 
 void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
+	ERR_FAIL_COND(p_scope.is_null());
 
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 	android_plugin->call(ANDROID_SN(metricsAddGauge),
+			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 
 void AndroidSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL(android_plugin);
+	ERR_FAIL_COND(p_scope.is_null());
 
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 	android_plugin->call(ANDROID_SN(metricsAddDistribution),
+			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 
@@ -299,7 +316,10 @@ void AndroidSDK::remove_attribute(const String &p_name) {
 }
 
 SentryScopeImpl *AndroidSDK::create_scope() {
-	return memnew(DisabledScope);
+	Object *android_plugin = _get_android_plugin();
+	ERR_FAIL_NULL_V(android_plugin, memnew(AndroidScope()));
+	int32_t handle = android_plugin->call(ANDROID_SN(createScope));
+	return memnew(AndroidScope(android_plugin, handle));
 }
 
 void AndroidSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -212,8 +212,8 @@ String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sent
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	return android_plugin->call(ANDROID_SN(captureEvent),
-			android_event->get_handle(),
-			android_scope->get_handle());
+			android_scope->get_handle(),
+			android_event->get_handle());
 }
 
 void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -227,11 +227,11 @@ void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sen
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(captureFeedback),
+			android_scope->get_handle(),
 			p_feedback->get_message(),
 			p_feedback->get_contact_email(),
 			p_feedback->get_name(),
-			p_feedback->get_associated_event_id(),
-			android_scope->get_handle());
+			p_feedback->get_associated_event_id());
 }
 
 void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -227,7 +227,7 @@ void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sen
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
 
 	ERR_FAIL_COND(p_scope.is_null());
-	AndroidScope *android_scope = p_scope.is_valid() ? static_cast<AndroidScope *>(p_scope->get_implementation()) : nullptr;
+	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(captureFeedback),
 			p_feedback->get_message(),

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -23,9 +23,6 @@ using namespace godot;
 
 namespace {
 
-// Sentinel passed in place of a scope handle: the plugin captures with no local scope layered on top.
-constexpr int32_t NO_LOCAL_SCOPE = 0;
-
 inline Variant _as_attribute(const Variant &p_value) {
 	Variant::Type type = p_value.get_type();
 	return (type < Variant::BOOL || type > Variant::STRING) ? (Variant)p_value.stringify() : p_value;
@@ -186,7 +183,7 @@ void AndroidSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, 
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(log),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
+			android_scope->get_handle(),
 			p_level, p_body, _sanitize_attributes(p_attributes));
 }
 
@@ -216,7 +213,7 @@ String AndroidSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<Sent
 
 	return android_plugin->call(ANDROID_SN(captureEvent),
 			android_event->get_handle(),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE);
+			android_scope->get_handle());
 }
 
 void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -234,7 +231,7 @@ void AndroidSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<Sen
 			p_feedback->get_contact_email(),
 			p_feedback->get_name(),
 			p_feedback->get_associated_event_id(),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE);
+			android_scope->get_handle());
 }
 
 void AndroidSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -271,7 +268,7 @@ void AndroidSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddCount),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
+			android_scope->get_handle(),
 			p_name, p_value, _sanitize_attributes(p_attributes));
 }
 
@@ -283,7 +280,7 @@ void AndroidSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddGauge),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
+			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 
@@ -295,7 +292,7 @@ void AndroidSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const
 	AndroidScope *android_scope = static_cast<AndroidScope *>(p_scope->get_implementation());
 
 	android_plugin->call(ANDROID_SN(metricsAddDistribution),
-			android_scope ? android_scope->get_handle() : NO_LOCAL_SCOPE,
+			android_scope->get_handle(),
 			p_name, p_value, p_unit, _sanitize_attributes(p_attributes));
 }
 

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -97,6 +97,8 @@ public:
 
 	virtual SentryScopeImpl *create_scope() override;
 
+	virtual bool supports_scopes() const override { return true; }
+
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 
 	virtual void init() override;

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -86,6 +86,23 @@ AndroidStringNames::AndroidStringNames() {
 	breadcrumbSetData = StringName("breadcrumbSetData");
 	breadcrumbGetTimestamp = StringName("breadcrumbGetTimestamp");
 
+	// Scopes.
+	createScope = StringName("createScope");
+	releaseScope = StringName("releaseScope");
+	cloneScope = StringName("cloneScope");
+	scopeSetContext = StringName("scopeSetContext");
+	scopeSetTag = StringName("scopeSetTag");
+	scopeSetUser = StringName("scopeSetUser");
+	scopeRemoveUser = StringName("scopeRemoveUser");
+	scopeSetLevel = StringName("scopeSetLevel");
+	scopeSetFingerprint = StringName("scopeSetFingerprint");
+	scopeSetAttributeBool = StringName("scopeSetAttributeBool");
+	scopeSetAttributeLong = StringName("scopeSetAttributeLong");
+	scopeSetAttributeDouble = StringName("scopeSetAttributeDouble");
+	scopeSetAttributeString = StringName("scopeSetAttributeString");
+	scopeAddBreadcrumb = StringName("scopeAddBreadcrumb");
+	scopeClear = StringName("scopeClear");
+
 	// Logs.
 	releaseLog = StringName("releaseLog");
 	logSetLevel = StringName("logSetLevel");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -97,6 +97,23 @@ public:
 	StringName breadcrumbSetData;
 	StringName breadcrumbGetTimestamp;
 
+	// Scopes.
+	StringName createScope;
+	StringName releaseScope;
+	StringName cloneScope;
+	StringName scopeSetContext;
+	StringName scopeSetTag;
+	StringName scopeSetUser;
+	StringName scopeRemoveUser;
+	StringName scopeSetLevel;
+	StringName scopeSetFingerprint;
+	StringName scopeSetAttributeBool;
+	StringName scopeSetAttributeLong;
+	StringName scopeSetAttributeDouble;
+	StringName scopeSetAttributeString;
+	StringName scopeAddBreadcrumb;
+	StringName scopeClear;
+
 	// Logs.
 	StringName releaseLog;
 	StringName logSetLevel;


### PR DESCRIPTION
Adds Android support for scopes and `SentrySDK.with_scope()` in GDScript. See the [root PR](https://github.com/getsentry/sentry-godot/pull/834) for additional context and implementation details.
- Stacked PR; root branch: #834
- Refs https://github.com/getsentry/sentry-godot/issues/188
- Docs https://github.com/getsentry/sentry-docs/pull/18930
