### PR TITLE
feat(scopes): Add `SentryScope.add_attachment()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835), [#836](https://github.com/getsentry/sentry-godot/pull/836))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
-- Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
+  - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835), [#836](https://github.com/getsentry/sentry-godot/pull/836))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
+- Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 
 ### Dependencies
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -939,6 +939,46 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun scopeAddFileAttachment(
+        handle: Int,
+        path: String,
+        filename: String,
+        contentType: String,
+        attachmentType: String
+    ) {
+        val scope = getScope(handle) ?: return
+        scope.addAttachment(
+            Attachment(
+                path,
+                filename.ifEmpty { File(path).name },
+                contentType.ifEmpty { null },
+                attachmentType.ifEmpty { null },
+                false
+            )
+        )
+    }
+
+    @UsedByGodot
+    fun scopeAddBytesAttachment(
+        handle: Int,
+        bytes: ByteArray,
+        filename: String,
+        contentType: String,
+        attachmentType: String
+    ) {
+        val scope = getScope(handle) ?: return
+        scope.addAttachment(
+            Attachment(
+                bytes,
+                filename,
+                contentType.ifEmpty { null },
+                attachmentType.ifEmpty { null },
+                false
+            )
+        )
+    }
+
+    @UsedByGodot
     fun scopeClear(handle: Int) {
         val scope = getScope(handle) ?: return
         scope.clear()

--- a/doc_classes/SentryScope.xml
+++ b/doc_classes/SentryScope.xml
@@ -19,6 +19,15 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_attachment">
+			<return type="void" />
+			<param index="0" name="attachment" type="SentryAttachment" />
+			<description>
+				Attaches a file to the events captured within this scope. The [param attachment] should be a [SentryAttachment] object created with [method SentryAttachment.create_with_path] or [method SentryAttachment.create_with_bytes]. Supports Godot's virtual file system paths like "user://".
+				See [method SentrySDK.add_attachment] for attaching a file to all future events.
+				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/attachments/]Attachments documentation[/url].
+			</description>
+		</method>
 		<method name="add_breadcrumb">
 			<return type="void" />
 			<param index="0" name="breadcrumb" type="SentryBreadcrumb" />

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -170,7 +170,8 @@ func _cmd_attachment_capture() -> int:
 		scope.add_attachment(scoped_bytes)
 		# Write the file after attaching it; this verifies file contents are loaded at event capture time.
 		_write_text_file("user://scoped_attachment.txt", "Scoped file attachment for integration testing.\n")
-		print("EVENT_CAPTURED: ", SentrySDK.capture_message("Scoped attachment test message"))
+		# Marked separately from EVENT_CAPTURED so the shared test cases still see a single capture.
+		print("SCOPED_EVENT_ID: ", SentrySDK.capture_message("Scoped attachment test message"))
 		)
 
 	var event_id := SentrySDK.capture_message("Attachment test message")

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -161,6 +161,18 @@ func _cmd_attachment_capture() -> int:
 	runtime_bytes.content_type = "text/plain"
 	SentrySDK.add_attachment(runtime_bytes)
 
+	# Captured before the unscoped event below, so that event can prove the scope attachments didn't leak.
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.add_attachment(SentryAttachment.create_with_path("user://scoped_attachment.txt"))
+		var scoped_bytes := SentryAttachment.create_with_bytes(
+			"Scoped bytes".to_utf8_buffer(), "scoped_bytes.txt")
+		scoped_bytes.content_type = "text/plain"
+		scope.add_attachment(scoped_bytes)
+		# Write the file after attaching it; this verifies file contents are loaded at event capture time.
+		_write_text_file("user://scoped_attachment.txt", "Scoped file attachment for integration testing.\n")
+		print("EVENT_CAPTURED: ", SentrySDK.capture_message("Scoped attachment test message"))
+		)
+
 	var event_id := SentrySDK.capture_message("Attachment test message")
 	print("EVENT_CAPTURED: ", event_id)
 	_print_test_result("attachment-capture", true, "Test complete")

--- a/src/sentry/android/android_scope.cpp
+++ b/src/sentry/android/android_scope.cpp
@@ -73,6 +73,25 @@ void AndroidScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	android_plugin->call(ANDROID_SN(scopeAddBreadcrumb), handle, crumb->get_handle());
 }
 
+void AndroidScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
+	ERR_FAIL_NULL(android_plugin);
+
+	if (!p_attachment->get_path().is_empty()) {
+		String absolute_path = p_attachment->get_globalized_path();
+		android_plugin->call(ANDROID_SN(scopeAddFileAttachment), handle,
+				absolute_path,
+				p_attachment->get_effective_filename(),
+				p_attachment->get_content_type(),
+				p_attachment->get_attachment_type());
+	} else {
+		android_plugin->call(ANDROID_SN(scopeAddBytesAttachment), handle,
+				p_attachment->get_bytes(),
+				p_attachment->get_filename(),
+				p_attachment->get_content_type(),
+				p_attachment->get_attachment_type());
+	}
+}
+
 void AndroidScope::clear() {
 	ERR_FAIL_NULL(android_plugin);
 	android_plugin->call(ANDROID_SN(scopeClear), handle);

--- a/src/sentry/android/android_scope.h
+++ b/src/sentry/android/android_scope.h
@@ -21,6 +21,7 @@ public:
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear() override;
 	virtual SentryScopeImpl *clone() const override;
 

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -101,6 +101,8 @@ AndroidStringNames::AndroidStringNames() {
 	scopeSetAttributeDouble = StringName("scopeSetAttributeDouble");
 	scopeSetAttributeString = StringName("scopeSetAttributeString");
 	scopeAddBreadcrumb = StringName("scopeAddBreadcrumb");
+	scopeAddFileAttachment = StringName("scopeAddFileAttachment");
+	scopeAddBytesAttachment = StringName("scopeAddBytesAttachment");
 	scopeClear = StringName("scopeClear");
 
 	// Logs.

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -112,6 +112,8 @@ public:
 	StringName scopeSetAttributeDouble;
 	StringName scopeSetAttributeString;
 	StringName scopeAddBreadcrumb;
+	StringName scopeAddFileAttachment;
+	StringName scopeAddBytesAttachment;
 	StringName scopeClear;
 
 	// Logs.

--- a/src/sentry/disabled/disabled_scope.h
+++ b/src/sentry/disabled/disabled_scope.h
@@ -15,6 +15,7 @@ public:
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override {}
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override {}
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override {}
+	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override {}
 	virtual void clear() override {}
 	virtual SentryScopeImpl *clone() const override { return memnew(DisabledScope); }
 };

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -306,6 +306,14 @@ class SentryBridge {
     scope.setUser(makeUser(id, username, email, ip));
   }
 
+  public scopeAddBytesAttachment(scope: Sentry.Scope, filename: string, bytes: Uint8Array, contentType: string): void {
+    scope.addAttachment({
+      filename,
+      data: bytes,
+      contentType,
+    });
+  }
+
   public scopeClear(scope: Sentry.Scope): void {
     // Preserve the propagation context across clear() because Scope.clear() rotates the trace in JS.
     const propagationContext = scope.getPropagationContext();

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -58,13 +58,19 @@ function safeParseJSON<T = any>(json: string, fallback: T): T {
   }
 }
 
+function makeAttachment(filename: string, bytes: Uint8Array, contentType: string, attachmentType: string): Attachment {
+  return {
+    filename,
+    data: bytes,
+    ...(contentType && { contentType }),
+    ...(attachmentType && { attachmentType }),
+  } as Attachment;
+}
+
 // Builds an attachment whose bytes the C++ layer reads from the path when an event is captured.
 function makePendingAttachment(path: string, filename: string, contentType: string, attachmentType: string): Attachment {
   return {
-    filename,
-    data: new Uint8Array(0),
-    ...(contentType && { contentType }),
-    ...(attachmentType && { attachmentType }),
+    ...makeAttachment(filename, new Uint8Array(0), contentType, attachmentType),
     [PENDING_PATH_KEY]: path,
   } as Attachment;
 }
@@ -325,12 +331,14 @@ class SentryBridge {
     scope.setUser(makeUser(id, username, email, ip));
   }
 
-  public scopeAddBytesAttachment(scope: Sentry.Scope, filename: string, bytes: Uint8Array, contentType: string): void {
-    scope.addAttachment({
-      filename,
-      data: bytes,
-      contentType,
-    });
+  public scopeAddBytesAttachment(
+    scope: Sentry.Scope,
+    filename: string,
+    bytes: Uint8Array,
+    contentType: string,
+    attachmentType: string,
+  ): void {
+    scope.addAttachment(makeAttachment(filename, bytes, contentType, attachmentType));
   }
 
   public scopeAddFileAttachment(
@@ -453,12 +461,8 @@ class SentryBridge {
     Sentry.addBreadcrumb(crumb);
   }
 
-  public addBytesAttachment(filename: string, bytes: Uint8Array, contentType: string): void {
-    Sentry.getIsolationScope().addAttachment({
-      filename,
-      data: bytes,
-      contentType,
-    });
+  public addBytesAttachment(filename: string, bytes: Uint8Array, contentType: string, attachmentType: string): void {
+    Sentry.getIsolationScope().addAttachment(makeAttachment(filename, bytes, contentType, attachmentType));
   }
 
   public addFileAttachment(path: string, filename: string, contentType: string, attachmentType: string): void {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -31,14 +31,6 @@ class IdStore<T> {
   }
 }
 
-// Stores info about attachments loaded from C++ layer during event processing.
-interface AttachmentData {
-  bytes: Uint8Array;
-  filename: string;
-  contentType?: string;
-  attachmentType?: string;
-}
-
 // The JS SDK has no notion of file attachments - it only takes bytes. A file is therefore added as an
 // attachment object marked with this property, which holds the path, and the C++ layer fills in the
 // bytes when an event is captured. Sentry copies only its own known fields into the envelope, so the
@@ -64,6 +56,17 @@ function safeParseJSON<T = any>(json: string, fallback: T): T {
     console.error("Failed to parse JSON:", error);
     return fallback;
   }
+}
+
+// Builds an attachment whose bytes the C++ layer reads from the path when an event is captured.
+function makePendingAttachment(path: string, filename: string, contentType: string, attachmentType: string): Attachment {
+  return {
+    filename,
+    data: new Uint8Array(0),
+    ...(contentType && { contentType }),
+    ...(attachmentType && { attachmentType }),
+    [PENDING_PATH_KEY]: path,
+  } as Attachment;
 }
 
 function makeUser(id: string, username: string, email: string, ip: string): User {
@@ -119,23 +122,8 @@ class SentryBridge {
     this._objectStore.release(id);
   }
 
-  public pushAttachmentData(
-    attachmentData: Array<AttachmentData>,
-    bytes: Uint8Array,
-    filename: string,
-    contentType?: string,
-    attachmentType?: string,
-  ): void {
-    attachmentData.push({
-      bytes,
-      filename,
-      contentType,
-      attachmentType,
-    });
-  }
-
   public init(
-    beforeSendCallback: (event: Sentry.Event, outAttachments: Array<AttachmentData>) => void,
+    beforeSendCallback: (event: Sentry.Event) => void,
     beforeSendLogCallback: ((log: Sentry.Log) => void) | null,
     beforeSendMetricCallback: ((metric: Metric) => void) | null,
     readAttachmentCallback: (request: AttachmentRequest) => void,
@@ -197,31 +185,13 @@ class SentryBridge {
     };
 
     if (beforeSendCallback) {
-      options.beforeSend = (event: Sentry.Event, hint: Sentry.EventHint) => {
+      options.beforeSend = (event: Sentry.Event) => {
         if (!this.isEnabled()) {
           // SDK is disabled, skip processing.
           return null;
         }
 
-        // NOTE: Populated during processing in C++ layer
-        const outAttachments: Array<AttachmentData> = [];
-
-        beforeSendCallback(event, outAttachments);
-
-        // Add attachments loaded from the C++ layer during event processing
-        if (!hint.attachments) {
-          hint.attachments = [];
-        }
-        for (const attachmentData of outAttachments) {
-          if (attachmentData.bytes) {
-            hint.attachments.push({
-              data: attachmentData.bytes,
-              filename: attachmentData.filename,
-              ...(attachmentData.contentType && { contentType: attachmentData.contentType }),
-              ...(attachmentData.attachmentType && { attachmentType: attachmentData.attachmentType }),
-            } as any);
-          }
-        }
+        beforeSendCallback(event);
 
         const shouldDiscard: boolean = (event as any).shouldDiscard;
         delete (event as any).shouldDiscard;
@@ -363,13 +333,14 @@ class SentryBridge {
     });
   }
 
-  public scopeAddFileAttachment(scope: Sentry.Scope, path: string, filename: string, contentType: string): void {
-    scope.addAttachment({
-      filename,
-      data: new Uint8Array(0),
-      ...(contentType && { contentType }),
-      [PENDING_PATH_KEY]: path,
-    } as Attachment);
+  public scopeAddFileAttachment(
+    scope: Sentry.Scope,
+    path: string,
+    filename: string,
+    contentType: string,
+    attachmentType: string,
+  ): void {
+    scope.addAttachment(makePendingAttachment(path, filename, contentType, attachmentType));
   }
 
   public scopeClear(scope: Sentry.Scope): void {
@@ -488,6 +459,10 @@ class SentryBridge {
       data: bytes,
       contentType,
     });
+  }
+
+  public addFileAttachment(path: string, filename: string, contentType: string, attachmentType: string): void {
+    Sentry.getIsolationScope().addAttachment(makePendingAttachment(path, filename, contentType, attachmentType));
   }
 
   public clearAttachments(): void {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import type { Breadcrumb, User } from "@sentry/browser";
-import type { Metric } from "@sentry/core";
+import type { Attachment, Metric } from "@sentry/core";
 import { wasmIntegration } from "@sentry/wasm";
 
 // ID-based store for WASM/JS interop. Assigns auto-incrementing uint32 IDs (0 is reserved).
@@ -37,6 +37,18 @@ interface AttachmentData {
   filename: string;
   contentType?: string;
   attachmentType?: string;
+}
+
+// The JS SDK has no notion of file attachments - it only takes bytes. A file is therefore added as an
+// attachment object marked with this property, which holds the path, and the C++ layer fills in the
+// bytes when an event is captured. Sentry copies only its own known fields into the envelope, so the
+// marker is never sent.
+const PENDING_PATH_KEY = "__godotPath";
+
+// Handed to the C++ layer to have it read one file; it leaves the bytes unset if the read fails.
+interface AttachmentRequest {
+  path: string;
+  data?: Uint8Array;
 }
 
 // *** Utility Functions
@@ -126,6 +138,7 @@ class SentryBridge {
     beforeSendCallback: (event: Sentry.Event, outAttachments: Array<AttachmentData>) => void,
     beforeSendLogCallback: ((log: Sentry.Log) => void) | null,
     beforeSendMetricCallback: ((metric: Metric) => void) | null,
+    readAttachmentCallback: (request: AttachmentRequest) => void,
     dsn: string,
     debug: boolean,
     release: string,
@@ -249,6 +262,42 @@ class SentryBridge {
     }
 
     Sentry.init(options);
+
+    if (readAttachmentCallback) {
+      // Runs for every event type right before the attachments become envelope items, whereas
+      // beforeSend only sees error events and would leave feedback captures with empty bytes.
+      Sentry.getClient()?.on("beforeSendEvent", (_event: Sentry.Event, hint?: Sentry.EventHint) => {
+        if (!hint?.attachments?.some((attachment: any) => attachment[PENDING_PATH_KEY])) {
+          return;
+        }
+
+        const outgoing: Array<any> = [];
+        for (const attachment of hint.attachments as Array<any>) {
+          const path = attachment[PENDING_PATH_KEY];
+          if (!path) {
+            outgoing.push(attachment);
+            continue;
+          }
+
+          // The C++ layer fills in the bytes, and leaves the request untouched if it cannot read the file.
+          const request: AttachmentRequest = { path };
+          readAttachmentCallback(request);
+          if (!request.data) {
+            // Not a warning: some attachments are expected to be missing.
+            console.debug(`Sentry: dropping attachment - file could not be read: ${path}`);
+            continue;
+          }
+
+          // Copy before adding bytes so scoped attachments don't retain them for future captures.
+          const resolved = { ...attachment, data: request.data };
+          delete resolved[PENDING_PATH_KEY];
+          outgoing.push(resolved);
+        }
+        hint.attachments = outgoing;
+      });
+    } else {
+      console.error("Sentry: Internal error: attachment read callback is missing. File attachments added to a scope will be empty.");
+    }
   }
 
   public close(timeout: number): void {
@@ -312,6 +361,15 @@ class SentryBridge {
       data: bytes,
       contentType,
     });
+  }
+
+  public scopeAddFileAttachment(scope: Sentry.Scope, path: string, filename: string, contentType: string): void {
+    scope.addAttachment({
+      filename,
+      data: new Uint8Array(0),
+      ...(contentType && { contentType }),
+      [PENDING_PATH_KEY]: path,
+    } as Attachment);
   }
 
   public scopeClear(scope: Sentry.Scope): void {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -60,6 +60,7 @@ try {
 			"scopeSetFingerprint",
 			"scopeSetUser",
 			"scopeAddBytesAttachment",
+			"scopeAddFileAttachment",
 			"scopeClear",
 			"logTrace",
 			"logDebug",
@@ -72,8 +73,8 @@ try {
 			"lastEventId",
 			"addBreadcrumb",
 			"addBytesAttachment",
+			"addFileAttachment",
 			"clearAttachments",
-			"pushAttachmentData",
 			"storeBytes",
 			"takeBytes",
 			"releaseBytes",
@@ -110,8 +111,24 @@ try {
 
 		console.log("\n🧪 Functional tests:");
 
+		// Stands in for the C++ layer: hands back fixed bytes, leaving "user://missing.txt" unread like a missing file.
+		const readAttachmentPaths = [];
+		const readAttachment = (request) => {
+			readAttachmentPaths.push(request.path);
+			if (request.path !== "user://missing.txt") {
+				request.data = new Uint8Array([ 1, 2, 3, 4 ]);
+			}
+		};
+
 		runTest("init()", () => {
-			bridge.init(() => {}, null, null, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
+			bridge.init(() => {}, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
+		});
+
+		// Observes what actually goes out with an event. The bridge registers its own handler during
+		// init() and handlers run in registration order, so this one sees the resolved and filtered list.
+		const sentAttachments = [];
+		bridge.createScope().getClient().on("beforeSendEvent", (_event, hint) => {
+			sentAttachments.push(hint?.attachments ?? []);
 		});
 
 		runTest("isEnabled()", () => {
@@ -229,6 +246,47 @@ try {
 			assertEqual(attachments[0].data.length, 3, "scopeAddBytesAttachment should carry the bytes");
 		});
 
+		runTest("scopeAddFileAttachment()", () => {
+			const scope = bridge.createScope();
+			bridge.scopeAddFileAttachment(scope, "user://save.dat", "save.dat", "application/octet-stream", "");
+			const attachments = scope.getScopeData().attachments;
+			assertEqual(attachments.length, 1, "scopeAddFileAttachment should add the attachment to the scope");
+			assertEqual(attachments[0].filename, "save.dat", "scopeAddFileAttachment should set the filename");
+			assertEqual(attachments[0].data.length, 0, "scopeAddFileAttachment should leave the bytes for capture time");
+			assertEqual(attachments[0].__godotPath, "user://save.dat",
+					"scopeAddFileAttachment should mark the attachment with the path to read at capture time");
+		});
+
+		runTest("file attachments resolve on capture", () => {
+			const scope = bridge.createScope();
+			bridge.scopeAddFileAttachment(scope, "user://save.dat", "save.dat", "application/octet-stream", "");
+
+			const readCountBefore = readAttachmentPaths.length;
+			bridge.captureEvent({ message : "Event with a file attachment" }, scope);
+			assertEqual(readAttachmentPaths.length, readCountBefore + 1, "captureEvent should read the file once");
+			assertEqual(readAttachmentPaths[readAttachmentPaths.length - 1], "user://save.dat", "captureEvent should read the attachment path");
+
+			const sent = sentAttachments[sentAttachments.length - 1];
+			assertEqual(sent.length, 1, "captureEvent should send the resolved attachment");
+			assertEqual(sent[0].data.length, 4, "the sent attachment should carry the bytes that were read");
+			assertEqual(sent[0].filename, "save.dat", "resolving should keep the filename");
+			assertEqual(sent[0].__godotPath, undefined, "the path marker should not be sent with the event");
+
+			const kept = scope.getScopeData().attachments[0];
+			assertEqual(kept.data.length, 0, "the scope's own attachment should not keep the bytes");
+			assertEqual(kept.__godotPath, "user://save.dat",
+					"the scope should keep the path so the next capture reads the file again");
+		});
+
+		runTest("unreadable file attachments are dropped", () => {
+			const scope = bridge.createScope();
+			bridge.scopeAddFileAttachment(scope, "user://missing.txt", "missing.txt", "", "");
+			bridge.captureEvent({ message : "Event with a missing file attachment" }, scope);
+
+			const sent = sentAttachments[sentAttachments.length - 1];
+			assertEqual(sent.length, 0, "an attachment the C++ layer could not read should not be sent");
+		});
+
 		runTest("scopeClear()", () => {
 			const scope = bridge.createScope();
 			bridge.scopeSetContext(scope, "test-context", '{"key": "value"}');
@@ -306,19 +364,17 @@ try {
 			assertEqual(bridge.takeBytes(id), undefined, "releaseBytes should discard bytes");
 		});
 
-		runTest("pushAttachmentData()", () => {
-			const attachments = [];
-			bridge.pushAttachmentData(attachments, new Uint8Array([ 1, 2, 3 ]), "test.bin", "application/octet-stream", "event.attachment");
-			assertEqual(attachments.length, 1, "should push one attachment");
-			assertEqual(attachments[0].filename, "test.bin", "filename should match");
-			assertEqual(attachments[0].bytes.length, 3, "bytes length should match");
-			assertEqual(attachments[0].contentType, "application/octet-stream", "contentType should match");
-			assertEqual(attachments[0].attachmentType, "event.attachment", "attachmentType should match");
+		// Globally added file attachments go through the same resolution as the scoped ones above.
+		runTest("addFileAttachment()", () => {
+			bridge.addFileAttachment("user://global.dat", "global.dat", "application/json", "event.view_hierarchy");
+			bridge.captureEvent({ message : "Event with a global file attachment" }, bridge.createScope());
 
-			bridge.pushAttachmentData(attachments, new Uint8Array([ 4, 5 ]), "test2.bin");
-			assertEqual(attachments.length, 2, "should push second attachment");
-			assertEqual(attachments[1].contentType, undefined, "optional contentType should be undefined");
-			assertEqual(attachments[1].attachmentType, undefined, "optional attachmentType should be undefined");
+			const sent = sentAttachments[sentAttachments.length - 1];
+			const globalAttachment = sent.find((attachment) => attachment.filename === "global.dat");
+			assert(globalAttachment, "addFileAttachment should send the attachment with the event");
+			assertEqual(globalAttachment.data.length, 4, "the global attachment should carry the bytes that were read");
+			assertEqual(globalAttachment.contentType, "application/json", "addFileAttachment should set the content type");
+			assertEqual(globalAttachment.attachmentType, "event.view_hierarchy", "addFileAttachment should set the attachment type");
 		});
 
 		runTest("addBytesAttachment()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -59,6 +59,7 @@ try {
 			"scopeSetContext",
 			"scopeSetFingerprint",
 			"scopeSetUser",
+			"scopeAddBytesAttachment",
 			"scopeClear",
 			"logTrace",
 			"logDebug",
@@ -216,6 +217,16 @@ try {
 			fork.setTag("subsystem", "worldgen");
 			assertEqual(scope.getScopeData().tags.subsystem, "savegame",
 					"writes to the clone should not reach the parent");
+		});
+
+		runTest("scopeAddBytesAttachment()", () => {
+			const scope = bridge.createScope();
+			bridge.scopeAddBytesAttachment(scope, "save.txt", new Uint8Array([ 1, 2, 3 ]), "text/plain");
+			const attachments = scope.getScopeData().attachments;
+			assertEqual(attachments.length, 1, "scopeAddBytesAttachment should add the attachment to the scope");
+			assertEqual(attachments[0].filename, "save.txt", "scopeAddBytesAttachment should set the filename");
+			assertEqual(attachments[0].contentType, "text/plain", "scopeAddBytesAttachment should set the content type");
+			assertEqual(attachments[0].data.length, 3, "scopeAddBytesAttachment should carry the bytes");
 		});
 
 		runTest("scopeClear()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -238,11 +238,12 @@ try {
 
 		runTest("scopeAddBytesAttachment()", () => {
 			const scope = bridge.createScope();
-			bridge.scopeAddBytesAttachment(scope, "save.txt", new Uint8Array([ 1, 2, 3 ]), "text/plain");
+			bridge.scopeAddBytesAttachment(scope, "save.txt", new Uint8Array([ 1, 2, 3 ]), "text/plain", "event.attachment");
 			const attachments = scope.getScopeData().attachments;
 			assertEqual(attachments.length, 1, "scopeAddBytesAttachment should add the attachment to the scope");
 			assertEqual(attachments[0].filename, "save.txt", "scopeAddBytesAttachment should set the filename");
 			assertEqual(attachments[0].contentType, "text/plain", "scopeAddBytesAttachment should set the content type");
+			assertEqual(attachments[0].attachmentType, "event.attachment", "scopeAddBytesAttachment should set the attachment type");
 			assertEqual(attachments[0].data.length, 3, "scopeAddBytesAttachment should carry the bytes");
 		});
 
@@ -378,7 +379,7 @@ try {
 		});
 
 		runTest("addBytesAttachment()", () => {
-			bridge.addBytesAttachment("test.txt", new Uint8Array([ 104, 101, 108, 108, 111 ]), "text/plain");
+			bridge.addBytesAttachment("test.txt", new Uint8Array([ 104, 101, 108, 108, 111 ]), "text/plain", "");
 		});
 
 		runTest("clearAttachments()", () => {

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -81,7 +81,8 @@ void JavaScriptScope::add_attachment(const Ref<SentryAttachment> &p_attachment) 
 				js_obj,
 				p_attachment->get_effective_filename().utf8(),
 				p_attachment->get_bytes(),
-				p_attachment->get_content_type_or_default().utf8());
+				p_attachment->get_content_type_or_default().utf8(),
+				p_attachment->get_attachment_type().utf8());
 	}
 }
 

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -74,7 +74,8 @@ void JavaScriptScope::add_attachment(const Ref<SentryAttachment> &p_attachment) 
 				js_obj,
 				p_attachment->get_path().utf8(),
 				p_attachment->get_effective_filename().utf8(),
-				p_attachment->get_content_type().utf8());
+				p_attachment->get_content_type().utf8(),
+				p_attachment->get_attachment_type().utf8());
 	} else {
 		js_bridge()->call("scopeAddBytesAttachment",
 				js_obj,

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -4,7 +4,6 @@
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/sentry_sdk.h"
 
-#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/json.hpp>
 #include <godot_cpp/core/error_macros.hpp>
 
@@ -70,20 +69,19 @@ void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) 
 }
 
 void JavaScriptScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
-	PackedByteArray bytes = p_attachment->get_bytes();
-
 	if (!p_attachment->get_path().is_empty()) {
-		// JS attachments carry bytes only, so the file is read here rather than when an event is captured.
-		Ref<FileAccess> file = FileAccess::open(p_attachment->get_path(), FileAccess::READ);
-		ERR_FAIL_COND_MSG(file.is_null(), vformat("Sentry: Failed to read attachment file: %s", p_attachment->get_path()));
-		bytes = file->get_buffer(file->get_length());
+		js_bridge()->call("scopeAddFileAttachment",
+				js_obj,
+				p_attachment->get_path().utf8(),
+				p_attachment->get_effective_filename().utf8(),
+				p_attachment->get_content_type().utf8());
+	} else {
+		js_bridge()->call("scopeAddBytesAttachment",
+				js_obj,
+				p_attachment->get_effective_filename().utf8(),
+				p_attachment->get_bytes(),
+				p_attachment->get_content_type_or_default().utf8());
 	}
-
-	js_bridge()->call("scopeAddBytesAttachment",
-			js_obj,
-			p_attachment->get_effective_filename().utf8(),
-			bytes,
-			p_attachment->get_content_type_or_default().utf8());
 }
 
 void JavaScriptScope::clear() {

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -4,6 +4,7 @@
 #include "sentry/javascript/javascript_breadcrumb.h"
 #include "sentry/sentry_sdk.h"
 
+#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/json.hpp>
 #include <godot_cpp/core/error_macros.hpp>
 
@@ -66,6 +67,23 @@ void JavaScriptScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) 
 	ERR_FAIL_NULL(crumb);
 
 	js_obj->call("addBreadcrumb", crumb->get_js_object(), SENTRY_OPTIONS()->get_max_breadcrumbs());
+}
+
+void JavaScriptScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
+	PackedByteArray bytes = p_attachment->get_bytes();
+
+	if (!p_attachment->get_path().is_empty()) {
+		// JS attachments carry bytes only, so the file is read here rather than when an event is captured.
+		Ref<FileAccess> file = FileAccess::open(p_attachment->get_path(), FileAccess::READ);
+		ERR_FAIL_COND_MSG(file.is_null(), vformat("Sentry: Failed to read attachment file: %s", p_attachment->get_path()));
+		bytes = file->get_buffer(file->get_length());
+	}
+
+	js_bridge()->call("scopeAddBytesAttachment",
+			js_obj,
+			p_attachment->get_effective_filename().utf8(),
+			bytes,
+			p_attachment->get_content_type_or_default().utf8());
 }
 
 void JavaScriptScope::clear() {

--- a/src/sentry/javascript/javascript_scope.h
+++ b/src/sentry/javascript/javascript_scope.h
@@ -24,6 +24,7 @@ public:
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear() override;
 	virtual SentryScopeImpl *clone() const override;
 

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -23,8 +23,6 @@
 
 namespace sentry::javascript {
 
-static JavaScriptSDK *js_sdk = nullptr;
-
 // *** WASM callbacks
 
 extern "C" {
@@ -366,14 +364,6 @@ void JavaScriptSDK::close() {
 bool JavaScriptSDK::is_enabled() const {
 	ERR_FAIL_COND_V(!js_bridge(), false);
 	return js_bridge()->call("isEnabled").as_bool();
-}
-
-JavaScriptSDK::JavaScriptSDK() {
-	js_sdk = this;
-}
-
-JavaScriptSDK::~JavaScriptSDK() {
-	js_sdk = nullptr;
 }
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -30,56 +30,17 @@ static JavaScriptSDK *js_sdk = nullptr;
 extern "C" {
 
 static void before_send_wasm_callback(int32_t *p_ids, int32_t p_len) {
-	ERR_FAIL_COND(p_len != 2);
-	ERR_FAIL_NULL(js_sdk);
+	ERR_FAIL_COND(p_len != 1);
 
 	JSObjectPtr event_obj = JSObject::from_id(p_ids[0]);
-	JSObjectPtr out_attachments = JSObject::from_id(p_ids[1]);
 	ERR_FAIL_COND(!event_obj);
-	ERR_FAIL_COND(!out_attachments);
 
 	Ref<JavaScriptEvent> event = memnew(JavaScriptEvent(event_obj));
 	Ref<JavaScriptEvent> processed = sentry::process_event(event);
 
 	// NOTE: We cannot return a value from a callback, so we use the same
 	//       event object to communicate the result back.
-	if (unlikely(processed.is_null())) {
-		// Discard event.
-		event_obj->set("shouldDiscard", true);
-	} else {
-		event_obj->set("shouldDiscard", false);
-
-		// Read file-based attachments and include them with the event.
-		for (const Ref<SentryAttachment> &att : js_sdk->get_file_attachments()) {
-			if (att->get_path().is_empty()) {
-				// Skip attachments with empty path.
-				// NOTE: Byte attachments are not processed here - they are added immediately.
-				continue;
-			}
-
-			Ref<FileAccess> file = FileAccess::open(att->get_path(), FileAccess::READ);
-			if (file.is_null()) {
-				// NOTE: Some attachments may legitimately be missing (e.g. screenshots not created on non-main threads).
-				sentry::logging::print_debug("Skipping attachment - file not found: " + att->get_path());
-				continue;
-			}
-
-			PackedByteArray bytes = file->get_buffer(file->get_length());
-			if (bytes.is_empty()) {
-				sentry::logging::print_debug("Skipping attachment - empty file: " + att->get_path());
-				continue;
-			}
-
-			sentry::logging::print_debug("Adding attachment: " + att->get_path());
-
-			js_bridge()->call("pushAttachmentData",
-					out_attachments,
-					bytes,
-					att->get_effective_filename().utf8(),
-					att->get_content_type().utf8(),
-					att->get_attachment_type().utf8());
-		}
-	}
+	event_obj->set("shouldDiscard", processed.is_null());
 }
 
 // Reads the file a scope attachment refers to, leaving the bytes unset if it cannot be read.
@@ -269,10 +230,13 @@ void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 	ERR_FAIL_COND_MSG(p_attachment.is_null(), "Sentry: Can't add null attachment.");
 
 	if (!p_attachment->get_path().is_empty()) {
-		// File attachment - add to list for on-demand loading during event processing.
-		file_attachments.push_back(p_attachment);
+		// The file is read when an event is captured, so it doesn't have to exist yet.
+		js_bridge()->call("addFileAttachment",
+				p_attachment->get_path().utf8(),
+				p_attachment->get_effective_filename().utf8(),
+				p_attachment->get_content_type().utf8(),
+				p_attachment->get_attachment_type().utf8());
 	} else {
-		// Bytes attachment - added immediately
 		ERR_FAIL_COND_MSG(p_attachment->get_filename().is_empty(), "Sentry: Can't add bytes attachment without filename.");
 
 		js_bridge()->call("addBytesAttachment",
@@ -285,9 +249,14 @@ void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 void JavaScriptSDK::clear_attachments() {
 	ERR_FAIL_COND(!js_bridge());
 
-	// Reset file attachments from options (Vector uses copy-on-write).
-	file_attachments = SENTRY_OPTIONS()->get_default_attachments();
 	js_bridge()->call("clearAttachments");
+	_add_default_attachments();
+}
+
+void JavaScriptSDK::_add_default_attachments() {
+	for (const Ref<SentryAttachment> &att : SENTRY_OPTIONS()->get_default_attachments()) {
+		add_attachment(att);
+	}
 }
 
 void JavaScriptSDK::metrics_add_count(const Ref<SentryScope> &p_scope, const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
@@ -348,8 +317,6 @@ void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_s
 void JavaScriptSDK::init() {
 	ERR_FAIL_COND(!js_bridge());
 
-	file_attachments = SENTRY_OPTIONS()->get_default_attachments();
-
 	JSObjectPtr before_send_callback = JSObject::create_callback(before_send_wasm_callback);
 	JSObjectPtr read_attachment_callback = JSObject::create_callback(read_attachment_wasm_callback);
 
@@ -383,6 +350,7 @@ void JavaScriptSDK::init() {
 
 	if (is_enabled()) {
 		set_user(SentryUser::create_default());
+		_add_default_attachments();
 	} else {
 		ERR_PRINT("Sentry: Failed to initialize JavaScript SDK.");
 	}
@@ -392,7 +360,6 @@ void JavaScriptSDK::close() {
 	ERR_FAIL_COND(!js_bridge());
 
 	js_bridge()->call("close", SENTRY_OPTIONS()->get_shutdown_timeout_ms());
-	file_attachments.clear();
 }
 
 bool JavaScriptSDK::is_enabled() const {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -242,7 +242,8 @@ void JavaScriptSDK::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 		js_bridge()->call("addBytesAttachment",
 				p_attachment->get_filename().utf8(),
 				p_attachment->get_bytes(),
-				p_attachment->get_content_type_or_default().utf8());
+				p_attachment->get_content_type_or_default().utf8(),
+				p_attachment->get_attachment_type().utf8());
 	}
 }
 

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -82,6 +82,33 @@ static void before_send_wasm_callback(int32_t *p_ids, int32_t p_len) {
 	}
 }
 
+// Reads the file a scope attachment refers to, leaving the bytes unset if it cannot be read.
+static void read_attachment_wasm_callback(int32_t *p_ids, int32_t p_len) {
+	ERR_FAIL_COND(p_len != 1);
+
+	JSObjectPtr request = JSObject::from_id(p_ids[0]);
+	ERR_FAIL_COND(!request);
+
+	String path = request->get("path").as_string();
+
+	Ref<FileAccess> file = FileAccess::open(path, FileAccess::READ);
+	if (file.is_null()) {
+		// NOTE: Some attachments may legitimately be missing (e.g. screenshots not created on non-main threads).
+		sentry::logging::print_debug("Skipping attachment - file not found: " + path);
+		return;
+	}
+
+	PackedByteArray bytes = file->get_buffer(file->get_length());
+	if (bytes.is_empty()) {
+		sentry::logging::print_debug("Skipping attachment - empty file: " + path);
+		return;
+	}
+
+	sentry::logging::print_debug("Adding attachment: " + path);
+
+	request->set("data", bytes);
+}
+
 static void before_send_log_wasm_callback(int32_t *p_ids, int32_t p_len) {
 	ERR_FAIL_COND(p_len != 1);
 
@@ -324,6 +351,7 @@ void JavaScriptSDK::init() {
 	file_attachments = SENTRY_OPTIONS()->get_default_attachments();
 
 	JSObjectPtr before_send_callback = JSObject::create_callback(before_send_wasm_callback);
+	JSObjectPtr read_attachment_callback = JSObject::create_callback(read_attachment_wasm_callback);
 
 	// Only create the before_send_log callback if user has set a callback
 	JSObjectPtr before_send_log_callback;
@@ -340,6 +368,7 @@ void JavaScriptSDK::init() {
 			before_send_callback,
 			before_send_log_callback,
 			before_send_metric_callback,
+			read_attachment_callback,
 			SENTRY_OPTIONS()->get_dsn().utf8(),
 			SENTRY_OPTIONS()->is_debug_enabled(),
 			SENTRY_OPTIONS()->get_release().utf8(),

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -52,9 +52,6 @@ public:
 	virtual void init() override;
 	virtual void close() override;
 	virtual bool is_enabled() const override;
-
-	JavaScriptSDK();
-	virtual ~JavaScriptSDK() override;
 };
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -9,10 +9,9 @@ namespace sentry::javascript {
 // Internal SDK utilizing Sentry for JavaScript.
 class JavaScriptSDK : public InternalSDK {
 private:
-	Vector<Ref<SentryAttachment>> file_attachments;
+	void _add_default_attachments();
 
 public:
-	_FORCE_INLINE_ const Vector<Ref<SentryAttachment>> &get_file_attachments() const { return file_attachments; }
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void remove_context(const String &p_key) override;
 

--- a/src/sentry/native/native_scope.cpp
+++ b/src/sentry/native/native_scope.cpp
@@ -39,6 +39,33 @@ void NativeScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	sentry_scope_add_breadcrumb(_scope, crumb_value);
 }
 
+void NativeScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
+	sentry_attachment_t *native_attachment = nullptr;
+
+	if (!p_attachment->get_path().is_empty()) {
+		String absolute_path = p_attachment->get_globalized_path();
+
+		native_attachment = sentry_scope_attach_file(_scope, absolute_path.utf8());
+		ERR_FAIL_NULL_MSG(native_attachment, vformat("Sentry: Failed to attach file: %s", absolute_path));
+
+		if (!p_attachment->get_filename().is_empty()) {
+			sentry_attachment_set_filename(native_attachment, p_attachment->get_filename().utf8());
+		}
+	} else {
+		PackedByteArray bytes = p_attachment->get_bytes();
+
+		native_attachment = sentry_scope_attach_bytes(_scope,
+				reinterpret_cast<const char *>(bytes.ptr()),
+				bytes.size(),
+				p_attachment->get_filename().utf8());
+		ERR_FAIL_NULL_MSG(native_attachment, vformat("Sentry: Failed to attach bytes with filename: %s", p_attachment->get_filename()));
+	}
+
+	if (!p_attachment->get_content_type().is_empty()) {
+		sentry_attachment_set_content_type(native_attachment, p_attachment->get_content_type().utf8());
+	}
+}
+
 void NativeScope::clear() {
 	sentry_scope_clear(_scope);
 }

--- a/src/sentry/native/native_scope.h
+++ b/src/sentry/native/native_scope.h
@@ -23,6 +23,7 @@ public:
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
+	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear() override;
 	virtual SentryScopeImpl *clone() const override;
 

--- a/src/sentry/sentry_scope.cpp
+++ b/src/sentry/sentry_scope.cpp
@@ -49,6 +49,14 @@ void SentryScope::add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) {
 	_impl->add_breadcrumb(p_breadcrumb);
 }
 
+void SentryScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
+	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
+	ERR_FAIL_COND_MSG(p_attachment.is_null(), "Sentry: Can't add a null attachment.");
+	ERR_FAIL_COND_MSG(p_attachment->get_path().is_empty() && p_attachment->get_filename().is_empty(),
+			"Sentry: Can't add bytes attachment without filename.");
+	_impl->add_attachment(p_attachment);
+}
+
 void SentryScope::clear() {
 	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	_impl->clear();
@@ -67,6 +75,7 @@ void SentryScope::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fingerprint", "fingerprint"), &SentryScope::set_fingerprint);
 	ClassDB::bind_method(D_METHOD("set_attribute", "name", "value"), &SentryScope::set_attribute);
 	ClassDB::bind_method(D_METHOD("add_breadcrumb", "breadcrumb"), &SentryScope::add_breadcrumb);
+	ClassDB::bind_method(D_METHOD("add_attachment", "attachment"), &SentryScope::add_attachment);
 	ClassDB::bind_method(D_METHOD("clear"), &SentryScope::clear);
 }
 

--- a/src/sentry/sentry_scope.h
+++ b/src/sentry/sentry_scope.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sentry/level.h"
+#include "sentry/sentry_attachment.h"
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_scope_impl.h"
 #include "sentry/sentry_user.h"
@@ -34,6 +35,7 @@ public:
 	void set_fingerprint(const PackedStringArray &p_fingerprint);
 	void set_attribute(const String &p_name, const Variant &p_value);
 	void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb);
+	void add_attachment(const Ref<SentryAttachment> &p_attachment);
 	void clear();
 
 	Ref<SentryScope> clone() const;

--- a/src/sentry/sentry_scope_impl.h
+++ b/src/sentry/sentry_scope_impl.h
@@ -2,6 +2,7 @@
 
 #include "sentry/castable.h"
 #include "sentry/level.h"
+#include "sentry/sentry_attachment.h"
 #include "sentry/sentry_breadcrumb.h"
 #include "sentry/sentry_user.h"
 
@@ -29,6 +30,7 @@ public:
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) = 0;
 	virtual void set_attribute(const String &p_name, const Variant &p_value) = 0;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) = 0;
+	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) = 0;
 	virtual void clear() = 0;
 	virtual SentryScopeImpl *clone() const = 0;
 

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -357,7 +357,9 @@ Describe "Platform Integration Tests" {
         BeforeAll {
             $runResult = $script:attachmentRunResult
 
-            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            $eventIds = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 2
+            $scopedEventId = $eventIds[0]
+            $eventId = $eventIds[1]
             if ($eventId) {
                 Write-GitHub "::group::Getting event content"
                 $script:runEvent = Get-SentryTestEvent -EventId "$eventId"
@@ -368,6 +370,13 @@ Describe "Platform Integration Tests" {
                 $expectedCount = 6
                 $script:attachments = Get-SentryTestEventAttachments -EventId "$eventId" -ExpectedCount $expectedCount
                 $script:attachmentNames = ($script:attachments | ForEach-Object { "'$($_.name)'" }) -join ", "
+                Write-GitHub "::endgroup::"
+
+                Write-GitHub "::group::Getting scoped event attachments"
+                # The 6 above plus the 2 added to the scope (scopes not implemented on Apple).
+                $expectedScopedCount = if ($script:IsCocoa) { 6 } else { 8 }
+                $script:scopedAttachments = Get-SentryTestEventAttachments -EventId "$scopedEventId" -ExpectedCount $expectedScopedCount
+                $script:scopedAttachmentNames = ($script:scopedAttachments | ForEach-Object { "'$($_.name)'" }) -join ", "
                 Write-GitHub "::endgroup::"
             }
         }
@@ -440,6 +449,35 @@ Describe "Platform Integration Tests" {
             $viewHierarchy | Should -Not -BeNullOrEmpty -Because "'view-hierarchy.json' should be among received attachments: $attachmentNames"
             $viewHierarchy.type | Should -Be "event.view_hierarchy"
             $viewHierarchy.size | Should -BeGreaterThan 0
+        }
+
+        It "Has file attachment added from current scope" -Skip:$script:IsCocoa {
+            $scopedFile = $scopedAttachments | Where-Object { $_.name -eq "scoped_attachment.txt" }
+            $scopedFile | Should -Not -BeNullOrEmpty -Because "'scoped_attachment.txt' should be among received attachments: $scopedAttachmentNames"
+            $scopedFile.type | Should -Be "event.attachment"
+            # "Scoped file attachment for integration testing.\n" is 48 bytes in UTF-8
+            $scopedFile.size | Should -Be 48
+        }
+
+        It "Has bytes attachment added from current scope" -Skip:$script:IsCocoa {
+            $scopedBytes = $scopedAttachments | Where-Object { $_.name -eq "scoped_bytes.txt" }
+            $scopedBytes | Should -Not -BeNullOrEmpty -Because "'scoped_bytes.txt' should be among received attachments: $scopedAttachmentNames"
+            $scopedBytes.type | Should -Be "event.attachment"
+            $scopedBytes.headers.'Content-Type' | Should -Be "text/plain"
+            # "Scoped bytes" is 12 bytes in UTF-8
+            $scopedBytes.size | Should -Be 12
+        }
+
+        It "Keeps the global attachments on the scoped event" {
+            $scopedNames = $scopedAttachments | ForEach-Object { $_.name }
+            $scopedNames | Should -Contain "config_attachment.txt" -Because "received attachments: $scopedAttachmentNames"
+            $scopedNames | Should -Contain "runtime_bytes.txt" -Because "received attachments: $scopedAttachmentNames"
+        }
+
+        It "Does not include scope-only attachments on the event captured outside the scope" {
+            $names = $attachments | ForEach-Object { $_.name }
+            $names | Should -Not -Contain "scoped_attachment.txt" -Because "received attachments: $attachmentNames"
+            $names | Should -Not -Contain "scoped_bytes.txt" -Because "received attachments: $attachmentNames"
         }
     }
 

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -357,9 +357,13 @@ Describe "Platform Integration Tests" {
         BeforeAll {
             $runResult = $script:attachmentRunResult
 
-            $eventIds = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 2
-            $scopedEventId = $eventIds[0]
-            $eventId = $eventIds[1]
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            # The app captures a second event within a scope that adds two extra attachments.
+            # Comparing both events verifies that scoped attachments are sent only with the scoped event
+            # and do not leak into events captured outside the scope.
+            # The scoped event uses SCOPED_EVENT_ID so shared test cases still see a single EVENT_CAPTURED line.
+            $scopedEventId = ($runResult.Output | Select-String -Pattern 'SCOPED_EVENT_ID: (\S+)' |
+                Select-Object -First 1).Matches.Groups[1].Value
             if ($eventId) {
                 Write-GitHub "::group::Getting event content"
                 $script:runEvent = Get-SentryTestEvent -EventId "$eventId"

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -378,7 +378,7 @@ Describe "Platform Integration Tests" {
 
                 Write-GitHub "::group::Getting scoped event attachments"
                 # The 6 above plus the 2 added to the scope (scopes not implemented on Apple).
-                $expectedScopedCount = if ($script:IsCocoa) { 6 } else { 8 }
+                $expectedScopedCount = if ($script:TestSetup.IsCocoa) { 6 } else { 8 }
                 $script:scopedAttachments = Get-SentryTestEventAttachments -EventId "$scopedEventId" -ExpectedCount $expectedScopedCount
                 $script:scopedAttachmentNames = ($script:scopedAttachments | ForEach-Object { "'$($_.name)'" }) -join ", "
                 Write-GitHub "::endgroup::"


### PR DESCRIPTION
Adds `SentryScope.add_attachment()`, so a file or a block of bytes can be attached to the events captured within a single scope rather than to everything the application sends. Implemented for Windows, Linux, Android and Web; Apple is deferred until scopes are supported there.

On Web the JavaScript SDK accepts only attachment bytes, so a file added to a scope is recorded as a path and read when an event is captured. I.e. file contents are read at capture time, just like in native. Globally added file attachments now take the same route, replacing the separate reading pass that previously ran inside `before_send`.

**Usage example**:
```gdscript
var feedback := SentryFeedback.new()
feedback.message = "The game freezes when I enter the castle"
feedback.contact_email = "player@example.com"

# The save file is attached only to what's captured inside this scope, not to every event.
SentrySDK.with_scope(func(scope: SentryScope):
	scope.add_attachment(SentryAttachment.create_with_path("user://savegame.dat"))
	SentrySDK.capture_feedback(feedback)
)
```
- Refs #188
- Refs #834 
- Resolves #426
- Resolves #427