### PR TITLE
test: Fail the run when a test script doesn't parse

### DIFF
--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -254,31 +254,32 @@ func _cmd_pii_capture() -> int:
 
 
 func _cmd_run_tests(tests: String = "res://test/suites/") -> int:
-	if FileAccess.file_exists("res://test/util/test_runner.gd"):
-		print(">>> Initializing testing")
-		await get_tree().process_frame
+	print(">>> Initializing testing")
+	await get_tree().process_frame
 
-		var included_paths: PackedStringArray = tests.split(";", false)
-		if included_paths.is_empty():
-			printerr("No test path provided.")
-			return 1
-		print(" -- Tests included: ", included_paths)
-
-		# Add test runner node.
-		print(" -- Adding test runner...")
-		var test_runner: Node = load("res://test/util/test_runner.gd").new()
-		get_tree().root.add_child(test_runner)
-		for path in included_paths:
-			test_runner.include_tests(path)
-
-		# Wait for completion.
-		await test_runner.finished
-		print(">>> Test run complete with code: ", str(test_runner.result_code))
-
-		return test_runner.result_code
-	else:
-		printerr("Error: Test runner not found")
+	var included_paths: PackedStringArray = tests.split(";", false)
+	if included_paths.is_empty():
+		printerr("No test path provided.")
 		return 1
+	print(" -- Tests included: ", included_paths)
+
+	# Add test runner node.
+	print(" -- Adding test runner...")
+	# NOTE: A script that fails to parse still loads, only as an invalid resource.
+	var runner_script: Script = load("res://test/util/test_runner.gd")
+	if runner_script == null or not runner_script.can_instantiate():
+		printerr("Error: Test runner could not be loaded.")
+		return 1
+	var test_runner: Node = runner_script.new()
+	get_tree().root.add_child(test_runner)
+	for path in included_paths:
+		test_runner.include_tests(path)
+
+	# Wait for completion.
+	await test_runner.finished
+	print(">>> Test run complete with code: ", str(test_runner.result_code))
+
+	return test_runner.result_code
 
 
 func _cmd_dotnet_exception_capture(p_scenario: String) -> int:

--- a/project/test/util/test_runner.gd
+++ b/project/test/util/test_runner.gd
@@ -14,7 +14,8 @@ enum Result {
 	FAILURE = 100,
 	WARNINGS = 101,
 	TESTS_NOT_FOUND = 104,
-	DIDNT_RUN = 105
+	DIDNT_RUN = 105,
+	SCRIPT_ERRORS = 106
 }
 
 
@@ -40,15 +41,21 @@ var suite_stats := Stats.new()
 var result_code: int = Result.DIDNT_RUN
 
 var _included_tests := PackedStringArray()
+var _broken_scripts := PackedStringArray()
 
 
 ## Initialize test execution
 func init_runner() -> void:
 	print_rich(Fmt.step(), Fmt.prominent("Initializing test runner..."))
 	_discover_tests()
+
 	if _test_cases.is_empty():
-		print_rich(Fmt.error("No test cases found!"))
-		_finish(Result.TESTS_NOT_FOUND)
+		if _broken_scripts.is_empty():
+			print_rich(Fmt.error("No test cases found!"))
+			_finish(Result.TESTS_NOT_FOUND)
+		else:
+			_print_broken_scripts()
+			_finish(Result.SCRIPT_ERRORS)
 		return
 	_state = RUN
 
@@ -56,7 +63,9 @@ func init_runner() -> void:
 ## Returns the exit code based on test results.[br]
 ## Maps test report status to process exit codes.
 func get_exit_code() -> int:
-	if stats.num_total == 0:
+	if not _broken_scripts.is_empty():
+		return Result.SCRIPT_ERRORS
+	elif stats.num_total == 0:
 		return Result.DIDNT_RUN
 	elif stats.num_failed > 0 or stats.num_errors > 0:
 		return Result.FAILURE
@@ -75,14 +84,20 @@ func include_tests(path: String) -> void:
 	_included_tests.append(path)
 
 
-## Discover tests added with include_tests()
-func _discover_tests() -> Array[GdUnitTestCase]:
+## Discover tests added with include_tests(), collecting scripts that fail to load.
+func _discover_tests() -> void:
 	var gdunit_test_discover_added := GdUnitSignals.instance().gdunit_test_discover_added
 
 	var scanner := GdUnitTestSuiteScanner.new()
 	for path in _included_tests:
