### PR TITLE
feat(feedback): Feedback form capture order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Improvements
 
 - Deprecate the `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options and their Project Settings counterparts, to be removed in v3; logs and metrics are only sent when you use `SentrySDK.logger` or `SentrySDK.metrics`, or enable automatic log capture with `godot_logger.log_mask` ([#869](https://github.com/getsentry/sentry-godot/pull/869))
+- The bundled user feedback form now waits a frame for the UI to hide before capturing, so a screenshot attached to the feedback shows the game instead of the form and the text typed into it ([#880](https://github.com/getsentry/sentry-godot/pull/880))
 
 ### Fixes
 

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -42,11 +42,11 @@
 			<param index="0" name="feedback" type="SentryFeedback" />
 			<description>
 				Captures user [param feedback] and sends it to Sentry. The feedback can optionally be associated with a specific error event if the [member SentryFeedback.associated_event_id] is set.
-				[b]Note:[/b] If your game collects feedback with an in-game form, hide the form and wait for a frame to be drawn before calling this method. A screenshot attached to the feedback (see [member SentryOptions.attach_screenshot]) then shows the game rather than the form and the text typed into it.
+				[b]Note:[/b] If your game collects feedback with an in-game form, capture on the next drawn frame so the form can be hidden or freed first. A screenshot attached to the feedback (see [member SentryOptions.attach_screenshot]) then shows the game rather than the form and the text typed into it.
 				[codeblock]
+				RenderingServer.frame_post_draw.connect(
+						SentrySDK.capture_feedback.bind(feedback), CONNECT_ONE_SHOT)
 				_feedback_form.hide()
-				await RenderingServer.frame_post_draw
-				SentrySDK.capture_feedback(feedback)
 				[/codeblock]
 				For more information, see [SentryFeedback] class and visit [url=https://docs.sentry.io/platforms/godot/user-feedback/]User Feedback documentation[/url].
 			</description>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -42,6 +42,12 @@
 			<param index="0" name="feedback" type="SentryFeedback" />
 			<description>
 				Captures user [param feedback] and sends it to Sentry. The feedback can optionally be associated with a specific error event if the [member SentryFeedback.associated_event_id] is set.
+				[b]Note:[/b] If your game collects feedback with an in-game form, hide the form and wait for a frame to be drawn before calling this method. A screenshot attached to the feedback (see [member SentryOptions.attach_screenshot]) then shows the game rather than the form and the text typed into it.
+				[codeblock]
+				_feedback_form.hide()
+				await RenderingServer.frame_post_draw
+				SentrySDK.capture_feedback(feedback)
+				[/codeblock]
 				For more information, see [SentryFeedback] class and visit [url=https://docs.sentry.io/platforms/godot/user-feedback/]User Feedback documentation[/url].
 			</description>
 		</method>

--- a/project/addons/sentry/user_feedback/user_feedback_form.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_form.gd
@@ -16,14 +16,10 @@ extends PanelContainer
 ## - sentry_theme.tres: Reference UI theme file.
 
 
-## Emitted when the user clicks the "Submit" button, right before the feedback is captured.
-## Hide the form in response, and don't free it yet: the feedback is captured a frame later, so
-## that a screenshot attached to it shows the game instead of the form and the text typed into it.
+## Emitted when the user clicks the "Submit" button, right after feedback is queued for capture.
+## Hide or free the form in response. Feedback is captured on the next drawn frame so the
+## attached screenshot shows the game without the form or any text entered into it.
 signal feedback_submitted(feedback: SentryFeedback)
-
-## Emitted after the feedback is handed over to the SDK, a frame after [signal feedback_submitted].
-## The form is safe to free at this point.
-signal feedback_captured(feedback: SentryFeedback)
 
 ## Emitted when feedback is cancelled after the user clicks the "Cancel" button.
 signal feedback_cancelled()
@@ -78,15 +74,11 @@ func _on_submit_button_pressed() -> void:
 	# Reset feedback message
 	_message_edit.text = ""
 
+	# Capture on the next drawn frame so the UI can be hidden or freed first.
+	# This keeps the form and typed message out of the feedback screenshot.
+	RenderingServer.frame_post_draw.connect(SentrySDK.capture_feedback.bind(feedback), CONNECT_ONE_SHOT)
+
 	feedback_submitted.emit(feedback)
-
-	# Wait one frame after emitting feedback_submitted so the UI can be hidden.
-	# This prevents the feedback form and typed message from appearing in the attached screenshot.
-	await RenderingServer.frame_post_draw
-
-	SentrySDK.capture_feedback(feedback)
-
-	feedback_captured.emit(feedback)
 
 
 func _on_message_edit_text_changed() -> void:

--- a/project/addons/sentry/user_feedback/user_feedback_form.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_form.gd
@@ -76,7 +76,8 @@ func _on_submit_button_pressed() -> void:
 
 	# Capture on the next drawn frame so the UI can be hidden or freed first.
 	# This keeps the form and typed message out of the feedback screenshot.
-	RenderingServer.frame_post_draw.connect(SentrySDK.capture_feedback.bind(feedback), CONNECT_ONE_SHOT)
+	RenderingServer.frame_post_draw.connect(
+		SentrySDK.capture_feedback.bind(feedback), CONNECT_ONE_SHOT)
 
 	feedback_submitted.emit(feedback)
 

--- a/project/addons/sentry/user_feedback/user_feedback_form.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_form.gd
@@ -16,8 +16,15 @@ extends PanelContainer
 ## - sentry_theme.tres: Reference UI theme file.
 
 
-## Emitted when feedback is successfully submitted after the user clicks the "Submit" button.
+## Emitted when the user clicks the "Submit" button, right before the feedback is captured.
+## Hide the form in response, and don't free it yet: the feedback is captured a frame later, so
+## that a screenshot attached to it shows the game instead of the form and the text typed into it.
 signal feedback_submitted(feedback: SentryFeedback)
+
+## Emitted after the feedback is handed over to the SDK, a frame after [signal feedback_submitted].
+## The form is safe to free at this point.
+signal feedback_captured(feedback: SentryFeedback)
+
 ## Emitted when feedback is cancelled after the user clicks the "Cancel" button.
 signal feedback_cancelled()
 
@@ -68,12 +75,18 @@ func _on_submit_button_pressed() -> void:
 	feedback.name = _name_edit.text
 	feedback.contact_email = _email_edit.text
 
-	SentrySDK.capture_feedback(feedback)
+	# Reset feedback message
+	_message_edit.text = ""
 
 	feedback_submitted.emit(feedback)
 
-	# Reset feedback message
-	_message_edit.text = ""
+	# Wait one frame after emitting feedback_submitted so the UI can be hidden.
+	# This prevents the feedback form and typed message from appearing in the attached screenshot.
+	await RenderingServer.frame_post_draw
+
+	SentrySDK.capture_feedback(feedback)
+
+	feedback_captured.emit(feedback)
 
 
 func _on_message_edit_text_changed() -> void:

--- a/project/addons/sentry/user_feedback/user_feedback_form.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_form.gd
@@ -65,14 +65,18 @@ func _update_controls() -> void:
 		%NameSection.visible = name_visible
 
 
+func _reset_form() -> void:
+	_message_edit.text = ""
+	_on_message_edit_text_changed()
+
+
 func _on_submit_button_pressed() -> void:
 	var feedback := SentryFeedback.new()
 	feedback.message = _message_edit.text
 	feedback.name = _name_edit.text
 	feedback.contact_email = _email_edit.text
 
-	# Reset feedback message
-	_message_edit.text = ""
+	_reset_form()
 
 	# Capture on the next drawn frame so the UI can be hidden or freed first.
 	# This keeps the form and typed message out of the feedback screenshot.

--- a/project/addons/sentry/user_feedback/user_feedback_gui.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_gui.gd
@@ -117,7 +117,6 @@ func _resize_children() -> void:
 
 
 func _on_user_feedback_form_feedback_submitted(feedback: SentryFeedback) -> void:
-	# Hide instead of freeing: the form captures the feedback a frame later.
 	hide()
 
 

--- a/project/addons/sentry/user_feedback/user_feedback_gui.gd
+++ b/project/addons/sentry/user_feedback/user_feedback_gui.gd
@@ -117,6 +117,7 @@ func _resize_children() -> void:
 
 
 func _on_user_feedback_form_feedback_submitted(feedback: SentryFeedback) -> void:
+	# Hide instead of freeing: the form captures the feedback a frame later.
 	hide()
 
 


### PR DESCRIPTION
Now that attachments are sent with user feedback, a screenshot goes out with it, and the user feedback form was capturing while it was still on screen: the screenshot showed the form and whatever the user had typed into it. In this PR, the form emits `feedback_submitted` first, waits for the next frame to be drawn so the GUI can hide, and captures after that. `SentrySDK.capture_feedback` documents the same order for custom forms.
