### PR TITLE
chore(android): Remove manual context clearing on scope clear

### DIFF
--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -980,12 +980,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
 
     @UsedByGodot
     fun scopeClear(handle: Int) {
-        val scope = getScope(handle) ?: return
-        scope.clear()
-        // WORKAROUND: Scope.clear() leaves contexts in place, so drop them here to match the other platforms.
-        for (key in scope.contexts.entrySet().map { it.key }) {
-            scope.removeContexts(key)
-        }
+        getScope(handle)?.clear()
     }
 
     @UsedByGodot


### PR DESCRIPTION
sentry-java's `Scope.clear()` used to leave contexts in place, so the Android layer removed each context key by hand after calling it. That was fixed upstream in https://github.com/getsentry/sentry-java/pull/5902 and released in 8.53.0, which this project already pins, so the workaround can go.