-		var scripts := scanner.scan(path)
-		for script in scripts:
+		# The scanner drops scripts it fails to load, so check them separately.
+		for script_path in _find_scripts(path):
+			# NOTE: A script that fails to parse still loads, only as an invalid resource.
+			var script := load(script_path) as Script
+			if script == null or not script.can_instantiate():
+				_broken_scripts.append(script_path)
+
+		for script in scanner.scan(path):
 			print_rich(Fmt.step(), "Scanning: ", Fmt.suite(script.resource_path))
 			GdUnitTestDiscoverer.discover_tests(script, func(test: GdUnitTestCase) -> void:
 				print_rich(Fmt.substep(), "Discovered %s" % Fmt.case(test.display_name))
@@ -90,7 +105,27 @@ func _discover_tests() -> Array[GdUnitTestCase]:
 				gdunit_test_discover_added.emit(test)
 			)
 
-	return _test_cases
+
+## Returns the GDScript paths at the given path, which is either a script or a directory.[br]
+## Returns nothing if the path doesn't exist or isn't a GDScript.
+static func _find_scripts(path: String) -> PackedStringArray:
+	var dir := DirAccess.open(path)
+	if dir == null:
+		if path.get_extension() == "gd" and FileAccess.file_exists(path):
+			return PackedStringArray([path])
+		return PackedStringArray()
+
+	# Directories excluded from the Godot project are excluded from testing too.
+	if dir.file_exists(".gdignore"):
+		return PackedStringArray()
+
+	var scripts := PackedStringArray()
+	for file_name in DirAccess.get_files_at(path):
+		if file_name.get_extension() == "gd":
+			scripts.append(path.path_join(file_name))
+	for dir_name in DirAccess.get_directories_at(path):
+		scripts.append_array(_find_scripts(path.path_join(dir_name)))
+	return scripts
 
 
 func _finish(code: int) -> void:
@@ -114,6 +149,7 @@ func _on_gdunit_event(event: GdUnitEvent) -> void:
 		GdUnitEvent.STOP:
 			print_rich(Fmt.step(), Fmt.prominent("Finished all tests."))
 			_print_stats(stats, "Overall Summary")
+			_print_broken_scripts()
 
 		GdUnitEvent.TESTSUITE_BEFORE:
 			print_rich(Fmt.step(), Fmt.prominent("Loading: "), Fmt.suite(event.resource_path()))
@@ -157,6 +193,16 @@ func _on_gdunit_event(event: GdUnitEvent) -> void:
 
 
 # *** CONSOLE OUTPUT
+
+## Reports test scripts that failed to load. Such scripts are absent from the test
+## results above, so they are listed separately to explain the failed run.
+func _print_broken_scripts() -> void:
+	if _broken_scripts.is_empty():
+		return
+	print_rich(Fmt.substep(), Fmt.bold(Fmt.error("Scripts failed to load:")))
+	for script_path in _broken_scripts:
+		print_rich("    ", Fmt.error(script_path))
+
 
 static func _print_result(status: String, test_suite: String, test_case: String) -> void:
 	print_rich(Fmt.substep(), status, ": ",


### PR DESCRIPTION
The desktop test runner now loads every test script under the included paths and verifies it is valid, lists any that fail to parse/load after the test summary, and exits with a dedicated code so the run fails. Suites that do load still run to completion. The CLI `run-tests` command also validates the test runner script itself before instantiating it.

Test suites are discovered through gdUnit's scanner, which drops any script it fails to load, so a GDScript parse error in one suite made that suite vanish from the run while the remaining tests passed and the process exited with success. A parse error in the test runner script itself produced the same outcome by a different route: instantiating an unparsed script raises a runtime error that aborts the command, and because the command is declared to return an integer, the aborted call hands back the default zero and reports success. The Android and Web runners also invoke the same `run-tests` command, so they are covered as well.

**After this PR:**

<img width="877" height="832" alt="image" src="https://github.com/user-attachments/assets/bf0d57cf-184a-4c5c-ad95-9919b9a4b85c" />

