### PR TITLE
feat(feedback): Add `before_send_feedback` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Not supported on macOS and iOS yet, where telemetry is still captured but the scope data is discarded with a warning
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
+- Add the `SentryOptions.before_send_feedback` callback to filter or enrich user feedback before it is sent ([#878](https://github.com/getsentry/sentry-godot/pull/878))
+  - Not supported on macOS and iOS yet, where feedback is still sent but the callback never runs
 
 ### Improvements
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -235,6 +235,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     fun init(
         optionsData: Dictionary,
         beforeSendHandlerId: Long,
+        beforeSendFeedbackHandlerId: Long,
         beforeSendLogHandlerId: Long,
         beforeSendMetricHandlerId: Long
     ) {
@@ -282,6 +283,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                         Log.v(TAG, "beforeSend: ${event.eventId} isCrashed: ${event.isCrashed}")
                         val handle: Int = registerEvent(event)
                         Callable.call(beforeSendHandlerId, "before_send", handle)
+                        eventsByHandle.get()?.remove(handle) // Returns the event or null if it was discarded.
+                    }
+                options.beforeSendFeedback =
+                    SentryOptions.BeforeSendCallback { event: SentryEvent, hint: Hint ->
+                        val handle: Int = registerEvent(event)
+                        Callable.call(beforeSendFeedbackHandlerId, "before_send_feedback", handle)
                         eventsByHandle.get()?.remove(handle) // Returns the event or null if it was discarded.
                     }
                 if (beforeSendLogHandlerId != 0L) {

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -58,6 +58,18 @@
 			[/codeblock]
 			To learn more, visit [url=https://docs.sentry.io/platforms/godot/configuration/filtering/]Filtering documentation[/url]. Also, check out [url=https://docs.sentry.io/platforms/godot/data-management/sensitive-data/]Scrubbing Sensitive Data[/url].
 		</member>
+		<member name="before_send_feedback" type="Callable" setter="set_before_send_feedback" getter="get_before_send_feedback" default="Callable()">
+			If assigned, this callback runs before user feedback is sent to Sentry. It takes [SentryEvent] as a parameter and returns either the same event object, with or without modifications, or [code]null[/code] to skip reporting the feedback. You can assign it in a configuration callback using manual initialization (see [method SentrySDK.init]). The fields submitted with the [SentryFeedback] object are carried in the event's [code]feedback[/code] context.
+			[codeblock]
+			func _before_send_feedback(event: SentryEvent) -&gt; SentryEvent:
+			    if event.environment == "editor_dev_run":
+			        # Discard feedback submitted while running from the editor.
+			        return null
+			    event.set_tag("feedback_source", "in_game_form")
+			    return event
+			[/codeblock]
+			[b]Platform support:[/b] This callback is not supported on iOS and macOS yet. Feedback is still sent there, but the callback never runs.
+		</member>
 		<member name="before_send_log" type="Callable" setter="set_before_send_log" getter="get_before_send_log" default="Callable()">
 			If assigned, this callback will be called before sending a log message to Sentry. It can be used to modify the log message or prevent it from being sent.
 			[codeblock]

--- a/project/test/isolated/test_before_send_feedback.gd
+++ b/project/test/isolated/test_before_send_feedback.gd
@@ -1,0 +1,160 @@
+extends SentryTestSuite
+## Verifies the `before_send_feedback` callback and what user feedback carries.
+
+
+signal feedback_captured
+
+var captured_feedback: Array[String]
+
+var before_send_feedback: Callable # (event: SentryEvent) -> SentryEvent
+
+## Position of the next feedback to be returned by wait_for_captured_feedback_json().
+var _next_captured_feedback := 0
+
+
+# TODO: drop the skip when Cocoa gains a feedback hook.
+func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "before_send_feedback is not supported on this platform yet.") -> void:
+	super()
+
+
+func init_sdk() -> void:
+	SentrySDK.init(func(options: SentryOptions) -> void:
+		options.before_send_feedback = func(event: SentryEvent) -> SentryEvent:
+			return before_send_feedback.call(event)
+	)
+
+
+func before_test() -> void:
+	super()
+	captured_feedback.clear()
+	_next_captured_feedback = 0
+	before_send_feedback = _default_before_send_feedback
+
+
+func _default_before_send_feedback(event: SentryEvent) -> SentryEvent:
+	captured_feedback.append(event.to_json())
+	feedback_captured.emit()
+	return null
+
+
+## Expect feedback to be processed and return its serialized JSON content.
+## Consecutive calls hand out captured feedback in capture order.
+func wait_for_captured_feedback_json() -> String:
+	if _next_captured_feedback >= captured_feedback.size():
+		await await_signal_on(self, "feedback_captured")
+	if _next_captured_feedback >= captured_feedback.size():
+		return ""
+	var json: String = captured_feedback[_next_captured_feedback]
+	_next_captured_feedback += 1
+	return json
+
+
+func test_submitted_fields_reach_the_callback() -> void:
+	var feedback := SentryFeedback.new()
+	feedback.message = "The boss fight is unbeatable"
+	feedback.name = "Bob"
+	feedback.contact_email = "bob@example.com"
+	feedback.associated_event_id = "082ce03eface41dd94b8c6b005382d5e"
+
+	SentrySDK.capture_feedback(feedback)
+	var json: String = await wait_for_captured_feedback_json()
+
+	assert_json(json).describe("feedback context carries the submitted fields") \
+		.at("/contexts/feedback") \
+		.is_object() \
+		.must_contain("message", "The boss fight is unbeatable") \
+		.must_contain("name", "Bob") \
+		.must_contain("contact_email", "bob@example.com") \
+		.must_contain("associated_event_id", "082ce03eface41dd94b8c6b005382d5e") \
+		.verify()
+
+
+func test_callback_can_modify_the_event() -> void:
+	before_send_feedback = func(event: SentryEvent) -> SentryEvent:
+		event.set_tag("feedback_source", "test_suite")
+		event.level = SentrySDK.LEVEL_WARNING
+		return _default_before_send_feedback(event)
+
+	var feedback := SentryFeedback.new()
+	feedback.message = "Modified feedback"
+	SentrySDK.capture_feedback(feedback)
+	var json: String = await wait_for_captured_feedback_json()
+
+	assert_json(json).describe("tag set in the callback reaches the event") \
+		.at("/tags") \
+		.must_contain("feedback_source", "test_suite") \
+		.verify()
+
+	assert_json(json).describe("level set in the callback reaches the event") \
+		.at("/") \
+		.must_contain("level", "warning") \
+		.verify()
+
+
+func test_feedback_does_not_reach_before_send() -> void:
+	var feedback := SentryFeedback.new()
+	feedback.message = "Feedback stays out of before_send"
+	SentrySDK.capture_feedback(feedback)
+	assert_str(await wait_for_captured_feedback_json()).is_not_empty()
+
+	await get_tree().process_frame  # ensure before_send doesn't run right after
+
+	assert_int(captured_events.size()).override_failure_message(
+		"Feedback should not have reached before_send").is_equal(0)
+
+
+func test_enrichment_reaches_feedback() -> void:
+	var feedback := SentryFeedback.new()
+	feedback.message = "Enriched feedback"
+	SentrySDK.capture_feedback(feedback)
+
+	assert_json(await wait_for_captured_feedback_json()) \
+		.describe("processor-injected contexts reach the feedback event") \
+		.at("/contexts/godot_performance") \
+		.is_object() \
+		.verify()
+
+
+## Feedback captured inside with_scope() carries the scoped data, and later captures do not.
+func test_scoped_feedback_capture() -> void:
+	var scoped_user := SentryUser.new()
+	scoped_user.id = "player_scope"
+
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("scoped", "in_scope")
+		scope.set_context("scene", {"name": "Dungeon", "depth": 3})
+		scope.set_user(scoped_user)
+		var feedback := SentryFeedback.new()
+		feedback.message = "Scoped feedback"
+		SentrySDK.capture_feedback(feedback)
+		)
+	var json_in_scope: String = await wait_for_captured_feedback_json()
+
+	var after := SentryFeedback.new()
+	after.message = "Feedback after the scope"
+	SentrySDK.capture_feedback(after)
+	var json_after: String = await wait_for_captured_feedback_json()
+
+	assert_json(json_in_scope).describe("scoped tag reaches the in-scope feedback") \
+		.at("/tags") \
+		.must_contain("scoped", "in_scope") \
+		.verify()
+
+	assert_json(json_in_scope).describe("scoped context reaches the in-scope feedback") \
+		.at("/contexts/scene") \
+		.is_object() \
+		.must_contain("name", "Dungeon") \
+		.must_contain("depth", 3) \
+		.verify()
+
+	assert_json(json_in_scope).describe("scoped user reaches the in-scope feedback") \
+		.at("/user") \
+		.must_contain("id", "player_scope") \
+		.verify()
+
+	assert_json(json_after).describe("scoped data does not leak past with_scope") \
+		.at("/") \
+		.must_not_contain("/tags/scoped") \
+		.must_not_contain("/contexts/scene") \
+		.verify()

--- a/project/test/isolated/test_before_send_feedback.gd.uid
+++ b/project/test/isolated/test_before_send_feedback.gd.uid
@@ -1,0 +1,1 @@
+uid://cklxbb5y4ohae

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -132,6 +132,7 @@ func test_level_properties(property: String, test_parameters := [
 @warning_ignore("unused_parameter")
 func test_callback_properties(property: String, test_parameters := [
 	["before_send"],
+	["before_send_feedback"],
 	["before_capture_screenshot"]
 ]) -> void:
 	var callback := func(_a): pass

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -3,6 +3,7 @@
 #include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/engine_lifecycle/sentry_scene_tree_watcher.h"
 #include "sentry/logging/sentry_godot_logger.h"
+#include "sentry/processing/enrichment_processor.h"
 #include "sentry/processing/screenshot_processor.h"
 #include "sentry/processing/sentry_event_processor.h"
 #include "sentry/processing/view_hierarchy_processor.h"
@@ -97,6 +98,7 @@ void register_runtime_classes() {
 	GDREGISTER_ABSTRACT_CLASS(SentryScope);
 	GDREGISTER_INTERNAL_CLASS(DisabledEvent);
 	GDREGISTER_INTERNAL_CLASS(SentryEventProcessor);
+	GDREGISTER_INTERNAL_CLASS(EnrichmentProcessor);
 	GDREGISTER_INTERNAL_CLASS(ScreenshotProcessor);
 	GDREGISTER_INTERNAL_CLASS(ViewHierarchyProcessor);
 	GDREGISTER_INTERNAL_CLASS(logging::SentryGodotLogger);
@@ -117,6 +119,7 @@ void register_runtime_classes() {
 	GDREGISTER_INTERNAL_CLASS(android::AndroidLog);
 	GDREGISTER_INTERNAL_CLASS(android::AndroidMetric);
 	GDREGISTER_INTERNAL_CLASS(android::SentryAndroidBeforeSendHandler);
+	GDREGISTER_INTERNAL_CLASS(android::SentryAndroidBeforeSendFeedbackHandler);
 	GDREGISTER_INTERNAL_CLASS(android::SentryAndroidBeforeSendLogHandler);
 	GDREGISTER_INTERNAL_CLASS(android::SentryAndroidBeforeSendMetricHandler);
 #endif

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -10,6 +10,7 @@
 #include "sentry/common_defs.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
+#include "sentry/processing/process_feedback.h"
 #include "sentry/processing/process_log.h"
 #include "sentry/processing/process_metric.h"
 #include "sentry/sentry_attachment.h"
@@ -68,6 +69,24 @@ void SentryAndroidBeforeSendHandler::_before_send(int32_t p_event_handle) {
 
 void SentryAndroidBeforeSendHandler::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("before_send"), &SentryAndroidBeforeSendHandler::_before_send);
+}
+
+// *** SentryAndroidBeforeSendFeedbackHandler
+
+void SentryAndroidBeforeSendFeedbackHandler::_before_send_feedback(int32_t p_event_handle) {
+	Ref<AndroidEvent> event_obj = memnew(AndroidEvent(android_plugin, p_event_handle));
+	event_obj->set_as_borrowed();
+
+	Ref<AndroidEvent> processed = sentry::process_feedback(event_obj);
+
+	if (processed.is_null()) {
+		// Discard feedback.
+		android_plugin->call(ANDROID_SN(releaseEvent), p_event_handle);
+	}
+}
+
+void SentryAndroidBeforeSendFeedbackHandler::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("before_send_feedback"), &SentryAndroidBeforeSendFeedbackHandler::_before_send_feedback);
 }
 
 // *** SentryAndroidBeforeSendLogHandler
@@ -389,6 +408,7 @@ void AndroidSDK::init() {
 	android_plugin->call(ANDROID_SN(init),
 			optionsData,
 			before_send_handler->get_instance_id(),
+			before_send_feedback_handler->get_instance_id(),
 			SENTRY_OPTIONS()->get_before_send_log().is_valid() ? before_send_log_handler->get_instance_id() : 0,
 			SENTRY_OPTIONS()->get_before_send_metric().is_valid() ? before_send_metric_handler->get_instance_id() : 0);
 
@@ -421,6 +441,9 @@ AndroidSDK::AndroidSDK() {
 	before_send_handler = memnew(SentryAndroidBeforeSendHandler);
 	before_send_handler->_initialize(android_plugin);
 
+	before_send_feedback_handler = memnew(SentryAndroidBeforeSendFeedbackHandler);
+	before_send_feedback_handler->_initialize(android_plugin);
+
 	before_send_log_handler = memnew(SentryAndroidBeforeSendLogHandler);
 	before_send_log_handler->_initialize(android_plugin);
 
@@ -432,6 +455,9 @@ AndroidSDK::~AndroidSDK() {
 	AndroidStringNames::destroy_singleton();
 	if (before_send_handler) {
 		memdelete(before_send_handler);
+	}
+	if (before_send_feedback_handler) {
+		memdelete(before_send_feedback_handler);
 	}
 	if (before_send_log_handler) {
 		memdelete(before_send_log_handler);

--- a/src/sentry/android/android_sdk.h
+++ b/src/sentry/android/android_sdk.h
@@ -21,6 +21,21 @@ protected:
 	static void _bind_methods();
 };
 
+class SentryAndroidBeforeSendFeedbackHandler : public Object {
+	GDCLASS(SentryAndroidBeforeSendFeedbackHandler, Object);
+	friend class AndroidSDK;
+
+private:
+	Object *android_plugin = nullptr;
+
+	void _initialize(Object *p_android_plugin) { android_plugin = p_android_plugin; }
+
+	void _before_send_feedback(int32_t p_event_handle);
+
+protected:
+	static void _bind_methods();
+};
+
 class SentryAndroidBeforeSendLogHandler : public Object {
 	GDCLASS(SentryAndroidBeforeSendLogHandler, Object);
 	friend class AndroidSDK;
@@ -56,6 +71,7 @@ class AndroidSDK : public InternalSDK {
 private:
 	uint64_t android_plugin_instance_id = 0;
 	SentryAndroidBeforeSendHandler *before_send_handler = nullptr;
+	SentryAndroidBeforeSendFeedbackHandler *before_send_feedback_handler = nullptr;
 	SentryAndroidBeforeSendLogHandler *before_send_log_handler = nullptr;
 	SentryAndroidBeforeSendMetricHandler *before_send_metric_handler = nullptr;
 
@@ -98,6 +114,7 @@ public:
 	virtual SentryScopeImpl *create_scope() override;
 
 	virtual bool supports_scopes() const override { return true; }
+	virtual bool supports_before_send_feedback() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/cocoa/cocoa_sdk.h
+++ b/src/sentry/cocoa/cocoa_sdk.h
@@ -48,6 +48,8 @@ public:
 
 	virtual SentryScopeImpl *create_scope() override;
 
+	virtual bool supports_before_send_feedback() const override { return false; }
+
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 
 	virtual void init() override;

--- a/src/sentry/disabled/disabled_sdk.h
+++ b/src/sentry/disabled/disabled_sdk.h
@@ -44,6 +44,7 @@ class DisabledSDK : public InternalSDK {
 
 	// Nothing is captured, so nothing is lost by discarding scope writes.
 	virtual bool supports_scopes() const override { return true; }
+	virtual bool supports_before_send_feedback() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override {}
 

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -58,6 +58,8 @@ public:
 	// writes, which is a platform gap worth warning about.
 	virtual bool supports_scopes() const { return false; }
 
+	virtual bool supports_before_send_feedback() const = 0;
+
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) = 0;
 
 	virtual void init() = 0;

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -130,6 +130,7 @@ class SentryBridge {
 
   public init(
     beforeSendCallback: (event: Sentry.Event) => void,
+    beforeSendFeedbackCallback: (event: Sentry.Event) => void,
     beforeSendLogCallback: ((log: Sentry.Log) => void) | null,
     beforeSendMetricCallback: ((metric: Metric) => void) | null,
     readAttachmentCallback: (request: AttachmentRequest) => void,
@@ -247,6 +248,26 @@ class SentryBridge {
     Sentry.getCurrentScope().clear();
 
     Sentry.init(options);
+
+    if (beforeSendFeedbackCallback) {
+      // @sentry/core has no beforeSendFeedback option, and feedback also bypasses beforeSend.
+      Sentry.getClient()?.addEventProcessor((event: Sentry.Event) => {
+        if (event.type !== "feedback") {
+          return event;
+        }
+
+        beforeSendFeedbackCallback(event);
+
+        const shouldDiscard: boolean = (event as any).shouldDiscard;
+        delete (event as any).shouldDiscard;
+
+        return shouldDiscard ? null : event;
+      });
+    } else {
+      console.error(
+        "Sentry: beforeSendFeedback callback is missing. User feedback will be sent without native-side processing; this is unexpected and likely indicates the bridge failed to initialize correctly.",
+      );
+    }
 
     if (readAttachmentCallback) {
       // Runs for every event type right before the attachments become envelope items, whereas

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -256,6 +256,10 @@ class SentryBridge {
           return event;
         }
 
+        if (!this.isEnabled()) {
+          return null;
+        }
+
         beforeSendFeedbackCallback(event);
 
         const shouldDiscard: boolean = (event as any).shouldDiscard;

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -120,8 +120,14 @@ try {
 			}
 		};
 
+		// Stands in for the C++ layer: records the feedback events the hook receives.
+		const feedbackEvents = [];
+		const beforeSendFeedback = (event) => {
+			feedbackEvents.push(event);
+		};
+
 		runTest("init()", () => {
-			bridge.init(() => {}, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
+			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during
@@ -339,8 +345,15 @@ try {
 		});
 
 		runTest("captureFeedback()", () => {
+			const feedbackCountBefore = feedbackEvents.length;
 			const result = bridge.captureFeedback("Test feedback", "Test User", "test@example.com", "");
 			assertEqual(typeof result, "string", "captureFeedback should return a string");
+			assertEqual(feedbackEvents.length, feedbackCountBefore + 1, "captureFeedback should run the before-send-feedback callback once");
+			const seen = feedbackEvents[feedbackEvents.length - 1];
+			assertEqual(seen.type, "feedback", "the callback should receive a feedback event");
+			assertEqual(seen.contexts.feedback.message, "Test feedback", "the callback should see the submitted message");
+			assertEqual(seen.contexts.feedback.name, "Test User", "the callback should see the submitted name");
+			assertEqual(seen.contexts.feedback.contact_email, "test@example.com", "the callback should see the submitted email");
 			const scoped = bridge.captureFeedback("Test feedback", "", "", "", bridge.createScope());
 			assertEqual(typeof scoped, "string", "Scoped captureFeedback should return a string");
 		});

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -10,6 +10,7 @@
 #include "sentry/javascript/javascript_util.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/process_event.h"
+#include "sentry/processing/process_feedback.h"
 #include "sentry/processing/process_log.h"
 #include "sentry/processing/process_metric.h"
 #include "sentry/sentry_sdk.h"
@@ -38,6 +39,20 @@ static void before_send_wasm_callback(int32_t *p_ids, int32_t p_len) {
 
 	// NOTE: We cannot return a value from a callback, so we use the same
 	//       event object to communicate the result back.
+	event_obj->set("shouldDiscard", processed.is_null());
+}
+
+static void before_send_feedback_wasm_callback(int32_t *p_ids, int32_t p_len) {
+	ERR_FAIL_COND(p_len != 1);
+
+	JSObjectPtr event_obj = JSObject::from_id(p_ids[0]);
+	ERR_FAIL_COND(!event_obj);
+
+	Ref<JavaScriptEvent> event = memnew(JavaScriptEvent(event_obj));
+	Ref<JavaScriptEvent> processed = sentry::process_feedback(event);
+
+	// We cannot return a value from a callback, so we use the same
+	// event object to communicate the result back.
 	event_obj->set("shouldDiscard", processed.is_null());
 }
 
@@ -317,6 +332,7 @@ void JavaScriptSDK::init() {
 	ERR_FAIL_COND(!js_bridge());
 
 	JSObjectPtr before_send_callback = JSObject::create_callback(before_send_wasm_callback);
+	JSObjectPtr before_send_feedback_callback = JSObject::create_callback(before_send_feedback_wasm_callback);
 	JSObjectPtr read_attachment_callback = JSObject::create_callback(read_attachment_wasm_callback);
 
 	// Only create the before_send_log callback if user has set a callback
@@ -332,6 +348,7 @@ void JavaScriptSDK::init() {
 
 	js_bridge()->call("init",
 			before_send_callback,
+			before_send_feedback_callback,
 			before_send_log_callback,
 			before_send_metric_callback,
 			read_attachment_callback,

--- a/src/sentry/javascript/javascript_sdk.h
+++ b/src/sentry/javascript/javascript_sdk.h
@@ -46,6 +46,7 @@ public:
 	virtual SentryScopeImpl *create_scope() override;
 
 	virtual bool supports_scopes() const override { return true; }
+	virtual bool supports_before_send_feedback() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -12,6 +12,7 @@
 #include "sentry/native/native_util.h"
 #include "sentry/native/platform_detection.h"
 #include "sentry/processing/process_event.h"
+#include "sentry/processing/process_feedback.h"
 #include "sentry/processing/process_log.h"
 #include "sentry/processing/process_metric.h"
 #include "sentry/sentry_attachment.h"
@@ -40,6 +41,19 @@ sentry_value_t _handle_before_send(sentry_value_t event, void *hint, void *closu
 		return sentry_value_new_null();
 	} else {
 		return event;
+	}
+}
+
+sentry_value_t _handle_before_send_feedback(sentry_value_t p_feedback, sentry_hint_t *p_hint, void *p_user_data) {
+	Ref<NativeEvent> event_obj = memnew(NativeEvent(p_feedback, false));
+	Ref<NativeEvent> processed = sentry::process_feedback(event_obj);
+
+	if (unlikely(processed.is_null())) {
+		// Discard feedback.
+		sentry_value_decref(p_feedback);
+		return sentry_value_new_null();
+	} else {
+		return p_feedback;
 	}
 }
 
@@ -449,6 +463,7 @@ void NativeSDK::init() {
 
 	// Hooks.
 	sentry_options_set_before_send(options, _handle_before_send, NULL);
+	sentry_options_set_before_send_feedback(options, _handle_before_send_feedback, NULL);
 	sentry_options_set_on_crash(options, _handle_on_crash, NULL);
 	sentry_options_set_logger(options, _log_native_message, NULL);
 

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -50,6 +50,7 @@ public:
 	virtual SentryScopeImpl *create_scope() override;
 
 	virtual bool supports_scopes() const override { return true; }
+	virtual bool supports_before_send_feedback() const override { return true; }
 
 	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 

--- a/src/sentry/processing/enrichment_processor.cpp
+++ b/src/sentry/processing/enrichment_processor.cpp
@@ -1,0 +1,35 @@
+#include "enrichment_processor.h"
+
+#include "sentry/contexts.h"
+
+namespace sentry {
+
+Ref<SentryEvent> EnrichmentProcessor::process_event(const Ref<SentryEvent> &p_event) {
+	Ref<SentryEvent> event = p_event;
+
+	// NOTE: On Cocoa/Android, crash reports are processed after app restart,
+	// so we skip enrichment to avoid attaching stale data from the current session.
+	// Native SDK processes crashes in the same session, so enrichment is safe.
+#if defined(SDK_COCOA) || defined(SDK_ANDROID)
+	constexpr bool enrich_crashes = false;
+#else
+	constexpr bool enrich_crashes = true;
+#endif
+	if (enrich_crashes || !event->is_crash()) {
+		HashMap<String, Dictionary> contexts = sentry::contexts::make_event_contexts();
+		for (const auto &kv : contexts) {
+			event->merge_context(kv.key, kv.value);
+		}
+	}
+
+	// Patch device_type into the device context on Cocoa and Android.
+	// These platform SDKs own the device context but don't include device_type,
+	// so we inject it per-event here. This covers both crash and non-crash events.
+#if defined(SDK_COCOA) || defined(SDK_ANDROID)
+	event->merge_context("device", sentry::contexts::make_device_context_patch());
+#endif
+
+	return event;
+}
+
+} // namespace sentry

--- a/src/sentry/processing/enrichment_processor.h
+++ b/src/sentry/processing/enrichment_processor.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "sentry/processing/sentry_event_processor.h"
+
+namespace sentry {
+
+// Event processor that injects Godot-specific contexts, such as engine and performance info.
+class EnrichmentProcessor : public SentryEventProcessor {
+	GDCLASS(EnrichmentProcessor, SentryEventProcessor);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual Ref<SentryEvent> process_event(const Ref<SentryEvent> &p_event) override;
+};
+
+} // namespace sentry

--- a/src/sentry/processing/process_event.cpp
+++ b/src/sentry/processing/process_event.cpp
@@ -1,6 +1,5 @@
 #include "process_event.h"
 
-#include "sentry/contexts.h"
 #include "sentry/dotnet/csharp_interop.h"
 #include "sentry/logging/print.h"
 #include "sentry/processing/sentry_event_processor.h"
@@ -33,29 +32,6 @@ Ref<SentryEvent> process_event(const Ref<SentryEvent> &p_event) {
 	sentry::logging::print_debug("Processing event ", p_event->get_id());
 
 	Ref<SentryEvent> event = p_event;
-
-	// Inject contexts.
-	// NOTE: On Cocoa/Android, crash reports are processed after app restart,
-	// so we skip enrichment to avoid attaching stale data from the current session.
-	// Native SDK processes crashes in the same session, so enrichment is safe.
-#if defined(SDK_COCOA) || defined(SDK_ANDROID)
-	constexpr bool enrich_crashes = false;
-#else
-	constexpr bool enrich_crashes = true;
-#endif
-	if (enrich_crashes || !p_event->is_crash()) {
-		HashMap<String, Dictionary> contexts = sentry::contexts::make_event_contexts();
-		for (const auto &kv : contexts) {
-			event->merge_context(kv.key, kv.value);
-		}
-	}
-
-	// Patch device_type into the device context on Cocoa and Android.
-	// These platform SDKs own the device context but don't include device_type,
-	// so we inject it per-event here. This covers both crash and non-crash events.
-#if defined(SDK_COCOA) || defined(SDK_ANDROID)
-	event->merge_context("device", sentry::contexts::make_device_context_patch());
-#endif
 
 	// Event processors
 	for (const Ref<SentryEventProcessor> &processor : SENTRY_OPTIONS()->get_event_processors()) {

--- a/src/sentry/processing/process_feedback.cpp
+++ b/src/sentry/processing/process_feedback.cpp
@@ -1,0 +1,56 @@
+#include "process_feedback.h"
+
+#include "sentry/logging/print.h"
+#include "sentry/processing/sentry_event_processor.h"
+#include "sentry/sentry_sdk.h"
+#include "sentry/util/recursion_guard.h"
+
+namespace sentry {
+
+Ref<SentryEvent> process_feedback(const Ref<SentryEvent> &p_event) {
+	static thread_local uint32_t processing_depth = 0;
+	sentry::util::RecursionGuard guard{ &processing_depth };
+	if (!guard.should_proceed()) {
+		// Avoid logger in case it's a triggering path for the cascaded error.
+		sentry::logging::print_no_logger(sentry::LEVEL_WARNING, "Skipping feedback processing for secondary feedback triggered while processing another one. Feedback will still be sent.");
+		return p_event;
+	}
+
+	if (p_event.is_null()) {
+		sentry::logging::print_error("Attempted to process a null feedback event");
+		return nullptr;
+	}
+
+	sentry::logging::print_debug("Processing feedback ", p_event->get_id());
+
+	Ref<SentryEvent> event = p_event;
+
+	for (const Ref<SentryEventProcessor> &processor : SENTRY_OPTIONS()->get_event_processors()) {
+		event = processor->process_event(event);
+		if (event.is_null()) {
+			return event;
+		} else if (event != p_event) {
+			sentry::logging::print_error("Event processor returned a different event object – discarding processor result");
+			event = p_event; // Reset to original event
+		}
+	}
+
+	if (const Callable &before_send_feedback = SENTRY_OPTIONS()->get_before_send_feedback(); before_send_feedback.is_valid()) {
+		event = before_send_feedback.call(event);
+
+		if (event.is_valid() && event != p_event) {
+			ERR_PRINT_ONCE("Sentry: before_send_feedback callback must return the same event object or null.");
+			return p_event;
+		}
+
+		if (event.is_valid()) {
+			sentry::logging::print_debug("before_send_feedback processed ", p_event->get_id());
+		} else {
+			sentry::logging::print_debug("before_send_feedback discarded ", p_event->get_id());
+		}
+	}
+
+	return event;
+}
+
+} // namespace sentry

--- a/src/sentry/processing/process_feedback.h
+++ b/src/sentry/processing/process_feedback.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "sentry/sentry_event.h"
+
+namespace sentry {
+
+// Processes prepared user feedback events by applying configured processors,
+// and running `before_send_feedback` callback before sending to Sentry.
+Ref<SentryEvent> process_feedback(const Ref<SentryEvent> &p_event);
+
+} //namespace sentry

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -402,6 +402,7 @@ void SentryOptions::add_default_attachment(const Ref<SentryAttachment> &p_attach
 
 void SentryOptions::release_callables() {
 	before_send = Callable();
+	before_send_feedback = Callable();
 	before_send_log = Callable();
 	before_send_metric = Callable();
 	before_capture_screenshot = Callable();
@@ -431,6 +432,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "app_hang_timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), set_app_hang_timeout_ms, get_app_hang_timeout_ms);
 
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send"), set_before_send, get_before_send);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_send_feedback"), set_before_send_feedback, get_before_send_feedback);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::CALLABLE, "before_capture_screenshot"), set_before_capture_screenshot, get_before_capture_screenshot);
 
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "experimental", PROPERTY_HINT_TYPE_STRING, "SentryExperimental", PROPERTY_USAGE_NONE), get_experimental);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -136,6 +136,7 @@ private:
 	Ref<SentryGodotLoggerOptions> godot_logger;
 
 	Callable before_send;
+	Callable before_send_feedback;
 	Callable before_capture_screenshot;
 
 	Vector<Ref<SentryEventProcessor>> event_processors;
@@ -224,6 +225,9 @@ public:
 
 	_FORCE_INLINE_ Callable get_before_send() const { return before_send; }
 	_FORCE_INLINE_ void set_before_send(const Callable &p_before_send) { before_send = p_before_send; }
+
+	_FORCE_INLINE_ Callable get_before_send_feedback() const { return before_send_feedback; }
+	_FORCE_INLINE_ void set_before_send_feedback(const Callable &p_before_send_feedback) { before_send_feedback = p_before_send_feedback; }
 
 	_FORCE_INLINE_ Callable get_before_capture_screenshot() const { return before_capture_screenshot; }
 	_FORCE_INLINE_ void set_before_capture_screenshot(const Callable &p_before_capture_screenshot) { before_capture_screenshot = p_before_capture_screenshot; }

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -8,6 +8,7 @@
 #include "sentry/dotnet/dotnet_scope_observer.h"
 #include "sentry/engine_lifecycle/engine_lifecycle.h"
 #include "sentry/logging/print.h"
+#include "sentry/processing/enrichment_processor.h"
 #include "sentry/processing/screenshot_processor.h"
 #include "sentry/processing/view_hierarchy_processor.h"
 #include "sentry/sentry_attachment.h"
@@ -197,6 +198,7 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 	}
 
 	// Add built-in event processors.
+	options->add_event_processor(memnew(EnrichmentProcessor));
 	if (options->is_attach_screenshot_enabled()) {
 		options->add_event_processor(memnew(ScreenshotProcessor));
 	}
@@ -215,6 +217,10 @@ void SentrySDK::init(const Callable &p_configuration_callback) {
 	}
 
 	_invalidate_scopes();
+
+	if (unlikely(options->get_before_send_feedback().is_valid() && !internal_sdk->supports_before_send_feedback())) {
+		WARN_PRINT_ONCE("Sentry: before_send_feedback is not supported on this platform yet - the callback will not run.");
+	}
 
 	sentry::logging::print_debug("Initializing Sentry SDK");
 	internal_sdk->init();


### PR DESCRIPTION
User feedback never reached `before_send`, so GDScript had no way to filter or enrich it. This PR adds a `before_send_feedback` hook that runs on the prepared feedback event, after scope data has been applied, with the submitted message, name, email, and associated event id carried in the event's `feedback` context. Returning null discards the feedback. Feedback also runs the same enrichment as events now, which is how the other Sentry SDKs treat it. iOS and macOS are the exception: sentry-cocoa exposes no hook to wire this to, so the callback never runs there and the SDK warns at init if you set one.