### PR TITLE
WIP: feat: Add `SentrySDK.set_environment()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `SentrySDK.set_environment()` to update the environment reported with subsequent events after initialization ([#839](https://github.com/getsentry/sentry-godot/pull/839))
+
 ### Fixes
 
 - Fixed missing line numbers in GDScript frames on Android with Godot 4.6 and later ([#826](https://github.com/getsentry/sentry-godot/pull/826))

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -294,6 +294,11 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun setEnvironment(environment: String) {
+        Sentry.getCurrentScopes().options.environment = environment
+    }
+
+    @UsedByGodot
     fun setUser(id: String, userName: String, email: String, ipAddress: String) {
         val user = User()
         if (id.isNotEmpty()) {

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -161,6 +161,16 @@
 				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/context/]Context documentation[/url].
 			</description>
 		</method>
+		<method name="set_environment">
+			<return type="void" />
+			<param index="0" name="environment" type="String" />
+			<description>
+				Changes the environment reported with subsequent events, overriding [member SentryOptions.environment] for the rest of the run.
+				Use [code]{auto}[/code] to resolve the environment from the current runtime context, as with [member SentryOptions.environment].
+				[b]Note:[/b] A release health session keeps the environment it started with.
+				To learn more, visit the [url=https://docs.sentry.io/platforms/godot/configuration/environments/]Environments documentation[/url].
+			</description>
+		</method>
 		<method name="set_tag">
 			<return type="void" />
 			<param index="0" name="key" type="String" />

--- a/project/test/suites/test_sdk.gd
+++ b/project/test/suites/test_sdk.gd
@@ -50,6 +50,21 @@ func test_remove_tag() -> void:
 	await assert_signal(monitor).is_emitted("callback_processed")
 
 
+## SentrySDK.set_environment() should change the environment assigned to the event object.
+func test_set_environment() -> void:
+	SentrySDK._set_before_send(
+		func(ev: SentryEvent):
+			assert_str(ev.environment).is_equal("custom-environment")
+			callback_processed.emit()
+			return null)
+
+	SentrySDK.set_environment("custom-environment")
+
+	var monitor := monitor_signals(self, false)
+	SentrySDK.capture_message("test-environment")
+	await assert_signal(monitor).is_emitted("callback_processed")
+
+
 ## SentrySDK Variant conversion should not cause stack overflow.
 func test_variant_conversion_against_stack_overflow() -> void:
 	var dict: Dictionary = { "some_key": "some_value"}

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -154,6 +154,13 @@ void AndroidSDK::remove_user() {
 	android_plugin->call(ANDROID_SN(removeUser));
 }
 
+void AndroidSDK::set_environment(const String &p_environment) {
+	ERR_FAIL_COND(p_environment.is_empty());
+	Object *android_plugin = _get_android_plugin();
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(setEnvironment), p_environment);
+}
+
 Ref<SentryBreadcrumb> AndroidSDK::create_breadcrumb() {
 	Object *android_plugin = _get_android_plugin();
 	ERR_FAIL_NULL_V(android_plugin, nullptr);

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -73,6 +73,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 	virtual void remove_user() override;
 
+	virtual void set_environment(const String &p_environment) override;
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -22,6 +22,7 @@ AndroidStringNames::AndroidStringNames() {
 	removeContext = StringName("removeContext");
 	setTag = StringName("setTag");
 	removeTag = StringName("removeTag");
+	setEnvironment = StringName("setEnvironment");
 	setUser = StringName("setUser");
 	removeUser = StringName("removeUser");
 	addBreadcrumb = StringName("addBreadcrumb");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -33,6 +33,7 @@ public:
 	StringName removeContext;
 	StringName setTag;
 	StringName removeTag;
+	StringName setEnvironment;
 	StringName setUser;
 	StringName removeUser;
 	StringName addBreadcrumb;

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -24,6 +24,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 	virtual void remove_user() override;
 
+	virtual void set_environment(const String &p_environment) override;
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -121,6 +121,13 @@ void CocoaSDK::remove_user() {
 	[SentryObjCSDK setUser:nil];
 }
 
+void CocoaSDK::set_environment(const String &p_environment) {
+	ERR_FAIL_COND(p_environment.is_empty());
+	[SentryObjCSDK configureScope:^(SentryObjCScope *scope) {
+		[scope setEnvironment:string_to_objc(p_environment)];
+	}];
+}
+
 Ref<SentryBreadcrumb> CocoaSDK::create_breadcrumb() {
 	return memnew(CocoaBreadcrumb);
 }

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -17,6 +17,8 @@ class DisabledSDK : public InternalSDK {
 	virtual void set_user(const Ref<SentryUser> &p_user) override {}
 	virtual void remove_user() override {}
 
+	virtual void set_environment(const String &p_environment) override {}
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override { return memnew(DisabledBreadcrumb); }
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override {}
 

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -27,6 +27,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) = 0;
 	virtual void remove_user() = 0;
 
+	virtual void set_environment(const String &p_environment) = 0;
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() = 0;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
 

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -275,6 +275,13 @@ class SentryBridge {
     Sentry.setTag(key, undefined);
   }
 
+  public setEnvironment(environment: string): void {
+    const client = Sentry.getClient();
+    if (client) {
+      client.getOptions().environment = environment;
+    }
+  }
+
   public setUser(id: string, username: string, email: string, ip: string): void {
     Sentry.setUser(makeUser(id, username, email, ip));
   }

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -52,6 +52,7 @@ try {
 			"removeContext",
 			"setTag",
 			"removeTag",
+			"setEnvironment",
 			"setUser",
 			"removeUser",
 			"eventSetUser",
@@ -120,6 +121,10 @@ try {
 
 		runTest("removeTag()", () => {
 			bridge.removeTag("test-tag");
+		});
+
+		runTest("setEnvironment()", () => {
+			bridge.setEnvironment("test-environment");
 		});
 
 		runTest("setContext()", () => {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -150,6 +150,12 @@ void JavaScriptSDK::remove_user() {
 	js_bridge()->call("removeUser");
 }
 
+void JavaScriptSDK::set_environment(const String &p_environment) {
+	ERR_FAIL_COND(p_environment.is_empty());
+	ERR_FAIL_COND(!js_bridge());
+	js_bridge()->call("setEnvironment", p_environment.utf8());
+}
+
 Ref<SentryBreadcrumb> JavaScriptSDK::create_breadcrumb() {
 	return memnew(JavaScriptBreadcrumb);
 }

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -22,6 +22,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 	virtual void remove_user() override;
 
+	virtual void set_environment(const String &p_environment) override;
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -227,6 +227,11 @@ void NativeSDK::remove_user() {
 	sentry_remove_user();
 }
 
+void NativeSDK::set_environment(const String &p_environment) {
+	ERR_FAIL_COND(p_environment.is_empty());
+	sentry_set_environment(p_environment.utf8());
+}
+
 Ref<SentryBreadcrumb> NativeSDK::create_breadcrumb() {
 	return memnew(NativeBreadcrumb);
 }

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -25,6 +25,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 	virtual void remove_user() override;
 
+	virtual void set_environment(const String &p_environment) override;
+
 	virtual Ref<SentryBreadcrumb> create_breadcrumb() override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -308,6 +308,16 @@ void SentrySDK::remove_user() {
 	}
 }
 
+void SentrySDK::set_environment(const String &p_environment) {
+	ERR_FAIL_COND_MSG(p_environment.is_empty(), "Sentry: Can't set an empty environment.");
+	// Write to options so get_environment() stays current and "{auto}" is resolved.
+	options->set_environment(p_environment);
+	if (is_configuring) {
+		return;
+	}
+	internal_sdk->set_environment(options->get_environment());
+}
+
 void SentrySDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
 	// Cache locally so get_trace_context() stays consistent with the backend.
 	trace_context.trace_id = p_trace_id;
@@ -545,6 +555,7 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentrySDK::remove_tag);
 	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentrySDK::set_user);
 	ClassDB::bind_method(D_METHOD("remove_user"), &SentrySDK::remove_user);
+	ClassDB::bind_method(D_METHOD("set_environment", "environment"), &SentrySDK::set_environment);
 	ClassDB::bind_method(D_METHOD("create_event"), &SentrySDK::create_event);
 	ClassDB::bind_method(D_METHOD("capture_event", "event"), &SentrySDK::capture_event);
 	ClassDB::bind_method(D_METHOD("capture_feedback", "feedback"), &SentrySDK::capture_feedback);

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -89,6 +89,8 @@ public:
 	void set_user(const Ref<SentryUser> &p_user);
 	void remove_user();
 
+	void set_environment(const String &p_environment);
+
 	void set_trace(const String &p_trace_id, const String &p_parent_span_id);
 
 	_FORCE_INLINE_ SentryLogger *get_logger() const { return logger; }


### PR DESCRIPTION
The environment could only be set before initialization. This adds `SentrySDK.set_environment()` to change it afterwards. Groundwork for syncing the environment between the native and .NET layers, which follows in a separate pull request.

- Refs #838

