### PR TITLE
ci: Remove secrets: inherit from changelog-preview workflow

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -16,4 +16,3 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@f4889d04564e47311038ecb6b910fef6b6cf1363 # v2
-    secrets: inherit


### PR DESCRIPTION
## Summary
- `changelog-preview.yml` used `secrets: inherit` when calling the reusable `getsentry/craft/.github/workflows/changelog-preview.yml`, exposing every repository secret to the called workflow.
- The called workflow only declares `inputs` under `workflow_call` (no `secrets`) and only reads the auto-provisioned `${{ secrets.GITHUB_TOKEN }}`, which reusable workflows already receive without inheritance.
- Removed `secrets: inherit` entirely — no explicit secrets map is needed.

## Test plan
- [x] Confirmed `getsentry/craft/.github/workflows/changelog-preview.yml` declares no `workflow_call.secrets` and only uses `secrets.GITHUB_TOKEN`
- [ ] Verify the Changelog Preview check still runs and posts correctly on this PR

Fixes VULN-2343

🤖 Generated with [Claude Code](https://claude.com/claude-code)