### PR TITLE
fix(attributes): Reject empty attribute keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - Web: Fixed tags, breadcrumbs and other globally set data carrying over into the next session when the SDK is closed and initialized again ([#857](https://github.com/getsentry/sentry-godot/pull/857))
+- Fixed attributes with an empty key not being rejected on structured logs and metrics; such attributes are now dropped and reported as an error ([#876](https://github.com/getsentry/sentry-godot/pull/876))
 
 ### Dependencies
 

--- a/project/test/isolated/test_metrics.gd
+++ b/project/test/isolated/test_metrics.gd
@@ -107,6 +107,17 @@ func test_count_with_attributes() -> void:
 	})
 
 
+func test_count_with_empty_attribute_key() -> void:
+	metric_processed.connect(func(metric: SentryMetric):
+		assert_that(metric.get_attribute("")).is_null()
+		assert_str(metric.get_attribute("level")).is_equal("forest")
+	, CONNECT_ONE_SHOT)
+	SentrySDK.metrics.count("enemy_defeated", 1, {
+		"": "should be dropped",
+		"level": "forest"
+	})
+
+
 func test_metric_attribute_methods() -> void:
 	metric_processed.connect(func(metric: SentryMetric):
 		metric.add_attributes({

--- a/project/test/isolated/test_structured_logs.gd
+++ b/project/test/isolated/test_structured_logs.gd
@@ -117,6 +117,17 @@ func test_structured_logs_with_custom_attributes() -> void:
 	})
 
 
+func test_structured_logs_with_empty_attribute_key() -> void:
+	log_processed.connect(func(entry: SentryLog):
+		assert_that(entry.get_attribute("")).is_null()
+		assert_str(entry.get_attribute("level")).is_equal("forest")
+	, CONNECT_ONE_SHOT)
+	SentrySDK.logger.info("Test 123", [], {
+		"": "should be dropped",
+		"level": "forest"
+	})
+
+
 func test_structured_logs_with_attribute_removal() -> void:
 	log_processed.connect(func(entry: SentryLog):
 		assert_str(entry.get_attribute("level")).is_equal("forest")

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -34,7 +34,9 @@ Dictionary _sanitize_attributes(const Dictionary &p_attributes) {
 		const Array &keys = p_attributes.keys();
 		for (int i = 0; i < keys.size(); i++) {
 			const Variant &key = keys[i];
-			attributes[key.stringify()] = _as_attribute(p_attributes[key]);
+			String name = key.stringify();
+			ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty name.");
+			attributes[name] = _as_attribute(p_attributes[key]);
 		}
 	}
 	return attributes;

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -54,7 +54,9 @@ NSDictionary<NSString *, SentryObjCAttributeContent *> *_metric_attributes_to_ob
 	const Array &keys = p_attributes.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		const Variant &key = keys[i];
-		attributes[sentry::cocoa::string_to_objc(key.stringify())] = sentry::cocoa::variant_to_attribute_content(p_attributes[key]);
+		String name = key.stringify();
+		ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty name.");
+		attributes[sentry::cocoa::string_to_objc(name)] = sentry::cocoa::variant_to_attribute_content(p_attributes[key]);
 	}
 	return attributes;
 }
@@ -172,7 +174,9 @@ void CocoaSDK::capture_log(const Ref<SentryScope> &p_scope, LogLevel p_level, co
 		const Array &keys = p_attributes.keys();
 		for (int i = 0; i < keys.size(); i++) {
 			const Variant &key = keys[i];
-			const NSString *objc_key = [NSString stringWithUTF8String:key.stringify().utf8()];
+			String name = key.stringify();
+			ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty name.");
+			const NSString *objc_key = [NSString stringWithUTF8String:name.utf8()];
 			const NSObject *objc_value = _as_attribute(p_attributes[key]);
 			[attributes setObject:objc_value forKey:objc_key];
 		}

--- a/src/sentry/javascript/javascript_util.cpp
+++ b/src/sentry/javascript/javascript_util.cpp
@@ -15,9 +15,11 @@ String attributes_to_json(const Dictionary &p_attributes) {
 	Array keys = p_attributes.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		const Variant &key = keys[i];
+		String name = key.stringify();
+		ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty name.");
 		Variant value = p_attributes[key];
 
-		writer.key(key.stringify());
+		writer.key(name);
 		switch (value.get_type()) {
 			case Variant::BOOL: {
 				writer.value_bool(value.operator bool());

--- a/src/sentry/native/native_util.cpp
+++ b/src/sentry/native/native_util.cpp
@@ -180,7 +180,9 @@ sentry_value_t dictionary_to_attributes(const Dictionary &p_attributes) {
 	}
 	sentry_value_t rv = sentry_value_new_object();
 	for (const Variant &key : p_attributes.keys()) {
-		sentry_value_set_by_key(rv, key.stringify().utf8(),
+		String name = key.stringify();
+		ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty name.");
+		sentry_value_set_by_key(rv, name.utf8(),
 				variant_to_attribute(p_attributes[key]));
 	}
 	return rv;


### PR DESCRIPTION
Attributes attached to structured logs and metrics were converted for the backend without their keys being checked, so an entry with an empty key was passed straight through. Such an entry is now skipped and reported as an error, which is how the SDK already treats an empty key passed to `SentrySDK.set_tag()` or `SentrySDK.set_context()`.

- Extracted from #863 