### PR TITLE
feat(scopes): Support scopes on WebAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Features
 
-- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835))
+- Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835), [#836](https://github.com/getsentry/sentry-godot/pull/836))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
-  - Only supported on Windows, Linux, and Android for now, with the remaining platforms still capturing telemetry but discarding the scope data and printing a warning
+  - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
 
 ### Dependencies
 

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -77,7 +77,7 @@
 			<description>
 				Returns the current scope on the calling thread. Inside a [method SentrySDK.with_scope] callable, this is the scope forked for that callable. The fork is discarded when the callable returns, and the parent scope it was forked from becomes current again. Outside of any [method SentrySDK.with_scope], the returned scope stays current for the telemetry captured later on that thread.
 				The returned scope belongs to the calling thread. Data written to it enriches only the telemetry captured on that thread, and modifying it from another thread is not supported. See [SentryScope] for details. To enrich telemetry captured on every thread, use the [SentrySDK] methods such as [method SentrySDK.set_tag] instead.
-				[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the returned scope.
+				[b]Note:[/b] The SDK does not support scopes on macOS and iOS yet. On those platforms it still captures telemetry, but discards the data written to the returned scope.
 			</description>
 		</method>
 		<method name="get_last_event_id" qualifiers="const">
@@ -209,7 +209,7 @@
 				Writes made through [SentrySDK] methods such as [method SentrySDK.set_tag] still apply globally, even when called inside the callable.
 				For more information, see [SentryScope] class.
 				[b]Note:[/b] The fork covers the synchronous part of [param callable] only. If the callable awaits, the fork is discarded at the first [code]await[/code] and a warning is printed.
-				[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
+				[b]Note:[/b] The SDK does not support scopes on macOS and iOS yet. On those platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -14,7 +14,7 @@
 		)
 		[/codeblock]
 		[b]Note:[/b] A scope is thread-local. Modify a scope only from the thread that created it. If a scope is modified from another thread, the SDK rejects the call with an error and discards the data. To enrich telemetry captured on another thread, get that thread's current scope with [method SentrySDK.get_current_scope], or use [SentrySDK] methods such as [method SentrySDK.set_tag] to enrich telemetry captured on all threads.
-		[b]Note:[/b] The SDK supports scopes on Windows, Linux, and Android only for now. On the other platforms it still captures telemetry, but discards the data written to the scope.
+		[b]Note:[/b] The SDK does not support scopes on macOS and iOS yet. On those platforms it still captures telemetry, but discards the data written to the scope.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -170,6 +170,7 @@ func test_before_send_metric_discard() -> void:
 
 
 # TODO: remove skip when implemented on other platforms
+# Skipped: JS merges scope attributes at serialization time, after the callback has already run.
 func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.set_attribute("from_global", "global")
 	SentrySDK.set_attribute("scope_over_global", "global")

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -206,6 +206,7 @@ func test_metric_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows
 
 
 # TODO: remove skip when implemented on other platforms
+# Skipped: JS merges scope attributes at serialization time, after the callback has already run.
 func test_metric_with_scope_attribute_types(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.with_scope(func(scope: SentryScope):
 		scope.set_attribute("level", "forest")

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -199,6 +199,7 @@ func test_structured_logs_with_global_attributes(_do_skip = OS.get_name() == "We
 
 
 # TODO: remove skip when implemented on other platforms
+# Skipped: JS merges scope attributes at serialization time, after the callback has already run.
 func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.set_attribute("from_global", "global")
 	SentrySDK.set_attribute("scope_over_global", "global")

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -235,6 +235,7 @@ func test_structured_logs_with_scope_attributes(_do_skip = OS.get_name() not in 
 
 
 # TODO: remove skip when implemented on other platforms
+# Skipped: JS merges scope attributes at serialization time, after the callback has already run.
 func test_structured_logs_with_scope_attribute_types(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"]) -> void:
 	SentrySDK.with_scope(func(scope: SentryScope):
 		scope.set_attribute("level", "forest")

--- a/project/test/suites/test_scope.gd
+++ b/project/test/suites/test_scope.gd
@@ -3,7 +3,7 @@ extends SentryTestSuite
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"],
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android", "Web"],
 		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -3,7 +3,7 @@ extends SentryTestSuite
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android"],
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android", "Web"],
 		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	super()
 

--- a/src/sentry/android/android_scope.h
+++ b/src/sentry/android/android_scope.h
@@ -5,6 +5,8 @@
 namespace sentry::android {
 
 class AndroidScope : public SentryScopeImpl {
+	SENTRY_CASTABLE(AndroidScope, SentryScopeImpl);
+
 private:
 	Object *android_plugin = nullptr;
 	int32_t handle = 0;

--- a/src/sentry/castable.h
+++ b/src/sentry/castable.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <type_traits>
+
+namespace sentry {
+
+// Casts between related classes without the cost of dynamic_cast.
+// Declare with SENTRY_CASTABLE in every participating class, naming Castable
+// as the base in the root class.
+class Castable {
+public:
+	struct TypeInfo {
+		const TypeInfo *parent;
+	};
+
+	static constexpr TypeInfo type_info{ nullptr };
+
+	// Returns true if p_from is a T, or derives from T. Null is safe and never matches.
+	template <typename T>
+	static bool is_class(const Castable *p_from) {
+		static_assert(std::is_same_v<typename T::castable_self, T>,
+				"T must declare SENTRY_CASTABLE");
+		if (!p_from) {
+			return false;
+		}
+		const TypeInfo *t = p_from->get_type_info();
+		while (t) {
+			if (t == &T::type_info) {
+				return true;
+			}
+			t = t->parent;
+		}
+		return false;
+	}
+
+	// Returns p_from as T, or null if it isn't one. Null is safe.
+	template <typename T>
+	static T *cast_to(Castable *p_from) {
+		return is_class<T>(p_from) ? static_cast<T *>(p_from) : nullptr;
+	}
+
+	// Returns p_from as T, or null if it isn't one. Null is safe.
+	template <typename T>
+	static const T *cast_to(const Castable *p_from) {
+		return is_class<T>(p_from) ? static_cast<const T *>(p_from) : nullptr;
+	}
+
+	virtual ~Castable() = default;
+
+protected:
+	virtual const TypeInfo *get_type_info() const = 0;
+};
+
+} //namespace sentry
+
+// Adds type info to a castable class. Add at the top of the class body.
+#define SENTRY_CASTABLE(m_class, m_base)                                           \
+public:                                                                            \
+	using castable_self = m_class;                                                 \
+	static constexpr ::sentry::Castable::TypeInfo type_info{ &m_base::type_info }; \
+                                                                                   \
+protected:                                                                         \
+	virtual const ::sentry::Castable::TypeInfo *get_type_info() const override {   \
+		static_assert(std::is_base_of_v<m_base, m_class>,                          \
+				#m_base " must be a base of " #m_class ".");                       \
+		return &type_info;                                                         \
+	}                                                                              \
+                                                                                   \
+private:

--- a/src/sentry/disabled/disabled_scope.h
+++ b/src/sentry/disabled/disabled_scope.h
@@ -5,6 +5,8 @@
 namespace sentry {
 
 class DisabledScope : public SentryScopeImpl {
+	SENTRY_CASTABLE(DisabledScope, SentryScopeImpl);
+
 public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void set_tag(const String &p_key, const String &p_value) override {}

--- a/src/sentry/javascript/bridge/README.md
+++ b/src/sentry/javascript/bridge/README.md
@@ -29,8 +29,15 @@ The bridge exposes `window.SentryBridge`. Example usage:
 SentryBridge.init(beforeSendCallback, beforeSendLogCallback, dsn, debug, release, dist, environment, sampleRate, maxBreadcrumbs, enableLogs)
 SentryBridge.setTag(key, value)
 SentryBridge.setUser(id, username, email, ip)
-SentryBridge.captureMessage(message, level)
 SentryBridge.captureEvent(event)
+```
+
+Scopes are created through the bridge and passed back as a trailing argument to the capture methods:
+
+```typescript
+const scope = SentryBridge.createScope()
+SentryBridge.scopeSetUser(scope, id, username, email, ip)
+SentryBridge.captureEvent(event, scope)
 ```
 
 See `src/sentry-bridge.ts` for all available methods.

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -287,47 +287,88 @@ class SentryBridge {
     event.user = makeUser(id, username, email, ip);
   }
 
-  public logTrace(message: string, attributesJson?: string): void {
-    Sentry.logger.trace(message, safeParseJSON(attributesJson || "", {}));
+  public createScope(): Sentry.Scope {
+    const scope = new Sentry.Scope();
+    scope.setClient(Sentry.getClient());
+    scope.setPropagationContext(Sentry.getCurrentScope().getPropagationContext());
+    return scope;
   }
 
-  public logDebug(message: string, attributesJson?: string): void {
-    Sentry.logger.debug(message, safeParseJSON(attributesJson || "", {}));
+  public scopeSetContext(scope: Sentry.Scope, key: string, valueJson: string): void {
+    scope.setContext(key, safeParseJSON(valueJson, {}));
   }
 
-  public logInfo(message: string, attributesJson?: string): void {
-    Sentry.logger.info(message, safeParseJSON(attributesJson || "", {}));
+  public scopeSetFingerprint(scope: Sentry.Scope, fingerprintJson: string): void {
+    scope.setFingerprint(safeParseJSON<string[]>(fingerprintJson, []));
   }
 
-  public logWarn(message: string, attributesJson?: string): void {
-    Sentry.logger.warn(message, safeParseJSON(attributesJson || "", {}));
+  public scopeSetUser(scope: Sentry.Scope, id: string, username: string, email: string, ip: string): void {
+    scope.setUser(makeUser(id, username, email, ip));
   }
 
-  public logError(message: string, attributesJson?: string): void {
-    Sentry.logger.error(message, safeParseJSON(attributesJson || "", {}));
+  public scopeClear(scope: Sentry.Scope): void {
+    // Preserve the propagation context across clear() because Scope.clear() rotates the trace in JS.
+    const propagationContext = scope.getPropagationContext();
+    scope.clear();
+    scope.setPropagationContext(propagationContext);
   }
 
-  public logFatal(message: string, attributesJson?: string): void {
-    Sentry.logger.fatal(message, safeParseJSON(attributesJson || "", {}));
+  public logTrace(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.trace(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
   }
 
-  public metricsAddCount(name: string, value: number, attributesJson?: string): void {
+  public logDebug(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.debug(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
+  }
+
+  public logInfo(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.info(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
+  }
+
+  public logWarn(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.warn(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
+  }
+
+  public logError(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.error(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
+  }
+
+  public logFatal(message: string, attributesJson?: string, scope?: Sentry.Scope): void {
+    Sentry.logger.fatal(message, safeParseJSON(attributesJson || "", {}), { scope: scope ?? undefined });
+  }
+
+  public metricsAddCount(name: string, value: number, attributesJson?: string, scope?: Sentry.Scope): void {
     Sentry.metrics.count(name, value, {
       attributes: safeParseJSON(attributesJson || "", {}),
+      scope: scope ?? undefined,
     });
   }
 
-  public metricsAddGauge(name: string, value: number, unit: string, attributesJson?: string): void {
+  public metricsAddGauge(
+    name: string,
+    value: number,
+    unit: string,
+    attributesJson?: string,
+    scope?: Sentry.Scope,
+  ): void {
     Sentry.metrics.gauge(name, value, {
       ...(unit !== "" && { unit }),
       attributes: safeParseJSON(attributesJson || "", {}),
+      scope: scope ?? undefined,
     });
   }
 
-  public metricsAddDistribution(name: string, value: number, unit: string, attributesJson?: string): void {
+  public metricsAddDistribution(
+    name: string,
+    value: number,
+    unit: string,
+    attributesJson?: string,
+    scope?: Sentry.Scope,
+  ): void {
     Sentry.metrics.distribution(name, value, {
       ...(unit !== "" && { unit }),
       attributes: safeParseJSON(attributesJson || "", {}),
+      scope: scope ?? undefined,
     });
   }
 
@@ -340,15 +381,23 @@ class SentryBridge {
     Sentry.getGlobalScope().removeAttribute(name);
   }
 
-  public captureMessage(message: string, level: string): string {
-    return Sentry.captureMessage(message, level as Sentry.SeverityLevel);
+  public captureEvent(event: Sentry.Event, scope?: Sentry.Scope): string {
+    if (!scope) {
+      return Sentry.captureEvent(event);
+    }
+    // Ensure scoped captures use the active client. Scopes created before init
+    // have no client and would otherwise drop events silently.
+    scope.setClient(Sentry.getClient());
+    return scope.captureEvent(event);
   }
 
-  public captureEvent(event: Sentry.Event): string {
-    return Sentry.captureEvent(event);
-  }
-
-  public captureFeedback(message: string, name: string, email: string, associatedEventId: string): string {
+  public captureFeedback(
+    message: string,
+    name: string,
+    email: string,
+    associatedEventId: string,
+    scope?: Sentry.Scope,
+  ): string {
     const feedback: any = { message };
     if (name !== "") {
       feedback.name = name;
@@ -359,7 +408,10 @@ class SentryBridge {
     if (associatedEventId !== "") {
       feedback.associatedEventId = associatedEventId;
     }
-    return Sentry.captureFeedback(feedback);
+    // Ensure scoped captures use the active client. Scopes created before init
+    // have no client and would otherwise drop events silently.
+    scope?.setClient(Sentry.getClient());
+    return Sentry.captureFeedback(feedback, undefined, scope ?? undefined);
   }
 
   public lastEventId(): string {
@@ -371,7 +423,7 @@ class SentryBridge {
   }
 
   public addBytesAttachment(filename: string, bytes: Uint8Array, contentType: string): void {
-    Sentry.getCurrentScope().addAttachment({
+    Sentry.getIsolationScope().addAttachment({
       filename,
       data: bytes,
       contentType,
@@ -379,7 +431,7 @@ class SentryBridge {
   }
 
   public clearAttachments(): void {
-    Sentry.getCurrentScope().clearAttachments();
+    Sentry.getIsolationScope().clearAttachments();
   }
 }
 

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -385,9 +385,6 @@ class SentryBridge {
     if (!scope) {
       return Sentry.captureEvent(event);
     }
-    // Ensure scoped captures use the active client. Scopes created before init
-    // have no client and would otherwise drop events silently.
-    scope.setClient(Sentry.getClient());
     return scope.captureEvent(event);
   }
 
@@ -408,9 +405,6 @@ class SentryBridge {
     if (associatedEventId !== "") {
       feedback.associatedEventId = associatedEventId;
     }
-    // Ensure scoped captures use the active client. Scopes created before init
-    // have no client and would otherwise drop events silently.
-    scope?.setClient(Sentry.getClient());
     return Sentry.captureFeedback(feedback, undefined, scope ?? undefined);
   }
 

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -55,13 +55,17 @@ try {
 			"setUser",
 			"removeUser",
 			"eventSetUser",
+			"createScope",
+			"scopeSetContext",
+			"scopeSetFingerprint",
+			"scopeSetUser",
+			"scopeClear",
 			"logTrace",
 			"logDebug",
 			"logInfo",
 			"logWarn",
 			"logError",
 			"logFatal",
-			"captureMessage",
 			"captureEvent",
 			"captureFeedback",
 			"lastEventId",
@@ -150,6 +154,32 @@ try {
 			assertEqual(Object.keys(event2.user).length, 0, "eventSetUser should skip empty fields");
 		});
 
+		runTest("createScope()", () => {
+			const scope = bridge.createScope();
+			assert(scope.getClient() !== undefined, "createScope should bind the current client");
+		});
+
+		runTest("scopeSetContext() / scopeSetFingerprint() / scopeSetUser()", () => {
+			const scope = bridge.createScope();
+			bridge.scopeSetContext(scope, "test-context", '{"key": "value"}');
+			bridge.scopeSetFingerprint(scope, '["a","b"]');
+			bridge.scopeSetUser(scope, "user123", "testuser", "test@example.com", "127.0.0.1");
+			const data = scope.getScopeData();
+			assertEqual(data.contexts["test-context"].key, "value", "scopeSetContext should set the context");
+			assertEqual(data.fingerprint.join(","), "a,b", "scopeSetFingerprint should set the fingerprint");
+			assertEqual(data.user.id, "user123", "scopeSetUser should set the user");
+		});
+
+		runTest("scopeClear()", () => {
+			const scope = bridge.createScope();
+			bridge.scopeSetContext(scope, "test-context", '{"key": "value"}');
+			const traceId = scope.getPropagationContext().traceId;
+			bridge.scopeClear(scope);
+			assertEqual(scope.getScopeData().contexts["test-context"], undefined, "scopeClear should clear scope data");
+			assertEqual(scope.getPropagationContext().traceId, traceId,
+					"scopeClear should preserve the propagation context");
+		});
+
 		runTest("logTrace()", () => {
 			bridge.logTrace("Test trace message", '{"key": "value"}');
 		});
@@ -174,14 +204,11 @@ try {
 			bridge.logFatal("Test fatal message", '{"key": "value"}');
 		});
 
-		runTest("captureMessage()", () => {
-			const result = bridge.captureMessage("Test message", "info");
-			assertEqual(typeof result, "string", "captureMessage should return a string");
-		});
-
 		runTest("captureEvent()", () => {
 			const result = bridge.captureEvent({ message : "Test event" });
 			assertEqual(typeof result, "string", "captureEvent should return a string");
+			const scoped = bridge.captureEvent({ message : "Test event" }, bridge.createScope());
+			assertEqual(typeof scoped, "string", "Scoped captureEvent should return a string");
 		});
 
 		runTest("lastEventId()", () => {
@@ -196,6 +223,8 @@ try {
 		runTest("captureFeedback()", () => {
 			const result = bridge.captureFeedback("Test feedback", "Test User", "test@example.com", "");
 			assertEqual(typeof result, "string", "captureFeedback should return a string");
+			const scoped = bridge.captureFeedback("Test feedback", "", "", "", bridge.createScope());
+			assertEqual(typeof scoped, "string", "Scoped captureFeedback should return a string");
 		});
 
 		runTest("storeBytes() / takeBytes()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -162,31 +162,60 @@ try {
 					"createScope should inherit the current trace");
 		});
 
-		runTest("scopeSetContext() / scopeSetFingerprint() / scopeSetUser()", () => {
+		runTest("scope setters", () => {
 			const scope = bridge.createScope();
 			bridge.scopeSetContext(scope, "test-context", '{"key": "value"}');
 			bridge.scopeSetFingerprint(scope, '["a","b"]');
 			bridge.scopeSetUser(scope, "user123", "testuser", "test@example.com", "127.0.0.1");
+			scope.setTag("subsystem", "savegame");
+			scope.setLevel("warning");
 			const data = scope.getScopeData();
 			assertEqual(data.contexts["test-context"].key, "value", "scopeSetContext should set the context");
 			assertEqual(data.fingerprint.join(","), "a,b", "scopeSetFingerprint should set the fingerprint");
 			assertEqual(data.user.id, "user123", "scopeSetUser should set the user");
+			assertEqual(data.tags.subsystem, "savegame", "setTag should set a tag");
+			assertEqual(data.level, "warning", "setLevel should set the level");
+			scope.setUser(null);
+			assertEqual(scope.getScopeData().user.id, undefined, "setUser(null) should clear the user");
 		});
 
-		runTest("scope.setAttribute() / scope.setUser(null)", () => {
+		runTest("scope.addBreadcrumb()", () => {
+			const scope = bridge.createScope();
+			// Second argument is the breadcrumb cap the C++ layer reads from SentryOptions.
+			scope.addBreadcrumb({ message : "first" }, 2);
+			scope.addBreadcrumb({ message : "second" }, 2);
+			scope.addBreadcrumb({ message : "third" }, 2);
+			const data = scope.getScopeData();
+			assertEqual(data.breadcrumbs.length, 2, "addBreadcrumb should honor the max breadcrumbs argument");
+			assertEqual(data.breadcrumbs[0].message, "second", "addBreadcrumb should drop the oldest past the cap");
+			assertEqual(data.breadcrumbs[1].message, "third", "addBreadcrumb should keep the newest breadcrumb");
+		});
+
+		runTest("scope.setAttribute()", () => {
 			const scope = bridge.createScope();
 			scope.setAttribute("level", "forest");
 			scope.setAttribute("enemy_id", 42);
 			scope.setAttribute("health", 10.5);
 			scope.setAttribute("elite", false);
-			bridge.scopeSetUser(scope, "user123", "testuser", "test@example.com", "127.0.0.1");
-			scope.setUser(null);
 			const data = scope.getScopeData();
 			assertEqual(data.attributes.level, "forest", "setAttribute should set a string attribute");
 			assertEqual(data.attributes.enemy_id, 42, "setAttribute should set an int attribute");
 			assertEqual(data.attributes.health, 10.5, "setAttribute should set a float attribute");
 			assertEqual(data.attributes.elite, false, "setAttribute should set a bool attribute");
-			assertEqual(data.user.id, undefined, "setUser(null) should clear the user");
+		});
+
+		runTest("scope.clone()", () => {
+			const scope = bridge.createScope();
+			scope.setTag("subsystem", "savegame");
+			const fork = scope.clone();
+			assert(fork.getClient() !== undefined, "clone should carry the client over");
+			assertEqual(fork.getPropagationContext().traceId, scope.getPropagationContext().traceId,
+					"clone should stay on the parent's trace");
+			assertEqual(fork.getScopeData().tags.subsystem, "savegame",
+					"clone should inherit the parent's data");
+			fork.setTag("subsystem", "worldgen");
+			assertEqual(scope.getScopeData().tags.subsystem, "savegame",
+					"writes to the clone should not reach the parent");
 		});
 
 		runTest("scopeClear()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -157,6 +157,9 @@ try {
 		runTest("createScope()", () => {
 			const scope = bridge.createScope();
 			assert(scope.getClient() !== undefined, "createScope should bind the current client");
+			assertEqual(bridge.createScope().getPropagationContext().traceId,
+					scope.getPropagationContext().traceId,
+					"createScope should inherit the current trace");
 		});
 
 		runTest("scopeSetContext() / scopeSetFingerprint() / scopeSetUser()", () => {
@@ -168,6 +171,22 @@ try {
 			assertEqual(data.contexts["test-context"].key, "value", "scopeSetContext should set the context");
 			assertEqual(data.fingerprint.join(","), "a,b", "scopeSetFingerprint should set the fingerprint");
 			assertEqual(data.user.id, "user123", "scopeSetUser should set the user");
+		});
+
+		runTest("scope.setAttribute() / scope.setUser(null)", () => {
+			const scope = bridge.createScope();
+			scope.setAttribute("level", "forest");
+			scope.setAttribute("enemy_id", 42);
+			scope.setAttribute("health", 10.5);
+			scope.setAttribute("elite", false);
+			bridge.scopeSetUser(scope, "user123", "testuser", "test@example.com", "127.0.0.1");
+			scope.setUser(null);
+			const data = scope.getScopeData();
+			assertEqual(data.attributes.level, "forest", "setAttribute should set a string attribute");
+			assertEqual(data.attributes.enemy_id, 42, "setAttribute should set an int attribute");
+			assertEqual(data.attributes.health, 10.5, "setAttribute should set a float attribute");
+			assertEqual(data.attributes.elite, false, "setAttribute should set a bool attribute");
+			assertEqual(data.user.id, undefined, "setUser(null) should clear the user");
 		});
 
 		runTest("scopeClear()", () => {

--- a/src/sentry/javascript/javascript_breadcrumb.h
+++ b/src/sentry/javascript/javascript_breadcrumb.h
@@ -6,11 +6,13 @@
 namespace sentry::javascript {
 
 class JavaScriptSDK;
+class JavaScriptScope;
 
 class JavaScriptBreadcrumb : public SentryBreadcrumb {
 	GDCLASS(JavaScriptBreadcrumb, SentryBreadcrumb);
 
 	friend class JavaScriptSDK;
+	friend class JavaScriptScope;
 
 private:
 	JSObjectPtr js_obj;

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -1,0 +1,100 @@
+#include "javascript_scope.h"
+
+#include "sentry/javascript/javascript_breadcrumb.h"
+#include "sentry/sentry_sdk.h"
+
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/core/error_macros.hpp>
+
+namespace sentry::javascript {
+
+void JavaScriptScope::set_context(const String &p_key, const Dictionary &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
+	ERR_FAIL_COND(!js_obj);
+	js_bridge()->call("scopeSetContext", js_obj, p_key.utf8(), JSON::stringify(p_value).utf8());
+}
+
+void JavaScriptScope::set_tag(const String &p_key, const String &p_value) {
+	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set tag with an empty key.");
+	ERR_FAIL_COND(!js_obj);
+	js_obj->call("setTag", p_key.utf8(), p_value.utf8());
+}
+
+void JavaScriptScope::set_user(const Ref<SentryUser> &p_user) {
+	ERR_FAIL_COND(!js_obj);
+
+	if (p_user.is_null()) {
+		js_obj->call("setUser", nullptr);
+		return;
+	}
+
+	js_bridge()->call("scopeSetUser",
+			js_obj,
+			p_user->get_id().utf8(),
+			p_user->get_username().utf8(),
+			p_user->get_email().utf8(),
+			p_user->get_ip_address().utf8());
+}
+
+void JavaScriptScope::set_level(sentry::Level p_level) {
+	ERR_FAIL_COND(!js_obj);
+	js_obj->call("setLevel", level_as_cstring(p_level));
+}
+
+void JavaScriptScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
+	ERR_FAIL_COND(!js_obj);
+	js_bridge()->call("scopeSetFingerprint", js_obj, JSON::stringify(p_fingerprint).utf8());
+}
+
+void JavaScriptScope::set_attribute(const String &p_name, const Variant &p_value) {
+	ERR_FAIL_COND(!js_obj);
+	switch (p_value.get_type()) {
+		case Variant::Type::BOOL: {
+			js_obj->call("setAttribute", p_name.utf8(), p_value.operator bool());
+		} break;
+		case Variant::Type::INT: {
+			js_obj->call("setAttribute", p_name.utf8(), p_value.operator int64_t());
+		} break;
+		case Variant::Type::FLOAT: {
+			js_obj->call("setAttribute", p_name.utf8(), p_value.operator double());
+		} break;
+		case Variant::Type::STRING: {
+			js_obj->call("setAttribute", p_name.utf8(), p_value.operator String().utf8());
+		} break;
+		default: {
+			js_obj->call("setAttribute", p_name.utf8(), p_value.stringify().utf8());
+		} break;
+	}
+}
+
+void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
+	ERR_FAIL_COND(!js_obj);
+	Ref<JavaScriptBreadcrumb> crumb = p_breadcrumb;
+	ERR_FAIL_COND(crumb.is_null());
+
+	js_obj->call("addBreadcrumb", crumb->get_js_object(), SENTRY_OPTIONS()->get_max_breadcrumbs());
+}
+
+void JavaScriptScope::clear() {
+	ERR_FAIL_COND(!js_obj);
+	js_bridge()->call("scopeClear", js_obj);
+}
+
+SentryScopeImpl *JavaScriptScope::clone() const {
+	ERR_FAIL_COND_V(!js_obj, memnew(JavaScriptScope));
+	JSObjectPtr cloned_obj = js_obj->call("clone").as_object();
+	ERR_FAIL_COND_V(!cloned_obj, memnew(JavaScriptScope));
+	return memnew(JavaScriptScope(cloned_obj));
+}
+
+JavaScriptScope::JavaScriptScope(const JSObjectPtr &p_js_scope_object) :
+		js_obj(p_js_scope_object) {
+}
+
+JavaScriptScope::JavaScriptScope() {
+	ERR_FAIL_COND(!js_bridge());
+	js_obj = js_bridge()->call("createScope").as_object();
+	ERR_FAIL_COND_MSG(!js_obj, "Sentry: Failed to create scope object.");
+}
+
+} //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -9,13 +9,11 @@
 namespace sentry::javascript {
 
 void JavaScriptScope::set_context(const String &p_key, const Dictionary &p_value) {
-	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set context with an empty key.");
 	ERR_FAIL_COND(!js_obj);
 	js_bridge()->call("scopeSetContext", js_obj, p_key.utf8(), JSON::stringify(p_value).utf8());
 }
 
 void JavaScriptScope::set_tag(const String &p_key, const String &p_value) {
-	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't set tag with an empty key.");
 	ERR_FAIL_COND(!js_obj);
 	js_obj->call("setTag", p_key.utf8(), p_value.utf8());
 }

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -1,5 +1,6 @@
 #include "javascript_scope.h"
 
+#include "sentry/disabled/disabled_scope.h"
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/sentry_sdk.h"
 
@@ -9,18 +10,14 @@
 namespace sentry::javascript {
 
 void JavaScriptScope::set_context(const String &p_key, const Dictionary &p_value) {
-	ERR_FAIL_COND(!js_obj);
 	js_bridge()->call("scopeSetContext", js_obj, p_key.utf8(), JSON::stringify(p_value).utf8());
 }
 
 void JavaScriptScope::set_tag(const String &p_key, const String &p_value) {
-	ERR_FAIL_COND(!js_obj);
 	js_obj->call("setTag", p_key.utf8(), p_value.utf8());
 }
 
 void JavaScriptScope::set_user(const Ref<SentryUser> &p_user) {
-	ERR_FAIL_COND(!js_obj);
-
 	if (p_user.is_null()) {
 		js_obj->call("setUser", nullptr);
 		return;
@@ -35,17 +32,14 @@ void JavaScriptScope::set_user(const Ref<SentryUser> &p_user) {
 }
 
 void JavaScriptScope::set_level(sentry::Level p_level) {
-	ERR_FAIL_COND(!js_obj);
 	js_obj->call("setLevel", level_as_cstring(p_level));
 }
 
 void JavaScriptScope::set_fingerprint(const PackedStringArray &p_fingerprint) {
-	ERR_FAIL_COND(!js_obj);
 	js_bridge()->call("scopeSetFingerprint", js_obj, JSON::stringify(p_fingerprint).utf8());
 }
 
 void JavaScriptScope::set_attribute(const String &p_name, const Variant &p_value) {
-	ERR_FAIL_COND(!js_obj);
 	switch (p_value.get_type()) {
 		case Variant::Type::BOOL: {
 			js_obj->call("setAttribute", p_name.utf8(), p_value.operator bool());
@@ -66,7 +60,6 @@ void JavaScriptScope::set_attribute(const String &p_name, const Variant &p_value
 }
 
 void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
-	ERR_FAIL_COND(!js_obj);
 	Ref<JavaScriptBreadcrumb> crumb = p_breadcrumb;
 	ERR_FAIL_COND(crumb.is_null());
 
@@ -74,25 +67,17 @@ void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) 
 }
 
 void JavaScriptScope::clear() {
-	ERR_FAIL_COND(!js_obj);
 	js_bridge()->call("scopeClear", js_obj);
 }
 
 SentryScopeImpl *JavaScriptScope::clone() const {
-	ERR_FAIL_COND_V(!js_obj, memnew(JavaScriptScope));
 	JSObjectPtr cloned_obj = js_obj->call("clone").as_object();
-	ERR_FAIL_COND_V(!cloned_obj, memnew(JavaScriptScope));
+	ERR_FAIL_COND_V_MSG(!cloned_obj, memnew(DisabledScope), "Sentry: Failed to clone scope object.");
 	return memnew(JavaScriptScope(cloned_obj));
 }
 
 JavaScriptScope::JavaScriptScope(const JSObjectPtr &p_js_scope_object) :
 		js_obj(p_js_scope_object) {
-}
-
-JavaScriptScope::JavaScriptScope() {
-	ERR_FAIL_COND(!js_bridge());
-	js_obj = js_bridge()->call("createScope").as_object();
-	ERR_FAIL_COND_MSG(!js_obj, "Sentry: Failed to create scope object.");
 }
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -60,8 +60,8 @@ void JavaScriptScope::set_attribute(const String &p_name, const Variant &p_value
 }
 
 void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
-	Ref<JavaScriptBreadcrumb> crumb = p_breadcrumb;
-	ERR_FAIL_COND(crumb.is_null());
+	JavaScriptBreadcrumb *crumb = Object::cast_to<JavaScriptBreadcrumb>(p_breadcrumb.ptr());
+	ERR_FAIL_NULL(crumb);
 
 	js_obj->call("addBreadcrumb", crumb->get_js_object(), SENTRY_OPTIONS()->get_max_breadcrumbs());
 }

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -9,6 +9,8 @@
 
 namespace sentry::javascript {
 
+// NOTE: Bridge and js_obj are guaranteed to be valid: creation failures yield a DisabledScope instead.
+
 void JavaScriptScope::set_context(const String &p_key, const Dictionary &p_value) {
 	js_bridge()->call("scopeSetContext", js_obj, p_key.utf8(), JSON::stringify(p_value).utf8());
 }

--- a/src/sentry/javascript/javascript_scope.h
+++ b/src/sentry/javascript/javascript_scope.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "sentry/javascript/javascript_interop.h"
+#include "sentry/sentry_scope_impl.h"
+
+namespace sentry::javascript {
+
+class JavaScriptScope : public SentryScopeImpl {
+private:
+	JSObjectPtr js_obj;
+
+public:
+	_FORCE_INLINE_ JSObjectPtr get_js_object() const { return js_obj; }
+
+	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
+	virtual void set_tag(const String &p_key, const String &p_value) override;
+	virtual void set_user(const Ref<SentryUser> &p_user) override;
+	virtual void set_level(sentry::Level p_level) override;
+	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
+	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
+	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void clear() override;
+	virtual SentryScopeImpl *clone() const override;
+
+	explicit JavaScriptScope(const JSObjectPtr &p_js_scope_object);
+	JavaScriptScope();
+};
+
+} //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_scope.h
+++ b/src/sentry/javascript/javascript_scope.h
@@ -9,6 +9,8 @@ namespace sentry::javascript {
 // yield a DisabledScope instead.
 // See JavaScriptSDK::create_scope().
 class JavaScriptScope : public SentryScopeImpl {
+	SENTRY_CASTABLE(JavaScriptScope, SentryScopeImpl);
+
 private:
 	JSObjectPtr js_obj;
 

--- a/src/sentry/javascript/javascript_scope.h
+++ b/src/sentry/javascript/javascript_scope.h
@@ -5,6 +5,9 @@
 
 namespace sentry::javascript {
 
+// Backed by a JS Scope object, which is guaranteed to be valid: creation failures
+// yield a DisabledScope instead.
+// See JavaScriptSDK::create_scope().
 class JavaScriptScope : public SentryScopeImpl {
 private:
 	JSObjectPtr js_obj;
@@ -23,7 +26,7 @@ public:
 	virtual SentryScopeImpl *clone() const override;
 
 	explicit JavaScriptScope(const JSObjectPtr &p_js_scope_object);
-	JavaScriptScope();
+	JavaScriptScope() = delete;
 };
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -111,19 +111,6 @@ static void before_send_metric_wasm_callback(int32_t *p_ids, int32_t p_len) {
 
 } // extern "C"
 
-namespace {
-
-inline JSObjectPtr _get_scope_object(const Ref<SentryScope> &p_scope) {
-	if (p_scope.is_null()) {
-		return nullptr;
-	}
-	JavaScriptScope *js_scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-	ERR_FAIL_NULL_V(js_scope, nullptr);
-	return js_scope->get_js_object();
-}
-
-} // unnamed namespace
-
 // *** JavaScriptSDK
 
 void JavaScriptSDK::set_context(const String &p_key, const Dictionary &p_value) {
@@ -181,27 +168,29 @@ void JavaScriptSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 void JavaScriptSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 
+	ERR_FAIL_COND(p_scope.is_null());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
 	String attr_value = attributes_to_json(p_attributes);
-	JSObjectPtr scope_obj = _get_scope_object(p_scope);
 
 	switch (p_level) {
 		case LOG_LEVEL_TRACE: {
-			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 		case LOG_LEVEL_DEBUG: {
-			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 		case LOG_LEVEL_INFO: {
-			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 		case LOG_LEVEL_WARN: {
-			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 		case LOG_LEVEL_ERROR: {
-			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 		case LOG_LEVEL_FATAL: {
-			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8(), scope_obj);
+			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
 		} break;
 	}
 }
@@ -220,7 +209,11 @@ String JavaScriptSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<S
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	JavaScriptEvent *ev = Object::cast_to<JavaScriptEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(ev, String());
-	return js_bridge()->call("captureEvent", ev->get_js_object(), _get_scope_object(p_scope)).as_string();
+
+	ERR_FAIL_COND_V(p_scope.is_null(), String());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
+	return js_bridge()->call("captureEvent", ev->get_js_object(), scope->get_js_object()).as_string();
 }
 
 void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -228,12 +221,15 @@ void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
 
+	ERR_FAIL_COND(p_scope.is_null());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
 	js_bridge()->call("captureFeedback",
 			p_feedback->get_message().utf8(),
 			p_feedback->get_name().utf8(),
 			p_feedback->get_contact_email().utf8(),
 			p_feedback->get_associated_event_id().ascii(),
-			_get_scope_object(p_scope));
+			scope->get_js_object());
 }
 
 void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -265,19 +261,31 @@ void JavaScriptSDK::clear_attachments() {
 void JavaScriptSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8(), _get_scope_object(p_scope));
+
+	ERR_FAIL_COND(p_scope.is_null());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
+	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8(), scope->get_js_object());
 }
 
 void JavaScriptSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
+
+	ERR_FAIL_COND(p_scope.is_null());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
+	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), scope->get_js_object());
 }
 
 void JavaScriptSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
+
+	ERR_FAIL_COND(p_scope.is_null());
+	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+
+	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), scope->get_js_object());
 }
 
 void JavaScriptSDK::set_attribute(const String &p_name, const Variant &p_value) {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -1,5 +1,6 @@
 #include "javascript_sdk.h"
 
+#include "sentry/disabled/disabled_scope.h"
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/javascript/javascript_event.h"
 #include "sentry/javascript/javascript_interop.h"
@@ -111,6 +112,18 @@ static void before_send_metric_wasm_callback(int32_t *p_ids, int32_t p_len) {
 
 } // extern "C"
 
+namespace {
+
+// Returns the JS Scope object backing p_scope, or null if it's not backed by one (ie DisabledScope).
+// Scope creation can fall back to DisabledScope, and null falls back to capture without passed scope.
+inline JSObjectPtr _get_scope_object(const Ref<SentryScope> &p_scope) {
+	ERR_FAIL_COND_V(p_scope.is_null(), nullptr);
+	JavaScriptScope *js_scope = dynamic_cast<JavaScriptScope *>(p_scope->get_implementation());
+	return js_scope ? js_scope->get_js_object() : nullptr;
+}
+
+} // unnamed namespace
+
 // *** JavaScriptSDK
 
 void JavaScriptSDK::set_context(const String &p_key, const Dictionary &p_value) {
@@ -168,29 +181,27 @@ void JavaScriptSDK::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 void JavaScriptSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, const String &p_body, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 
-	ERR_FAIL_COND(p_scope.is_null());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
 	String attr_value = attributes_to_json(p_attributes);
+	JSObjectPtr scope_obj = _get_scope_object(p_scope);
 
 	switch (p_level) {
 		case LOG_LEVEL_TRACE: {
-			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_DEBUG: {
-			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_INFO: {
-			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_WARN: {
-			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_ERROR: {
-			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_FATAL: {
-			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8(), scope->get_js_object());
+			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 	}
 }
@@ -210,10 +221,7 @@ String JavaScriptSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<S
 	JavaScriptEvent *ev = Object::cast_to<JavaScriptEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(ev, String());
 
-	ERR_FAIL_COND_V(p_scope.is_null(), String());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
-	return js_bridge()->call("captureEvent", ev->get_js_object(), scope->get_js_object()).as_string();
+	return js_bridge()->call("captureEvent", ev->get_js_object(), _get_scope_object(p_scope)).as_string();
 }
 
 void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -221,15 +229,12 @@ void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<
 	ERR_FAIL_COND_MSG(p_feedback.is_null(), "Sentry: Can't capture feedback - feedback object is null.");
 	ERR_FAIL_COND_MSG(p_feedback->get_message().is_empty(), "Sentry: Can't capture feedback - feedback message is empty.");
 
-	ERR_FAIL_COND(p_scope.is_null());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
 	js_bridge()->call("captureFeedback",
 			p_feedback->get_message().utf8(),
 			p_feedback->get_name().utf8(),
 			p_feedback->get_contact_email().utf8(),
 			p_feedback->get_associated_event_id().ascii(),
-			scope->get_js_object());
+			_get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -261,31 +266,19 @@ void JavaScriptSDK::clear_attachments() {
 void JavaScriptSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-
-	ERR_FAIL_COND(p_scope.is_null());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
-	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8(), scope->get_js_object());
+	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-
-	ERR_FAIL_COND(p_scope.is_null());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
-	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), scope->get_js_object());
+	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-
-	ERR_FAIL_COND(p_scope.is_null());
-	JavaScriptScope *scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
-
-	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), scope->get_js_object());
+	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::set_attribute(const String &p_name, const Variant &p_value) {
@@ -315,7 +308,10 @@ void JavaScriptSDK::remove_attribute(const String &p_name) {
 }
 
 SentryScopeImpl *JavaScriptSDK::create_scope() {
-	return memnew(JavaScriptScope);
+	ERR_FAIL_COND_V(!js_bridge(), memnew(DisabledScope));
+	JSObjectPtr scope_obj = js_bridge()->call("createScope").as_object();
+	ERR_FAIL_COND_V_MSG(!scope_obj, memnew(DisabledScope), "Sentry: Failed to create scope object.");
+	return memnew(JavaScriptScope(scope_obj));
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -1,11 +1,11 @@
 #include "javascript_sdk.h"
 
-#include "sentry/disabled/disabled_scope.h"
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/javascript/javascript_event.h"
 #include "sentry/javascript/javascript_interop.h"
 #include "sentry/javascript/javascript_log.h"
 #include "sentry/javascript/javascript_metric.h"
+#include "sentry/javascript/javascript_scope.h"
 #include "sentry/javascript/javascript_util.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
@@ -111,6 +111,19 @@ static void before_send_metric_wasm_callback(int32_t *p_ids, int32_t p_len) {
 
 } // extern "C"
 
+namespace {
+
+inline JSObjectPtr _get_scope_object(const Ref<SentryScope> &p_scope) {
+	if (p_scope.is_null()) {
+		return nullptr;
+	}
+	JavaScriptScope *js_scope = static_cast<JavaScriptScope *>(p_scope->get_implementation());
+	ERR_FAIL_NULL_V(js_scope, nullptr);
+	return js_scope->get_js_object();
+}
+
+} // unnamed namespace
+
 // *** JavaScriptSDK
 
 void JavaScriptSDK::set_context(const String &p_key, const Dictionary &p_value) {
@@ -169,25 +182,26 @@ void JavaScriptSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_leve
 	ERR_FAIL_COND(!js_bridge());
 
 	String attr_value = attributes_to_json(p_attributes);
+	JSObjectPtr scope_obj = _get_scope_object(p_scope);
 
 	switch (p_level) {
 		case LOG_LEVEL_TRACE: {
-			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logTrace", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_DEBUG: {
-			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logDebug", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_INFO: {
-			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logInfo", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_WARN: {
-			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logWarn", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_ERROR: {
-			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logError", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 		case LOG_LEVEL_FATAL: {
-			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8());
+			js_bridge()->call("logFatal", p_body.utf8(), attr_value.utf8(), scope_obj);
 		} break;
 	}
 }
@@ -206,7 +220,7 @@ String JavaScriptSDK::capture_event(const Ref<SentryScope> &p_scope, const Ref<S
 	ERR_FAIL_COND_V_MSG(p_event.is_null(), String(), "Sentry: Can't capture event - event object is null.");
 	JavaScriptEvent *ev = Object::cast_to<JavaScriptEvent>(p_event.ptr());
 	ERR_FAIL_NULL_V(ev, String());
-	return js_bridge()->call("captureEvent", ev->get_js_object()).as_string();
+	return js_bridge()->call("captureEvent", ev->get_js_object(), _get_scope_object(p_scope)).as_string();
 }
 
 void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<SentryFeedback> &p_feedback) {
@@ -218,7 +232,8 @@ void JavaScriptSDK::capture_feedback(const Ref<SentryScope> &p_scope, const Ref<
 			p_feedback->get_message().utf8(),
 			p_feedback->get_name().utf8(),
 			p_feedback->get_contact_email().utf8(),
-			p_feedback->get_associated_event_id().ascii());
+			p_feedback->get_associated_event_id().ascii(),
+			_get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
@@ -250,19 +265,19 @@ void JavaScriptSDK::clear_attachments() {
 void JavaScriptSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8());
+	js_bridge()->call("metricsAddCount", p_name.utf8(), p_value, attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::metrics_add_gauge(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8());
+	js_bridge()->call("metricsAddGauge", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::metrics_add_distribution(const Ref<SentryScope> &p_scope, const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND(!js_bridge());
 	String attr_value = attributes_to_json(p_attributes);
-	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8());
+	js_bridge()->call("metricsAddDistribution", p_name.utf8(), p_value, p_unit.utf8(), attr_value.utf8(), _get_scope_object(p_scope));
 }
 
 void JavaScriptSDK::set_attribute(const String &p_name, const Variant &p_value) {
@@ -292,7 +307,7 @@ void JavaScriptSDK::remove_attribute(const String &p_name) {
 }
 
 SentryScopeImpl *JavaScriptSDK::create_scope() {
-	return memnew(DisabledScope);
+	return memnew(JavaScriptScope);
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -118,7 +118,7 @@ namespace {
 // Scope creation can fall back to DisabledScope, and null falls back to capture without passed scope.
 inline JSObjectPtr _get_scope_object(const Ref<SentryScope> &p_scope) {
 	ERR_FAIL_COND_V(p_scope.is_null(), nullptr);
-	JavaScriptScope *js_scope = dynamic_cast<JavaScriptScope *>(p_scope->get_implementation());
+	JavaScriptScope *js_scope = Castable::cast_to<JavaScriptScope>(p_scope->get_implementation());
 	return js_scope ? js_scope->get_js_object() : nullptr;
 }
 

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -46,6 +46,8 @@ public:
 
 	virtual SentryScopeImpl *create_scope() override;
 
+	virtual bool supports_scopes() const override { return true; }
+
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 
 	virtual void init() override;

--- a/src/sentry/native/native_scope.h
+++ b/src/sentry/native/native_scope.h
@@ -8,6 +8,8 @@ namespace sentry::native {
 
 // Thin wrapper around sentry-native scope used for SentryScope implementation on Windows and Linux.
 class NativeScope : public SentryScopeImpl {
+	SENTRY_CASTABLE(NativeScope, SentryScopeImpl);
+
 private:
 	sentry_scope_t *_scope;
 

--- a/src/sentry/sentry_scope_impl.h
+++ b/src/sentry/sentry_scope_impl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "sentry/castable.h"
 #include "sentry/level.h"
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_user.h"
@@ -17,7 +18,9 @@ namespace sentry {
 // Kept as a pure C++ class instead of a Godot class to avoid ClassDB
 // registration and reduce overhead.
 // Lifetime governed by SentryScope.
-class SentryScopeImpl {
+class SentryScopeImpl : public Castable {
+	SENTRY_CASTABLE(SentryScopeImpl, Castable);
+
 public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void set_tag(const String &p_key, const String &p_value) = 0;


### PR DESCRIPTION
Adds WebAssembly/JS support for scopes and `SentrySDK.with_scope()` in GDScript. See the https://github.com/getsentry/sentry-godot/pull/834 for additional context and implementation details.

- Stacked PR; root branch: https://github.com/getsentry/sentry-godot/pull/834
- Refs #188
- Docs https://github.com/getsentry/sentry-docs/pull/18930
