### PR TITLE
feat(options): Deprecate enable_logs and enable_metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 
+### Improvements
+
+- Deprecate the `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options and their Project Settings counterparts, to be removed in v3; logs and metrics are only sent when you use `SentrySDK.logger` or `SentrySDK.metrics`, or enable automatic log capture with `godot_logger.log_mask` ([#869](https://github.com/getsentry/sentry-godot/pull/869))
+
 ### Fixes
 
 - Web: Fixed tags, breadcrumbs and other globally set data carrying over into the next session when the SDK is closed and initialized again ([#857](https://github.com/getsentry/sentry-godot/pull/857))

--- a/doc_classes/SentryExperimental.xml
+++ b/doc_classes/SentryExperimental.xml
@@ -22,7 +22,7 @@
 				return metric
 			[/codeblock]
 		</member>
-		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Metrics are now generally available. Use [member SentryOptions.enable_metrics] instead.">
+		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Will be removed in v3. Metrics are only sent if you use [member SentrySDK.metrics].">
 			Enables Sentry metrics functionality. When enabled, you can emit custom metrics using the [SentryMetrics] API available through [member SentrySDK.metrics].
 		</member>
 	</members>

--- a/doc_classes/SentryGodotLoggerOptions.xml
+++ b/doc_classes/SentryGodotLoggerOptions.xml
@@ -33,7 +33,6 @@
 		</member>
 		<member name="log_mask" type="int" setter="set_log_mask" getter="get_log_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="0">
 			Specifies the Godot logger events that are automatically captured as Sentry logs. Accepts a single value or a bitwise combination of [enum SentryOptions.GodotLoggerEventMask] masks. Empty by default, so no events are captured as logs.
-			[b]Note:[/b] Log capture requires [member SentryOptions.enable_logs] to be enabled.
 		</member>
 	</members>
 </class>

--- a/doc_classes/SentryLogger.xml
+++ b/doc_classes/SentryLogger.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		A dedicated API for logging messages to Sentry's structured logging system. Access this API through [member SentrySDK.logger]. [SentryLogger] provides methods for different log levels ([method trace], [method debug], [method info], [method warn], [method error], [method fatal]) and enables structured data capture with your log messages.
-		[b]Note:[/b] The [member SentryOptions.enable_logs] option must be enabled for logging functionality to work.
 		[codeblock]
 		# Simple messages
 		SentrySDK.logger.info("Game session started")

--- a/doc_classes/SentryMetrics.xml
+++ b/doc_classes/SentryMetrics.xml
@@ -5,7 +5,6 @@
 	</brief_description>
 	<description>
 		A dedicated API for emitting metrics to Sentry. Access this API through [member SentrySDK.metrics]. [SentryMetrics] provides methods for emitting different metric types: [method count] for incrementing counters, [method gauge] for tracking point-in-time values, and [method distribution] for recording value distributions.
-		[b]Note:[/b] The [member SentryOptions.enable_metrics] option must be enabled for metrics functionality to work.
 		[codeblock]
 		# Count occurrences
 		SentrySDK.metrics.count("match_started")

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -101,12 +101,12 @@
 			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_ms]. This helps identify performance issues where the application becomes frozen or unresponsive.
 			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
-		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true">
+		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true" deprecated="Will be removed in v3. Logs are only sent if you use [member SentrySDK.logger] or set [member SentryGodotLoggerOptions.log_mask].">
 			Enables Sentry's structured logging. If [code]true[/code], log entries can be emitted through [member SentrySDK.logger], and Godot logger events listed in [member SentryGodotLoggerOptions.log_mask] are automatically captured as Sentry Logs. [member SentryGodotLoggerOptions.log_mask] is empty by default, so no events are auto-captured.
 			See [member godot_logger] for options to capture Godot errors as Sentry events or breadcrumbs.
 			For more information, see [url=https://docs.sentry.io/platforms/godot/logs/]Sentry Logs[/url] documentation.
 		</member>
-		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true">
+		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Will be removed in v3. Metrics are only sent if you use [member SentrySDK.metrics].">
 			Enables Sentry metrics functionality. When enabled, you can emit custom metrics using the [SentryMetrics] API available through [member SentrySDK.metrics].
 		</member>
 		<member name="environment" type="String" setter="set_environment" getter="get_environment" default="&quot;{auto}&quot;">
@@ -124,7 +124,7 @@
 			Specifies the Godot logger events that are automatically captured as Sentry breadcrumbs. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.
 		</member>
 		<member name="logger_enabled" type="bool" setter="deprecated_set_logger_enabled" getter="deprecated_is_logger_enabled" default="true" deprecated="Use [member SentryGodotLoggerOptions.enabled] instead.">
-			If [code]true[/code], the SDK will capture logged errors as events, logs and/or breadcrumbs, as defined by [member logger_event_mask] and [member logger_breadcrumb_mask]. Crashes are always captured. See also [member enable_logs].
+			If [code]true[/code], the SDK will capture logged errors as events, logs and/or breadcrumbs, as defined by [member logger_event_mask] and [member logger_breadcrumb_mask]. Crashes are always captured.
 		</member>
 		<member name="logger_event_mask" type="int" setter="deprecated_set_logger_event_mask" getter="deprecated_get_logger_event_mask" enum="SentryOptions.GodotLoggerEventMask" is_bitfield="true" default="13" deprecated="Use [member SentryGodotLoggerOptions.event_mask] instead.">
 			Specifies the Godot logger events that are automatically captured as Sentry events. Accepts a single value or a bitwise combination of [enum GodotLoggerEventMask] masks.

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -219,11 +219,11 @@
 			[b]Warning:[/b] Every method exposed here crashes the running application on purpose. It is meant for testing and demonstration only and must never be called in shipped code.
 		</member>
 		<member name="logger" type="SentryLogger" setter="" getter="get_logger">
-			Provides access to Sentry's structured logging API. Use this to send log messages to Sentry when [member SentryOptions.enable_logs] is enabled. The dedicated logger API offers methods for different log levels and enables you to capture structured data with your log messages.
+			Provides access to Sentry's structured logging API. Use this to send log messages to Sentry. The dedicated logger API offers methods for different log levels and enables you to capture structured data with your log messages.
 			See [SentryLogger] for more details.
 		</member>
 		<member name="metrics" type="SentryMetrics" setter="" getter="get_metrics">
-			Provides access to Sentry's metrics API. Use this to emit custom metrics to Sentry when [member SentryOptions.enable_metrics] is enabled.
+			Provides access to Sentry's metrics API. Use this to emit custom metrics to Sentry.
 			See [SentryMetrics] for more details.
 		</member>
 	</members>

--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -183,7 +183,6 @@ func _cmd_attachment_capture() -> int:
 ## Captures a structured log to Sentry.
 func _cmd_log_capture() -> int:
 	await _init_sentry(func(options: SentryOptions) -> void:
-		options.enable_logs = true
 		options.before_send_log = _before_send_log
 	)
 	_add_integration_test_context("log-capture")
@@ -217,7 +216,6 @@ func _before_send_log(entry: SentryLog) -> SentryLog:
 ## Captures counter, distribution, and gauge metrics to Sentry.
 func _cmd_metric_capture() -> int:
 	await _init_sentry(func(options: SentryOptions) -> void:
-		options.enable_metrics = true
 		options.before_send_metric = _before_send_metric
 	)
 	_add_integration_test_context("metric-capture")

--- a/project/test/isolated/test_logger_log_mask.gd
+++ b/project/test/isolated/test_logger_log_mask.gd
@@ -8,7 +8,6 @@ var _captured: Array[Dictionary] = []
 
 func before() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.enable_logs = true
 		options.godot_logger.log_mask = SentryOptions.MASK_ERROR
 		options.before_send_log = _before_send_log
 

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -16,7 +16,6 @@ func after() -> void:
 
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.enable_metrics = true
 		options.before_send_metric = _before_send_metric
 	)
 

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -4,7 +4,6 @@ signal log_processed(entry: SentryLog)
 
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.enable_logs = true
 		options.godot_logger.log_mask = SentryOptions.MASK_MESSAGE
 		options.before_send_log = _before_send_log
 	)

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -231,6 +231,14 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->enable_logs = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_logs", p_options->enable_logs);
 	p_options->enable_metrics = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_metrics", p_options->enable_metrics);
 
+	// Only a disabled setting is worth warning about: the enabled default carries no user intent.
+	if (!p_options->enable_logs) {
+		WARN_PRINT_ONCE("Sentry: The \"Enable Logs\" project setting is deprecated and will be removed in version 3.0. Logs are only sent if you use SentrySDK.logger or set \"sentry/godot_logger/logs\".");
+	}
+	if (!p_options->enable_metrics) {
+		WARN_PRINT_ONCE("Sentry: The \"Enable Metrics\" project setting is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
+	}
+
 	p_options->enable_app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking);
 	p_options->app_hang_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms);
 
@@ -347,6 +355,16 @@ void SentryOptions::deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &
 	godot_logger->deprecated_set_limits(p_limits);
 }
 
+void SentryOptions::deprecated_set_enable_logs(bool p_enabled) {
+	WARN_DEPRECATED_MSG("The \"enable_logs\" option is deprecated and will be removed in version 3.0. Logs are only sent if you use SentrySDK.logger or set \"godot_logger.log_mask\".");
+	set_enable_logs(p_enabled);
+}
+
+void SentryOptions::deprecated_set_enable_metrics(bool p_enabled) {
+	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
+	set_enable_metrics(p_enabled);
+}
+
 void SentryOptions::set_release(const String &p_release) {
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 	String app_name = ProjectSettings::get_singleton()->get_setting("application/config/name", "Unknown Godot project");
@@ -406,10 +424,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, sentry::make_level_enum_property("screenshot_level"), set_screenshot_level, get_screenshot_level);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "attach_scene_tree"), set_attach_scene_tree, is_attach_scene_tree_enabled);
 
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_logs"), set_enable_logs, get_enable_logs);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_log"), set_before_send_log, get_before_send_log);
-
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_metrics"), set_enable_metrics, get_enable_metrics);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_metric"), set_before_send_metric, get_before_send_metric);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "enable_app_hang_tracking"), set_app_hang_tracking_enabled, is_app_hang_tracking_enabled);
@@ -444,6 +459,11 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_breadcrumb_mask"), deprecated_set_logger_breadcrumb_mask, deprecated_get_logger_breadcrumb_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "logger_log_mask"), deprecated_set_logger_log_mask, deprecated_get_logger_log_mask);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::OBJECT, "logger_limits", PROPERTY_HINT_TYPE_STRING, "SentryLoggerLimits", PROPERTY_USAGE_NONE), deprecated_set_logger_limits, deprecated_get_logger_limits);
+
+	// DEPRECATED: Logs and metrics are only sent when their APIs are used, so these toggles are redundant.
+	// TODO: Remove these in version 3.0.
+	BIND_PROPERTY_SIMPLE_DEPRECATED(SentryOptions, Variant::BOOL, enable_logs);
+	BIND_PROPERTY_SIMPLE_DEPRECATED(SentryOptions, Variant::BOOL, enable_metrics);
 }
 
 SentryOptions::SentryOptions() {

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -77,7 +77,7 @@ SentryGodotLoggerOptions::SentryGodotLoggerOptions() {
 // *** SentryExperimental
 
 void SentryExperimental::deprecated_set_enable_metrics(bool p_value) {
-	WARN_DEPRECATED_MSG("Sentry Metrics are now generally available. This property is deprecated. Use SentryOptions.enable_metrics instead.");
+	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
 	ERR_FAIL_NULL(owner);
 	owner->set_enable_metrics(p_value);
 }

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -290,6 +290,12 @@ public:
 
 	Ref<SentryLoggerLimits> deprecated_get_logger_limits() const { return godot_logger->get_limits(); }
 	void deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
+
+	bool deprecated_get_enable_logs() const { return enable_logs; }
+	void deprecated_set_enable_logs(bool p_enabled);
+
+	bool deprecated_get_enable_metrics() const { return enable_metrics; }
+	void deprecated_set_enable_metrics(bool p_enabled);
 };
 
 } // namespace sentry


### PR DESCRIPTION
Deprecates the `enable_logs` and `enable_metrics` options on `SentryOptions`, together with the matching entries in Godot's Project Settings (the per-project configuration UI). Both options keep working exactly as they do today, so this only adds deprecation markers and respective warnings if those options are disabled.

- Resolves #864

These options are redundant because logs and metrics are sent only when a project uses `SentrySDK.logger`, `SentrySDK.metrics`, or opts into automatic log capture through `godot_logger.log_mask`.

The warning is attached to the scripting property binding rather than to the C++ setters, because the .NET layer writes its options back into the native options on every initialization and would otherwise warn on every C# project regardless of whether it touched the option. The Project Settings entries warn separately, and only when switched off, since the enabled default says nothing about user intent. The C# `EnableLogs` and `EnableMetrics` properties come from the .NET SDK rather than this repository, so they cannot be marked obsolete here and are unaffected.
