### PR TITLE
fix(web): Don't carry global data across close and init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 
+### Fixes
+
+- Web: Fixed tags, breadcrumbs and other globally set data carrying over into the next session when the SDK is closed and initialized again ([#857](https://github.com/getsentry/sentry-godot/pull/857))
+
 ### Dependencies
 
 - Bump Sentry Android from v8.51.0 to v8.52.0 ([#855](https://github.com/getsentry/sentry-godot/pull/855))

--- a/project/test/isolated/test_sdk_lifecycle.gd
+++ b/project/test/isolated/test_sdk_lifecycle.gd
@@ -4,14 +4,16 @@ extends GdUnitTestSuite
 
 signal callback_processed
 
-var _captured_event: SentryEvent
+var _captured_session_tag: String
+var _captured_event_json: String
 
 
 func _before_send(ev: SentryEvent) -> SentryEvent:
 	if ev.is_crash():
 		# Likely processing previous crash.
 		return ev
-	_captured_event = ev
+	_captured_session_tag = ev.get_tag("session")
+	_captured_event_json = ev.to_json()
 	callback_processed.emit()
 	return null
 
@@ -92,8 +94,8 @@ func test_reinit_clears_global_data() -> void:
 	SentrySDK.add_breadcrumb(SentryBreadcrumb.create("first session breadcrumb"))
 	SentrySDK.capture_message("message from the first session")
 	await assert_signal(self).is_emitted("callback_processed")
-	assert_str(_captured_event.get_tag("session")).is_equal("first")
-	assert_str(_captured_event.to_json()).contains("first session breadcrumb")
+	assert_str(_captured_session_tag).is_equal("first")
+	assert_str(_captured_event_json).contains("first session breadcrumb")
 
 	SentrySDK.close()
 
@@ -108,7 +110,7 @@ func test_reinit_clears_global_data() -> void:
 
 	SentrySDK.capture_message("message from the second session")
 	await assert_signal(self).is_emitted("callback_processed")
-	assert_str(_captured_event.get_tag("session")).is_empty()
-	assert_str(_captured_event.to_json()).not_contains("first session breadcrumb")
+	assert_str(_captured_session_tag).is_empty()
+	assert_str(_captured_event_json).not_contains("first session breadcrumb")
 
 	SentrySDK.close()

--- a/project/test/isolated/test_sdk_lifecycle.gd
+++ b/project/test/isolated/test_sdk_lifecycle.gd
@@ -4,11 +4,14 @@ extends GdUnitTestSuite
 
 signal callback_processed
 
+var _captured_event: SentryEvent
+
 
 func _before_send(ev: SentryEvent) -> SentryEvent:
 	if ev.is_crash():
 		# Likely processing previous crash.
 		return ev
+	_captured_event = ev
 	callback_processed.emit()
 	return null
 
@@ -69,5 +72,43 @@ func test_reinit_clears_options() -> void:
 
 	SentrySDK.capture_message("message should not trigger old before_send")
 	await assert_signal(self).is_not_emitted("callback_processed")
+
+	SentrySDK.close()
+
+	# NOTE: On Web, Sentry.close() is async - let it finish before the next test initializes.
+	await get_tree().create_timer(2.0).timeout
+
+
+## Test that re-init clears globally set data (old tags and breadcrumbs should not leak).
+func test_reinit_clears_global_data() -> void:
+	monitor_signals(self, false)
+
+	SentrySDK.init(func (options: SentryOptions) -> void:
+		options.before_send = _before_send
+		options.shutdown_timeout_ms = 2000
+	)
+
+	SentrySDK.set_tag("session", "first")
+	SentrySDK.add_breadcrumb(SentryBreadcrumb.create("first session breadcrumb"))
+	SentrySDK.capture_message("message from the first session")
+	await assert_signal(self).is_emitted("callback_processed")
+	assert_str(_captured_event.get_tag("session")).is_equal("first")
+	assert_str(_captured_event.to_json()).contains("first session breadcrumb")
+
+	SentrySDK.close()
+
+	# NOTE: On Web, Sentry.close() is async - need to wait for it to complete.
+	await get_tree().create_timer(2.0).timeout
+
+	# Re-init without setting them again -- the data from the first session should be gone.
+	SentrySDK.init(func (options: SentryOptions) -> void:
+		options.before_send = _before_send
+		options.shutdown_timeout_ms = 2000
+	)
+
+	SentrySDK.capture_message("message from the second session")
+	await assert_signal(self).is_emitted("callback_processed")
+	assert_str(_captured_event.get_tag("session")).is_empty()
+	assert_str(_captured_event.to_json()).not_contains("first session breadcrumb")
 
 	SentrySDK.close()

--- a/project/test/isolated/test_sdk_lifecycle.gd
+++ b/project/test/isolated/test_sdk_lifecycle.gd
@@ -1,32 +1,19 @@
-extends GdUnitTestSuite
+extends SentryTestSuite
 ## Test lifecycle methods.
 
 
-signal callback_processed
-
-var _captured_session_tag: String
-var _captured_event_json: String
-
-
-func _before_send(ev: SentryEvent) -> SentryEvent:
-	if ev.is_crash():
-		# Likely processing previous crash.
-		return ev
-	_captured_session_tag = ev.get_tag("session")
-	_captured_event_json = ev.to_json()
-	callback_processed.emit()
-	return null
+func before() -> void:
+	# NOTE: Not calling super() on purpose - this suite initializes the SDK itself.
+	pass
 
 
 ## Test manual initialization and shutdown of SDK.
 func test_sdk_lifecycle() -> void:
-	monitor_signals(self, false)
-
 	# SDK should be disabled at start.
 	assert_bool(SentrySDK.is_enabled()).is_false()
 
 	SentrySDK.capture_message("message not captured before SDK is initialized")
-	await assert_signal(self).is_not_emitted("callback_processed")
+	await assert_signal(self).is_not_emitted("event_captured")
 
 	SentrySDK.init(func (options: SentryOptions) -> void:
 		options.before_send = _before_send
@@ -35,7 +22,7 @@ func test_sdk_lifecycle() -> void:
 	assert_bool(SentrySDK.is_enabled()).is_true()
 
 	SentrySDK.capture_message("message captured when SDK is initialiazed")
-	await assert_signal(self).is_emitted("callback_processed")
+	await assert_signal(self).is_emitted("event_captured")
 
 	SentrySDK.close()
 
@@ -45,13 +32,11 @@ func test_sdk_lifecycle() -> void:
 	assert_bool(SentrySDK.is_enabled()).is_false()
 
 	SentrySDK.capture_message("message not captured when SDK is closed")
-	await assert_signal(self).is_not_emitted("callback_processed")
+	await assert_signal(self).is_not_emitted("event_captured")
 
 
 ## Test that re-init creates fresh options (old before_send should not leak).
 func test_reinit_clears_options() -> void:
-	monitor_signals(self, false)
-
 	# First init with before_send callback.
 	SentrySDK.init(func (options: SentryOptions) -> void:
 		options.before_send = _before_send
@@ -60,7 +45,7 @@ func test_reinit_clears_options() -> void:
 	assert_bool(SentrySDK.is_enabled()).is_true()
 
 	SentrySDK.capture_message("message triggers before_send")
-	await assert_signal(self).is_emitted("callback_processed")
+	await assert_signal(self).is_emitted("event_captured")
 
 	SentrySDK.close()
 
@@ -73,7 +58,7 @@ func test_reinit_clears_options() -> void:
 	assert_bool(SentrySDK.is_enabled()).is_true()
 
 	SentrySDK.capture_message("message should not trigger old before_send")
-	await assert_signal(self).is_not_emitted("callback_processed")
+	await assert_signal(self).is_not_emitted("event_captured")
 
 	SentrySDK.close()
 
@@ -83,8 +68,6 @@ func test_reinit_clears_options() -> void:
 
 ## Test that re-init clears globally set data (old tags and breadcrumbs should not leak).
 func test_reinit_clears_global_data() -> void:
-	monitor_signals(self, false)
-
 	SentrySDK.init(func (options: SentryOptions) -> void:
 		options.before_send = _before_send
 		options.shutdown_timeout_ms = 2000
@@ -93,9 +76,17 @@ func test_reinit_clears_global_data() -> void:
 	SentrySDK.set_tag("session", "first")
 	SentrySDK.add_breadcrumb(SentryBreadcrumb.create("first session breadcrumb"))
 	SentrySDK.capture_message("message from the first session")
-	await assert_signal(self).is_emitted("callback_processed")
-	assert_str(_captured_session_tag).is_equal("first")
-	assert_str(_captured_event_json).contains("first session breadcrumb")
+	var first_json: String = await wait_for_captured_event_json()
+
+	assert_json(first_json).describe("First session event carries its tag") \
+		.must_contain("/tags/session", "first") \
+		.verify()
+
+	assert_json(first_json).describe("First session event carries its breadcrumb") \
+		.at("/breadcrumbs/") \
+		.with_objects() \
+		.containing("message", "first session breadcrumb") \
+		.exactly(1)
 
 	SentrySDK.close()
 
@@ -109,8 +100,12 @@ func test_reinit_clears_global_data() -> void:
 	)
 
 	SentrySDK.capture_message("message from the second session")
-	await assert_signal(self).is_emitted("callback_processed")
-	assert_str(_captured_session_tag).is_empty()
-	assert_str(_captured_event_json).not_contains("first session breadcrumb")
+	var second_json: String = await wait_for_captured_event_json()
+
+	assert_json(second_json).describe("Second session drops the first session's tag") \
+		.must_not_contain("/tags/session") \
+		.verify()
+
+	assert_str(second_json).not_contains("first session breadcrumb")
 
 	SentrySDK.close()

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -237,11 +237,14 @@ class SentryBridge {
       console.debug("Sentry: beforeSendMetric callback not provided.");
     }
 
-    // Both scopes outlive Sentry.close(), so without this a previous session's data would leak into
+    // The scopes outlive Sentry.close(), so without this a previous session's data would leak into
     // this one: tags, breadcrumbs and attachments from the isolation scope, attributes from the
-    // global one, which is where setAttribute() writes and where logs and metrics read from.
+    // global one, and the trace that captures and forked scopes inherit from the current one.
+    // Clearing here is safe even if a close() flush is still in flight: scope data and attachments are
+    // merged into the event synchronously at capture time, so nothing already captured reads a scope again.
     Sentry.getIsolationScope().clear();
     Sentry.getGlobalScope().clear();
+    Sentry.getCurrentScope().clear();
 
     Sentry.init(options);
 

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -237,6 +237,10 @@ class SentryBridge {
       console.debug("Sentry: beforeSendMetric callback not provided.");
     }
 
+    // Global data is kept on the isolation scope, which outlives Sentry.close(), so without this a
+    // previous session's tags, breadcrumbs and attachments would leak into this one.
+    Sentry.getIsolationScope().clear();
+
     Sentry.init(options);
 
     if (readAttachmentCallback) {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -237,9 +237,11 @@ class SentryBridge {
       console.debug("Sentry: beforeSendMetric callback not provided.");
     }
 
-    // Global data is kept on the isolation scope, which outlives Sentry.close(), so without this a
-    // previous session's tags, breadcrumbs and attachments would leak into this one.
+    // Both scopes outlive Sentry.close(), so without this a previous session's data would leak into
+    // this one: tags, breadcrumbs and attachments from the isolation scope, attributes from the
+    // global one, which is where setAttribute() writes and where logs and metrics read from.
     Sentry.getIsolationScope().clear();
+    Sentry.getGlobalScope().clear();
 
     Sentry.init(options);
 


### PR DESCRIPTION
**Before this PR**: On Web, the JavaScript SDK stored all global data (tags, breadcrumbs, contexts, user info, attachments) in an isolation scope that survived `Sentry.close()`. When the SDK reinitialized, it carried over the old scope data. Items that append instead of replace, like breadcrumbs and attachments, accumulated with each cycle.

**After this PR**: All scopes get wiped when the SDK initializes. Each new session starts fresh, matching the behavior on other platforms. This also generates a new propagation context at startup, which is the intended outcome.
