### PR TITLE
fix(android): capture_event() returns an ID for discarded events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fixed missing line numbers in GDScript frames on Android with Godot 4.6 and later ([#826](https://github.com/getsentry/sentry-godot/pull/826))
+- Fixed `SentrySDK.capture_event()` on Android returning a valid-looking event ID for events that were discarded, such as by `before_send` ([#845](https://github.com/getsentry/sentry-godot/pull/845))
 
 ### Dependencies
 

--- a/project/test/suites/test_event.gd
+++ b/project/test/suites/test_event.gd
@@ -89,3 +89,17 @@ func test_capture_event() -> void:
 	assert_str(event_id).is_equal(event.id)
 	assert_str(SentrySDK.get_last_event_id()).is_not_empty()
 	assert_str(event_id).is_equal(SentrySDK.get_last_event_id())
+
+
+## SentrySDK.capture_event() should return a nil event ID if the event is discarded in before_send.
+func test_capture_event_discarded(
+		_do_skip = OS.get_name() == "Web",
+		_skip_reason = "JS SDK returns a freshly generated ID before before_send runs") -> void:
+	SentrySDK._set_before_send(func(_ev): return null)
+
+	var event := SentrySDK.create_event()
+	var event_id := SentrySDK.capture_event(event)
+
+	# The nil ID is dashed in the native layer and undashed on Android and Apple platforms.
+	assert_str(event_id.replace("-", "")).is_equal("00000000000000000000000000000000")
+	assert_str(event_id).is_not_equal(event.id)

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -208,8 +208,7 @@ String AndroidSDK::capture_event(const Ref<SentryEvent> &p_event) {
 	Ref<AndroidEvent> android_event = p_event;
 	ERR_FAIL_COND_V(android_event.is_null(), String());
 	int32_t handle = android_event->get_handle();
-	android_plugin->call(ANDROID_SN(captureEvent), handle);
-	return android_event->get_id();
+	return android_plugin->call(ANDROID_SN(captureEvent), handle);
 }
 
 void AndroidSDK::capture_feedback(const Ref<SentryFeedback> &p_feedback) {


### PR DESCRIPTION
On Android, `SentrySDK.capture_event()` returned the ID stored on the event object instead of the ID that sentry-java reported back from the capture call. The two differ whenever an event is dropped: when a `before_send` callback discards an event, sentry-java returns a nil ID of all zeros, but the plugin threw that value away and handed back the event's own ID. Callers were therefore given a valid-looking ID for an event that was never sent, with no way to tell the difference.
- Extracted from #834 