### PR TITLE
feat(spans): Support Spans on WebAssembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 - Add the `SentryOptions.before_send_feedback` callback to filter or enrich user feedback before it is sent ([#878](https://github.com/getsentry/sentry-godot/pull/878))
   - Not supported on macOS and iOS yet, where feedback is still sent but the callback never runs
-- Add Spans support to the GDScript API for measuring operations and grouping telemetry captured while they run ([#863](https://github.com/getsentry/sentry-godot/pull/863))
+- Add Spans support to the GDScript API for measuring operations and grouping telemetry captured while they run ([#863](https://github.com/getsentry/sentry-godot/pull/863), [#875](https://github.com/getsentry/sentry-godot/pull/875))
   - `SentrySDK.start_span()` starts a span and makes it active, and `SentrySDK.get_active_span()` returns the active span for the calling thread
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
-  - Not supported on macOS, iOS, Android, or Web yet, where the SDK returns a no-op span with a warning
+  - Not supported on macOS, iOS, or Android yet, where the SDK returns a no-op span with a warning
 
 ### Improvements
 

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -222,7 +222,7 @@
 				When [param parent_span] is omitted, the new span becomes a child of [method SentrySDK.get_active_span] if one exists; otherwise, it starts a new root span. Pass [code]null[/code] to force a new root span, or pass a [SentrySpan] to create a child of that span even when another span is active. If [param parent_span] has ended, the SDK prints an error and returns a no-op span.
 				The [param attributes] dictionary is added to the span when it starts. The special [code]sentry.op[/code] attribute sets the operation the span is grouped under in Sentry. The SDK skips an entry with an empty key and prints an error.
 				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code]. The API works either way: telemetry captured during an active span carries its trace context even when the span is not sent.
-				[b]Platform support:[/b] Spans are not supported on macOS, iOS, Android, or Web yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
+				[b]Platform support:[/b] Spans are not supported on macOS, iOS, or Android yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 			</description>
 		</method>

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -19,7 +19,6 @@
 		Set [code]sentry.op[/code] to categorize the work the span measures, such as [code]asset.load[/code] or [code]db.query[/code]. Sentry groups and filters spans by operation. Pass it in the [code]attributes[/code] dictionary of [method SentrySDK.start_span], since some platforms fix the operation when the span starts.
 		[b]Note:[/b] Spans are thread-local. Call span methods only from the thread that created the span.
 		[b]Platform support:[/b] Spans are not supported on macOS, iOS, or Android yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.
-		[b]On Web:[/b] The SDK sends spans in the Span v2 format, which self-hosted Sentry does not ingest yet, so spans from a web export only reach Sentry SaaS.
 		To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 	</description>
 	<tutorials>

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -18,7 +18,8 @@
 		Each unended active span also leaves a scope fork on the calling thread; the SDK warns if the scope stack grows unusually deep.
 		Set [code]sentry.op[/code] to categorize the work the span measures, such as [code]asset.load[/code] or [code]db.query[/code]. Sentry groups and filters spans by operation. Pass it in the [code]attributes[/code] dictionary of [method SentrySDK.start_span], since some platforms fix the operation when the span starts.
 		[b]Note:[/b] Spans are thread-local. Call span methods only from the thread that created the span.
-		[b]Platform support:[/b] Spans are not supported on macOS, iOS, Android, or Web yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.
+		[b]Platform support:[/b] Spans are not supported on macOS, iOS, or Android yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.
+		[b]On Web:[/b] The SDK sends spans in the Span v2 format, which self-hosted Sentry does not ingest yet, so spans from a web export only reach Sentry SaaS.
 		To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 	</description>
 	<tutorials>

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -3,7 +3,7 @@ extends SentryTestSuite
 
 
 # TODO: widen the platform list as spans are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux"],
+func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Web"],
 		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
 	super()
 

--- a/scripts/javascript-version.ps1
+++ b/scripts/javascript-version.ps1
@@ -11,6 +11,7 @@ $packageJsonFile = "$bridgeDir/package.json"
 # Sentry packages to track — add new packages here.
 $sentryPackages = @(
 	"@sentry/browser",
+	"@sentry/core",
 	"@sentry/wasm"
 )
 

--- a/src/sentry/javascript/bridge/package-lock.json
+++ b/src/sentry/javascript/bridge/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sentry/browser": "^10.72.0",
+        "@sentry/core": "^10.72.0",
         "@sentry/wasm": "^10.72.0"
       },
       "devDependencies": {

--- a/src/sentry/javascript/bridge/package.json
+++ b/src/sentry/javascript/bridge/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@sentry/browser": "^10.72.0",
+    "@sentry/core": "^10.72.0",
     "@sentry/wasm": "^10.72.0"
   }
 }

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -183,7 +183,6 @@ class SentryBridge {
           return !excludedIntegrations.includes(integration.name);
         });
         filtered.push(wasmIntegration());
-        filtered.push(Sentry.spanStreamingIntegration());
         filtered.push(
           Sentry.breadcrumbsIntegration({
             console: false, // very noisy in Godot SDK

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -1,6 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import type { Breadcrumb, User } from "@sentry/browser";
-import type { Attachment, Metric } from "@sentry/core";
+import { _INTERNAL_setSpanForScope, generateSpanId } from "@sentry/core";
+import type { Attachment, Metric, SpanStatus } from "@sentry/core";
 import { wasmIntegration } from "@sentry/wasm";
 
 // ID-based store for WASM/JS interop. Assigns auto-incrementing uint32 IDs (0 is reserved).
@@ -140,6 +141,7 @@ class SentryBridge {
     dist: string,
     environment: string,
     sampleRate: number,
+    tracesSampleRate: number,
     maxBreadcrumbs: number,
     sendDefaultPii: boolean,
     sdkVersion: string,
@@ -155,6 +157,7 @@ class SentryBridge {
       dist,
       environment,
       sampleRate,
+      tracesSampleRate,
       maxBreadcrumbs,
       sendDefaultPii,
       _metadata: {
@@ -173,6 +176,7 @@ class SentryBridge {
           return !excludedIntegrations.includes(integration.name);
         });
         filtered.push(wasmIntegration());
+        filtered.push(Sentry.spanStreamingIntegration());
         filtered.push(
           Sentry.breadcrumbsIntegration({
             console: false, // very noisy in Godot SDK
@@ -386,6 +390,23 @@ class SentryBridge {
     const propagationContext = scope.getPropagationContext();
     scope.clear();
     scope.setPropagationContext(propagationContext);
+  }
+
+  public scopeSetSpan(scope: Sentry.Scope, span?: Sentry.Span): void {
+    // No public alternative: setActiveSpanInBrowser binds only to the current scope.
+    _INTERNAL_setSpanForScope(scope, span ?? undefined);
+  }
+
+  public startSpan(name: string, attributesJson: string, parentSpan?: Sentry.Span): Sentry.Span {
+    return Sentry.startInactiveSpan({
+      name,
+      attributes: safeParseJSON(attributesJson, {}),
+      parentSpan: parentSpan ?? null,
+    });
+  }
+
+  public spanSetStatus(span: Sentry.Span, code: SpanStatus["code"]): void {
+    span.setStatus({ code });
   }
 
   public logTrace(message: string, attributesJson?: string, scope?: Sentry.Scope): void {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -249,6 +249,12 @@ class SentryBridge {
 
     Sentry.init(options);
 
+    // Use one stable fallback span ID for captures without an active span.
+    Sentry.getCurrentScope().setPropagationContext({
+      ...Sentry.getCurrentScope().getPropagationContext(),
+      propagationSpanId: generateSpanId(),
+    });
+
     if (beforeSendFeedbackCallback) {
       // @sentry/core has no beforeSendFeedback option, and feedback also bypasses beforeSend.
       Sentry.getClient()?.addEventProcessor((event: Sentry.Event) => {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -398,11 +398,11 @@ class SentryBridge {
     scope.addAttachment(makePendingAttachment(path, filename, contentType, attachmentType));
   }
 
-  public scopeClear(scope: Sentry.Scope): void {
-    // Preserve the propagation context across clear() because Scope.clear() rotates the trace in JS.
-    const propagationContext = scope.getPropagationContext();
-    scope.clear();
-    scope.setPropagationContext(propagationContext);
+  public scopeClear(scope: Sentry.Scope): Sentry.Scope {
+    const fresh = new Sentry.Scope();
+    fresh.setClient(scope.getClient() ?? Sentry.getClient());
+    fresh.setPropagationContext(scope.getPropagationContext());
+    return fresh;
   }
 
   public scopeSetSpan(scope: Sentry.Scope, span?: Sentry.Span): void {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/browser";
 import type { Breadcrumb, User } from "@sentry/browser";
 import { _INTERNAL_setSpanForScope, generateSpanId } from "@sentry/core";
-import type { Attachment, Metric, SpanStatus } from "@sentry/core";
+import type { Attachment, Metric } from "@sentry/core";
 import { wasmIntegration } from "@sentry/wasm";
 
 // ID-based store for WASM/JS interop. Assigns auto-incrementing uint32 IDs (0 is reserved).
@@ -37,6 +37,13 @@ class IdStore<T> {
 // bytes when an event is captured. Sentry copies only its own known fields into the envelope, so the
 // marker is never sent.
 const PENDING_PATH_KEY = "__godotPath";
+
+// SentrySpan.SpanStatus value for a failed span, as the C++ layer sends it.
+const SPAN_STATUS_ERROR = 1;
+
+// OpenTelemetry status codes, which @sentry/core expects but does not export as constants.
+const OTEL_CODE_OK = 1;
+const OTEL_CODE_ERROR = 2;
 
 // Handed to the C++ layer to have it read one file; it leaves the bytes unset if the read fails.
 interface AttachmentRequest {
@@ -411,8 +418,8 @@ class SentryBridge {
     });
   }
 
-  public spanSetStatus(span: Sentry.Span, code: SpanStatus["code"]): void {
-    span.setStatus({ code });
+  public spanSetStatus(span: Sentry.Span, status: number): void {
+    span.setStatus({ code: status === SPAN_STATUS_ERROR ? OTEL_CODE_ERROR : OTEL_CODE_OK });
   }
 
   public logTrace(message: string, attributesJson?: string, scope?: Sentry.Scope): void {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -197,8 +197,7 @@ try {
 			assert(spanId, "init should pin a span id for events captured outside a span");
 			assertEqual(bridge.createScope().getPropagationContext().propagationSpanId, spanId,
 					"every scope should carry the same pinned span id");
-			bridge.scopeClear(scope);
-			assertEqual(scope.getPropagationContext().propagationSpanId, spanId,
+			assertEqual(bridge.scopeClear(scope).getPropagationContext().propagationSpanId, spanId,
 					"scopeClear should preserve the pinned span id");
 		});
 
@@ -314,10 +313,11 @@ try {
 			const scope = bridge.createScope();
 			bridge.scopeSetContext(scope, "test-context", '{"key": "value"}');
 			const traceId = scope.getPropagationContext().traceId;
-			bridge.scopeClear(scope);
-			assertEqual(scope.getScopeData().contexts["test-context"], undefined, "scopeClear should clear scope data");
-			assertEqual(scope.getPropagationContext().traceId, traceId,
+			const cleared = bridge.scopeClear(scope);
+			assertEqual(cleared.getScopeData().contexts["test-context"], undefined, "scopeClear should clear scope data");
+			assertEqual(cleared.getPropagationContext().traceId, traceId,
 					"scopeClear should preserve the propagation context");
+			assert(cleared.getClient() !== undefined, "scopeClear should keep the client bound");
 		});
 
 		runTest("spans stream instead of becoming transactions", () => {
@@ -369,8 +369,7 @@ try {
 			bridge.scopeSetSpan(scope, span);
 			assertEqual(scope.getScopeData().span, span, "scopeSetSpan should bind the span to the scope");
 			assertEqual(scope.clone().getScopeData().span, span, "a forked scope should inherit the bound span");
-			bridge.scopeClear(scope);
-			assertEqual(scope.getScopeData().span, undefined, "scopeClear should drop the bound span");
+			assertEqual(bridge.scopeClear(scope).getScopeData().span, undefined, "scopeClear should drop the bound span");
 			bridge.scopeSetSpan(scope, span);
 			bridge.scopeSetSpan(scope);
 			assertEqual(scope.getScopeData().span, undefined, "scopeSetSpan without a span should unbind");

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -356,12 +356,10 @@ try {
 
 		runTest("spanSetStatus()", () => {
 			const span = bridge.startSpan("load-level", "");
-			bridge.spanSetStatus(span, 2);
-			assertEqual(spanToStreamedSpanJSON(span).status, "error", "the error status code should stream as error");
 			bridge.spanSetStatus(span, 1);
-			assertEqual(spanToStreamedSpanJSON(span).status, "ok", "the ok status code should stream as ok");
+			assertEqual(spanToStreamedSpanJSON(span).status, "error", "SPAN_STATUS_ERROR should stream as error");
 			bridge.spanSetStatus(span, 0);
-			assertEqual(spanToStreamedSpanJSON(span).status, "ok", "the unset status code should stream as ok too");
+			assertEqual(spanToStreamedSpanJSON(span).status, "ok", "SPAN_STATUS_OK should stream as ok");
 			span.end();
 		});
 

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -320,12 +320,10 @@ try {
 			assert(cleared.getClient() !== undefined, "scopeClear should keep the client bound");
 		});
 
-		runTest("spans stream instead of becoming transactions", () => {
+		runTest("spans become transactions", () => {
 			const client = bridge.createScope().getClient();
-			assertEqual(client.getOptions().traceLifecycle, "stream",
-					"init should put the client on the streaming trace lifecycle");
-			assert(client.getIntegrationByName("SpanStreaming"),
-					"init should register the integration that streams ended spans");
+			assertEqual(client.getIntegrationByName("SpanStreaming"), undefined,
+					"init should not register span streaming");
 		});
 
 		runTest("startSpan()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -36,6 +36,8 @@ function runTest(name, testFn) {
 try {
 	require("./dist/sentry-bundle.js");
 
+	const { spanToStreamedSpanJSON } = require("@sentry/core");
+
 	console.log("✅ Bundle loaded successfully\n");
 
 	const bridge = global.window.SentryBridge;
@@ -62,6 +64,9 @@ try {
 			"scopeAddBytesAttachment",
 			"scopeAddFileAttachment",
 			"scopeClear",
+			"scopeSetSpan",
+			"startSpan",
+			"spanSetStatus",
 			"logTrace",
 			"logDebug",
 			"logInfo",
@@ -127,7 +132,7 @@ try {
 		};
 
 		runTest("init()", () => {
-			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, "0.1.0");
+			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 1.0, 100, false, "0.1.0");
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during
@@ -184,6 +189,17 @@ try {
 			assertEqual(bridge.createScope().getPropagationContext().traceId,
 					scope.getPropagationContext().traceId,
 					"createScope should inherit the current trace");
+		});
+
+		runTest("events outside a span share one span id", () => {
+			const scope = bridge.createScope();
+			const spanId = scope.getPropagationContext().propagationSpanId;
+			assert(spanId, "init should pin a span id for events captured outside a span");
+			assertEqual(bridge.createScope().getPropagationContext().propagationSpanId, spanId,
+					"every scope should carry the same pinned span id");
+			bridge.scopeClear(scope);
+			assertEqual(scope.getPropagationContext().propagationSpanId, spanId,
+					"scopeClear should preserve the pinned span id");
 		});
 
 		runTest("scope setters", () => {
@@ -302,6 +318,65 @@ try {
 			assertEqual(scope.getScopeData().contexts["test-context"], undefined, "scopeClear should clear scope data");
 			assertEqual(scope.getPropagationContext().traceId, traceId,
 					"scopeClear should preserve the propagation context");
+		});
+
+		runTest("spans stream instead of becoming transactions", () => {
+			const client = bridge.createScope().getClient();
+			assertEqual(client.getOptions().traceLifecycle, "stream",
+					"init should put the client on the streaming trace lifecycle");
+			assert(client.getIntegrationByName("SpanStreaming"),
+					"init should register the integration that streams ended spans");
+		});
+
+		runTest("startSpan()", () => {
+			const span = bridge.startSpan("load-level", '{"sentry.op":"asset.load","chunks":7}');
+			const json = spanToStreamedSpanJSON(span);
+			assertEqual(json.name, "load-level", "startSpan should name the span");
+			assertEqual(json.attributes["sentry.op"], "asset.load", "startSpan should carry the op through as an attribute");
+			assertEqual(json.attributes.chunks, 7, "startSpan should apply the attributes");
+			span.setAttribute("biome", "forest");
+			assertEqual(spanToStreamedSpanJSON(span).attributes.biome, "forest", "the started span should record attributes");
+			span.end();
+		});
+
+		runTest("startSpan() with a parent", () => {
+			const parent = bridge.startSpan("load-level", "");
+			const child = bridge.startSpan("decompress", "", parent);
+			assertEqual(child.spanContext().traceId, parent.spanContext().traceId,
+					"a child span should stay on the parent's trace");
+			assertEqual(spanToStreamedSpanJSON(child).parent_span_id, parent.spanContext().spanId,
+					"a child span should point at the parent");
+			assertEqual(spanToStreamedSpanJSON(child).is_segment, false,
+					"a child span should not be a segment");
+			assertEqual(spanToStreamedSpanJSON(bridge.startSpan("unrelated", "")).is_segment, true,
+					"a span started without a parent should be a segment");
+			child.end();
+			parent.end();
+		});
+
+		runTest("spanSetStatus()", () => {
+			const span = bridge.startSpan("load-level", "");
+			bridge.spanSetStatus(span, 2);
+			assertEqual(spanToStreamedSpanJSON(span).status, "error", "the error status code should stream as error");
+			bridge.spanSetStatus(span, 1);
+			assertEqual(spanToStreamedSpanJSON(span).status, "ok", "the ok status code should stream as ok");
+			bridge.spanSetStatus(span, 0);
+			assertEqual(spanToStreamedSpanJSON(span).status, "ok", "the unset status code should stream as ok too");
+			span.end();
+		});
+
+		runTest("scopeSetSpan()", () => {
+			const scope = bridge.createScope();
+			const span = bridge.startSpan("load-level", "");
+			bridge.scopeSetSpan(scope, span);
+			assertEqual(scope.getScopeData().span, span, "scopeSetSpan should bind the span to the scope");
+			assertEqual(scope.clone().getScopeData().span, span, "a forked scope should inherit the bound span");
+			bridge.scopeClear(scope);
+			assertEqual(scope.getScopeData().span, undefined, "scopeClear should drop the bound span");
+			bridge.scopeSetSpan(scope, span);
+			bridge.scopeSetSpan(scope);
+			assertEqual(scope.getScopeData().span, undefined, "scopeSetSpan without a span should unbind");
+			span.end();
 		});
 
 		runTest("logTrace()", () => {

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -2,6 +2,7 @@
 
 #include "sentry/disabled/disabled_scope.h"
 #include "sentry/javascript/javascript_breadcrumb.h"
+#include "sentry/javascript/javascript_span.h"
 #include "sentry/sentry_sdk.h"
 
 #include <godot_cpp/classes/json.hpp>
@@ -83,6 +84,14 @@ void JavaScriptScope::add_attachment(const Ref<SentryAttachment> &p_attachment) 
 				p_attachment->get_bytes(),
 				p_attachment->get_content_type_or_default().utf8(),
 				p_attachment->get_attachment_type().utf8());
+	}
+}
+
+void JavaScriptScope::set_span(SentrySpanImpl *p_span) {
+	if (JavaScriptSpan *js_span = Castable::cast_to<JavaScriptSpan>(p_span)) {
+		js_bridge()->call("scopeSetSpan", js_obj, js_span->get_js_object());
+	} else {
+		js_bridge()->call("scopeSetSpan", js_obj, nullptr);
 	}
 }
 

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -96,7 +96,9 @@ void JavaScriptScope::set_span(SentrySpanImpl *p_span) {
 }
 
 void JavaScriptScope::clear() {
-	js_bridge()->call("scopeClear", js_obj);
+	JSObjectPtr fresh_obj = js_bridge()->call("scopeClear", js_obj).as_object();
+	ERR_FAIL_COND_MSG(!fresh_obj, "Sentry: Failed to clear scope object.");
+	js_obj = fresh_obj;
 }
 
 SentryScopeImpl *JavaScriptScope::clone() const {

--- a/src/sentry/javascript/javascript_scope.h
+++ b/src/sentry/javascript/javascript_scope.h
@@ -25,6 +25,7 @@ public:
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
+	virtual void set_span(SentrySpanImpl *p_span) override;
 	virtual void clear() override;
 	virtual SentryScopeImpl *clone() const override;
 

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -327,7 +327,7 @@ SentryScopeImpl *JavaScriptSDK::create_scope() {
 
 SentrySpanImpl *JavaScriptSDK::create_span(const String &p_name, const Dictionary &p_attributes) {
 	ERR_FAIL_COND_V(!js_bridge(), SentrySpanImpl::create_noop());
-	return start_js_span(p_name, p_attributes, nullptr);
+	return JavaScriptSpan::start_span(p_name, p_attributes, nullptr);
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -7,6 +7,7 @@
 #include "sentry/javascript/javascript_log.h"
 #include "sentry/javascript/javascript_metric.h"
 #include "sentry/javascript/javascript_scope.h"
+#include "sentry/javascript/javascript_span.h"
 #include "sentry/javascript/javascript_util.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
@@ -325,8 +326,8 @@ SentryScopeImpl *JavaScriptSDK::create_scope() {
 }
 
 SentrySpanImpl *JavaScriptSDK::create_span(const String &p_name, const Dictionary &p_attributes) {
-	WARN_PRINT_ONCE("Sentry: Spans are not implemented on this platform yet - nothing will be recorded.");
-	return SentrySpanImpl::create_noop();
+	ERR_FAIL_COND_V(!js_bridge(), SentrySpanImpl::create_noop());
+	return start_js_span(p_name, p_attributes, nullptr);
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
@@ -363,6 +364,7 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_dist().utf8(),
 			SENTRY_OPTIONS()->get_environment().utf8(),
 			SENTRY_OPTIONS()->get_sample_rate(),
+			SENTRY_OPTIONS()->get_traces_sample_rate(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),
 			SENTRY_OPTIONS()->is_send_default_pii_enabled(),
 			SENTRY_GODOT_SDK_VERSION);

--- a/src/sentry/javascript/javascript_span.cpp
+++ b/src/sentry/javascript/javascript_span.cpp
@@ -1,0 +1,54 @@
+#include "javascript_span.h"
+
+#include "sentry/javascript/javascript_util.h"
+
+#include <godot_cpp/core/error_macros.hpp>
+
+namespace sentry::javascript {
+
+// NOTE: Bridge and js_obj are guaranteed to be valid: creation/bridge failures yield a DisabledSpan instead.
+
+void JavaScriptSpan::set_attribute(const String &p_key, const Variant &p_value) {
+	switch (p_value.get_type()) {
+		case Variant::Type::BOOL: {
+			js_obj->call("setAttribute", p_key.utf8(), p_value.operator bool());
+		} break;
+		case Variant::Type::INT: {
+			js_obj->call("setAttribute", p_key.utf8(), p_value.operator int64_t());
+		} break;
+		case Variant::Type::FLOAT: {
+			js_obj->call("setAttribute", p_key.utf8(), p_value.operator double());
+		} break;
+		case Variant::Type::STRING: {
+			js_obj->call("setAttribute", p_key.utf8(), p_value.operator String().utf8());
+		} break;
+		default: {
+			js_obj->call("setAttribute", p_key.utf8(), p_value.stringify().utf8());
+		} break;
+	}
+}
+
+void JavaScriptSpan::set_status(SpanStatus p_status) {
+	js_bridge()->call("spanSetStatus", js_obj, int64_t(p_status));
+}
+
+void JavaScriptSpan::end() {
+	js_obj->call("end");
+}
+
+SentrySpanImpl *JavaScriptSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
+	return start_js_span(p_name, p_attributes, js_obj);
+}
+
+JavaScriptSpan::JavaScriptSpan(const JSObjectPtr &p_js_span_object) :
+		js_obj(p_js_span_object) {
+}
+
+SentrySpanImpl *start_js_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent) {
+	String attr_value = attributes_to_json(p_attributes);
+	JSObjectPtr span_obj = js_bridge()->call("startSpan", p_name.utf8(), attr_value.utf8(), p_parent).as_object();
+	ERR_FAIL_COND_V_MSG(!span_obj, SentrySpanImpl::create_noop(), "Sentry: Failed to create span object.");
+	return memnew(JavaScriptSpan(span_obj));
+}
+
+} //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_span.cpp
+++ b/src/sentry/javascript/javascript_span.cpp
@@ -8,6 +8,17 @@ namespace sentry::javascript {
 
 // NOTE: Bridge and js_obj are guaranteed to be valid: creation/bridge failures yield a DisabledSpan instead.
 
+SentrySpanImpl *JavaScriptSpan::start_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent) {
+	String attr_value = attributes_to_json(p_attributes);
+	JSObjectPtr span_obj = js_bridge()->call("startSpan", p_name.utf8(), attr_value.utf8(), p_parent).as_object();
+	ERR_FAIL_COND_V_MSG(!span_obj, SentrySpanImpl::create_noop(), "Sentry: Failed to create span object.");
+	return memnew(JavaScriptSpan(span_obj));
+}
+
+SentrySpanImpl *JavaScriptSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
+	return start_span(p_name, p_attributes, js_obj);
+}
+
 void JavaScriptSpan::set_attribute(const String &p_key, const Variant &p_value) {
 	switch (p_value.get_type()) {
 		case Variant::Type::BOOL: {
@@ -34,17 +45,6 @@ void JavaScriptSpan::set_status(SpanStatus p_status) {
 
 void JavaScriptSpan::end() {
 	js_obj->call("end");
-}
-
-SentrySpanImpl *JavaScriptSpan::start_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent) {
-	String attr_value = attributes_to_json(p_attributes);
-	JSObjectPtr span_obj = js_bridge()->call("startSpan", p_name.utf8(), attr_value.utf8(), p_parent).as_object();
-	ERR_FAIL_COND_V_MSG(!span_obj, SentrySpanImpl::create_noop(), "Sentry: Failed to create span object.");
-	return memnew(JavaScriptSpan(span_obj));
-}
-
-SentrySpanImpl *JavaScriptSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
-	return start_span(p_name, p_attributes, js_obj);
 }
 
 JavaScriptSpan::JavaScriptSpan(const JSObjectPtr &p_js_span_object) :

--- a/src/sentry/javascript/javascript_span.cpp
+++ b/src/sentry/javascript/javascript_span.cpp
@@ -36,19 +36,19 @@ void JavaScriptSpan::end() {
 	js_obj->call("end");
 }
 
-SentrySpanImpl *JavaScriptSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
-	return start_js_span(p_name, p_attributes, js_obj);
-}
-
-JavaScriptSpan::JavaScriptSpan(const JSObjectPtr &p_js_span_object) :
-		js_obj(p_js_span_object) {
-}
-
-SentrySpanImpl *start_js_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent) {
+SentrySpanImpl *JavaScriptSpan::start_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent) {
 	String attr_value = attributes_to_json(p_attributes);
 	JSObjectPtr span_obj = js_bridge()->call("startSpan", p_name.utf8(), attr_value.utf8(), p_parent).as_object();
 	ERR_FAIL_COND_V_MSG(!span_obj, SentrySpanImpl::create_noop(), "Sentry: Failed to create span object.");
 	return memnew(JavaScriptSpan(span_obj));
+}
+
+SentrySpanImpl *JavaScriptSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
+	return start_span(p_name, p_attributes, js_obj);
+}
+
+JavaScriptSpan::JavaScriptSpan(const JSObjectPtr &p_js_span_object) :
+		js_obj(p_js_span_object) {
 }
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_span.h
+++ b/src/sentry/javascript/javascript_span.h
@@ -13,20 +13,19 @@ class JavaScriptSpan : public SentrySpanImpl {
 private:
 	JSObjectPtr js_obj;
 
+	explicit JavaScriptSpan(const JSObjectPtr &p_js_span_object);
+
 public:
+	// Starts a JavaScript span, parented to p_parent when provided; otherwise starts a root-level span.
+	static SentrySpanImpl *start_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent);
+
+	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) override;
+
 	_FORCE_INLINE_ JSObjectPtr get_js_object() const { return js_obj; }
 
 	virtual void set_attribute(const String &p_key, const Variant &p_value) override;
 	virtual void set_status(SpanStatus p_status) override;
 	virtual void end() override;
-
-	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) override;
-
-	explicit JavaScriptSpan(const JSObjectPtr &p_js_span_object);
-	JavaScriptSpan() = delete;
 };
-
-// Starts a JavaScript span, parented to p_parent when provided; otherwise starts a root-level span.
-SentrySpanImpl *start_js_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent);
 
 } //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_span.h
+++ b/src/sentry/javascript/javascript_span.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "sentry/javascript/javascript_interop.h"
+#include "sentry/sentry_span_impl.h"
+
+namespace sentry::javascript {
+
+// Backed by a JS Span object, which is guaranteed to be valid: creation failures yield a DisabledSpan instead.
+// See JavaScriptSDK::create_span().
+class JavaScriptSpan : public SentrySpanImpl {
+	SENTRY_CASTABLE(JavaScriptSpan, SentrySpanImpl);
+
+private:
+	JSObjectPtr js_obj;
+
+public:
+	_FORCE_INLINE_ JSObjectPtr get_js_object() const { return js_obj; }
+
+	virtual void set_attribute(const String &p_key, const Variant &p_value) override;
+	virtual void set_status(SpanStatus p_status) override;
+	virtual void end() override;
+
+	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) override;
+
+	explicit JavaScriptSpan(const JSObjectPtr &p_js_span_object);
+	JavaScriptSpan() = delete;
+};
+
+// Starts a JavaScript span, parented to p_parent when provided; otherwise starts a root-level span.
+SentrySpanImpl *start_js_span(const String &p_name, const Dictionary &p_attributes, const JSObjectPtr &p_parent);
+
+} //namespace sentry::javascript


### PR DESCRIPTION
Adds span support to Web exports, including parent-child relationships, scope association, attributes, status, and span completion. Web games can now use the same `SentrySDK.start_span()` API as supported desktop platforms and send performance data from WebAssembly builds.

- Refs #861
- Base PR #863
- Docs PR https://github.com/getsentry/sentry-docs/pull/19210
