### PR TITLE
[WIP] feat(feedback): Add SentryEvent.get_feedback()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 - Add the `SentryOptions.before_send_feedback` callback to filter or enrich user feedback before it is sent ([#878](https://github.com/getsentry/sentry-godot/pull/878))
   - Not supported on macOS and iOS yet, where feedback is still sent but the callback never runs
+- Add `SentryEvent.get_feedback()` to inspect and modify submitted user feedback ([#883](https://github.com/getsentry/sentry-godot/pull/883))
 
 ### Improvements
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -56,6 +56,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         }
     }
 
+    private val feedbacksByHandle = object : ThreadLocal<MutableMap<Int, Feedback>>() {
+        override fun initialValue(): MutableMap<Int, Feedback> {
+            return mutableMapOf()
+        }
+    }
+
     private val breadcrumbsByHandle = object : ThreadLocal<MutableMap<Int, Breadcrumb>>() {
         override fun initialValue(): MutableMap<Int, Breadcrumb> {
             return mutableMapOf()
@@ -92,6 +98,14 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             Log.e(TAG, "Internal Error -- SentryEvent not found: $eventHandle")
         }
         return event
+    }
+
+    private fun getFeedback(feedbackHandle: Int): Feedback? {
+        val feedback: Feedback? = feedbacksByHandle.get()?.get(feedbackHandle)
+        if (feedback == null) {
+            Log.e(TAG, "Internal Error -- Feedback not found: $feedbackHandle")
+        }
+        return feedback
     }
 
     private fun getBreadcrumb(breadcrumbHandle: Int): Breadcrumb? {
@@ -164,6 +178,21 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         }
 
         eventsMap[handle] = event
+        return handle
+    }
+
+    private fun registerFeedback(feedback: Feedback): Int {
+        val feedbacksMap = feedbacksByHandle.get() ?: run {
+            Log.e(TAG, "Internal Error -- feedbacksByHandle is null")
+            return 0
+        }
+
+        var handle = Random.nextInt()
+        while (handle == 0 || feedbacksMap.containsKey(handle)) {
+            handle = Random.nextInt()
+        }
+
+        feedbacksMap[handle] = feedback
         return handle
     }
 
@@ -514,7 +543,13 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureFeedback(scopeHandle: Int, message: String, contactEmail: String, name: String, associatedEventId: String) {
+    fun captureFeedback(
+        scopeHandle: Int,
+        message: String,
+        contactEmail: String,
+        name: String,
+        associatedEventId: String
+    ) {
         val feedback = Feedback(message)
         feedback.contactEmail = contactEmail.ifEmpty { null }
         feedback.name = name.ifEmpty { null }
@@ -695,6 +730,12 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
+    fun eventGetFeedback(eventHandle: Int): Int {
+        val feedback: Feedback = getEvent(eventHandle)?.contexts?.feedback ?: return 0
+        return registerFeedback(feedback)
+    }
+
+    @UsedByGodot
     fun eventIsCrash(eventHandle: Int): Boolean {
         return getEvent(eventHandle)?.isCrashed == true
     }
@@ -781,6 +822,55 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     @UsedByGodot
     fun eventGetExceptionValue(eventHandle: Int, index: Int): String {
         return getEvent(eventHandle)?.exceptions?.getOrNull(index)?.value ?: ""
+    }
+
+    @UsedByGodot
+    fun releaseFeedback(handle: Int) {
+        feedbacksByHandle.get()?.remove(handle)
+    }
+
+    @UsedByGodot
+    fun feedbackSetMessage(handle: Int, message: String) {
+        getFeedback(handle)?.message = message
+    }
+
+    @UsedByGodot
+    fun feedbackGetMessage(handle: Int): String {
+        return getFeedback(handle)?.message ?: ""
+    }
+
+    @UsedByGodot
+    fun feedbackSetContactEmail(handle: Int, contactEmail: String) {
+        getFeedback(handle)?.contactEmail = contactEmail.ifEmpty { null }
+    }
+
+    @UsedByGodot
+    fun feedbackGetContactEmail(handle: Int): String {
+        return getFeedback(handle)?.contactEmail ?: ""
+    }
+
+    @UsedByGodot
+    fun feedbackSetName(handle: Int, name: String) {
+        getFeedback(handle)?.name = name.ifEmpty { null }
+    }
+
+    @UsedByGodot
+    fun feedbackGetName(handle: Int): String {
+        return getFeedback(handle)?.name ?: ""
+    }
+
+    @UsedByGodot
+    fun feedbackSetAssociatedEventId(handle: Int, associatedEventId: String) {
+        // sentry-java takes a non-null SentryId here, so the id can be replaced but not cleared.
+        if (associatedEventId.isEmpty()) {
+            return
+        }
+        getFeedback(handle)?.setAssociatedEventId(SentryId(associatedEventId))
+    }
+
+    @UsedByGodot
+    fun feedbackGetAssociatedEventId(handle: Int): String {
+        return getFeedback(handle)?.associatedEventId?.toString() ?: ""
     }
 
     @UsedByGodot

--- a/doc_classes/SentryEvent.xml
+++ b/doc_classes/SentryEvent.xml
@@ -22,6 +22,20 @@
 				Returns the exception value (error message) at the specified [param index], or an empty string if [param index] is out of bounds.
 			</description>
 		</method>
+		<method name="get_feedback" qualifiers="const">
+			<return type="SentryFeedback" />
+			<description>
+				Returns the user feedback attached to this event, or [code]null[/code] if there is none. Changes made to the returned object are applied to the event itself, which allows a [member SentryOptions.before_send_feedback] callback to scrub user-submitted feedback before it is sent.
+				[codeblock]
+				func _before_send_feedback(event: SentryEvent) -&gt; SentryEvent:
+					var feedback := event.get_feedback()
+					if feedback != null:
+						# Scrub or modify the feedback before sending.
+						feedback.contact_email = "redacted@example.com"
+					return event
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_tag">
 			<return type="String" />
 			<param index="0" name="key" type="String" />

--- a/doc_classes/SentryFeedback.xml
+++ b/doc_classes/SentryFeedback.xml
@@ -5,6 +5,13 @@
 	</brief_description>
 	<description>
 		[SentryFeedback] allows you to collect and send user feedback to Sentry. Create an instance of this class, set the required [member message] and optional fields, then submit it using [method SentrySDK.capture_feedback].
+		[codeblock]
+		var feedback := SentryFeedback.new()
+		feedback.message = "The boss fight ends before it starts"
+		feedback.contact_email = "player@example.com"
+		SentrySDK.capture_feedback(feedback)
+		[/codeblock]
+		[SentryFeedback] can also represent feedback attached to an event, as returned by [method SentryEvent.get_feedback]. Writing to this object updates the feedback stored on the event itself. This is useful in a [member SentryOptions.before_send_feedback] callback for scrubbing or modifying user-submitted feedback before it is sent. The returned object is only valid for the duration of the callback, because the event is sent as soon as the callback returns.
 		To learn more, visit [url=https://docs.sentry.io/platforms/godot/user-feedback/]User Feedback[/url] documentation.
 	</description>
 	<tutorials>
@@ -13,6 +20,7 @@
 		<member name="associated_event_id" type="String" setter="set_associated_event_id" getter="get_associated_event_id" default="&quot;&quot;">
 			The identifier of an error event in the same project. [i]Optional[/i].
 			Use this to explicitly link a related error in the feedback UI.
+			[b]Note:[/b] On Android, for an object returned by [method SentryEvent.get_feedback], assigning an empty string leaves this field unchanged. On other platforms, it clears the field.
 		</member>
 		<member name="contact_email" type="String" setter="set_contact_email" getter="get_contact_email" default="&quot;&quot;">
 			The email of the user who submitted the feedback. [i]Optional[/i].

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -59,7 +59,7 @@
 			To learn more, visit [url=https://docs.sentry.io/platforms/godot/configuration/filtering/]Filtering documentation[/url]. Also, check out [url=https://docs.sentry.io/platforms/godot/data-management/sensitive-data/]Scrubbing Sensitive Data[/url].
 		</member>
 		<member name="before_send_feedback" type="Callable" setter="set_before_send_feedback" getter="get_before_send_feedback" default="Callable()">
-			If assigned, this callback runs before user feedback is sent to Sentry. It takes [SentryEvent] as a parameter and returns either the same event object, with or without modifications, or [code]null[/code] to skip reporting the feedback. You can assign it in a configuration callback using manual initialization (see [method SentrySDK.init]). The fields submitted with the [SentryFeedback] object are carried in the event's [code]feedback[/code] context.
+			If assigned, this callback runs before user feedback is sent to Sentry. It takes [SentryEvent] as a parameter and returns either the same event object, with or without modifications, or [code]null[/code] to skip reporting the feedback. You can assign it in a configuration callback using manual initialization (see [method SentrySDK.init]). Call [method SentryEvent.get_feedback] on the event to read or modify the fields the user submitted.
 			[codeblock]
 			func _before_send_feedback(event: SentryEvent) -&gt; SentryEvent:
 			    if event.environment == "editor_dev_run":

--- a/project/test/isolated/test_before_send_feedback.gd
+++ b/project/test/isolated/test_before_send_feedback.gd
@@ -92,6 +92,56 @@ func test_callback_can_modify_the_event() -> void:
 		.verify()
 
 
+func test_callback_reads_the_submitted_fields() -> void:
+	var seen := {}
+	before_send_feedback = func(event: SentryEvent) -> SentryEvent:
+		var submitted := event.get_feedback()
+		seen["message"] = submitted.message
+		seen["name"] = submitted.name
+		seen["contact_email"] = submitted.contact_email
+		seen["associated_event_id"] = submitted.associated_event_id
+		return _default_before_send_feedback(event)
+
+	var feedback := SentryFeedback.new()
+	feedback.message = "The elevator eats my keys 🔑"
+	feedback.name = "Alice"
+	feedback.contact_email = "alice@example.com"
+	feedback.associated_event_id = "3c9f2b1ae5d4487fa1b0d5c6e7f80912"
+
+	SentrySDK.capture_feedback(feedback)
+	await wait_for_captured_feedback_json()
+
+	assert_str(seen["message"]).is_equal("The elevator eats my keys 🔑")
+	assert_str(seen["name"]).is_equal("Alice")
+	assert_str(seen["contact_email"]).is_equal("alice@example.com")
+	assert_str(seen["associated_event_id"]).is_equal("3c9f2b1ae5d4487fa1b0d5c6e7f80912")
+
+
+func test_callback_can_scrub_the_feedback() -> void:
+	before_send_feedback = func(event: SentryEvent) -> SentryEvent:
+		var submitted := event.get_feedback()
+		submitted.message = "[redacted]"
+		submitted.name = "Anonymous"
+		submitted.contact_email = ""
+		return _default_before_send_feedback(event)
+
+	var feedback := SentryFeedback.new()
+	feedback.message = "My password is hunter2"
+	feedback.name = "Bob"
+	feedback.contact_email = "bob@example.com"
+
+	SentrySDK.capture_feedback(feedback)
+	var json: String = await wait_for_captured_feedback_json()
+
+	assert_json(json).describe("fields rewritten in the callback reach the event") \
+		.at("/contexts/feedback") \
+		.is_object() \
+		.must_contain("message", "[redacted]") \
+		.must_contain("name", "Anonymous") \
+		.must_not_contain("contact_email") \
+		.verify()
+
+
 func test_feedback_does_not_reach_before_send() -> void:
 	var feedback := SentryFeedback.new()
 	feedback.message = "Feedback stays out of before_send"

--- a/src/sentry/android/android_event.cpp
+++ b/src/sentry/android/android_event.cpp
@@ -1,5 +1,6 @@
 #include "android_event.h"
 
+#include "android_feedback.h"
 #include "android_string_names.h"
 #include "android_util.h"
 #include "sentry/logging/print.h"
@@ -136,6 +137,16 @@ void AndroidEvent::merge_context(const String &p_key, const Dictionary &p_value)
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't merge context with an empty key.");
 	android_plugin->call(ANDROID_SN(eventMergeContext),
 			event_handle, p_key, sanitize_variant(p_value));
+}
+
+Ref<SentryFeedback> AndroidEvent::get_feedback() const {
+	ERR_FAIL_NULL_V(android_plugin, Ref<SentryFeedback>());
+	int32_t feedback_handle = android_plugin->call(ANDROID_SN(eventGetFeedback), event_handle);
+	if (feedback_handle == 0) {
+		return Ref<SentryFeedback>();
+	}
+	AndroidFeedback *impl = memnew(AndroidFeedback(android_plugin, feedback_handle));
+	return Ref<SentryFeedback>(memnew(SentryFeedback(impl)));
 }
 
 void AndroidEvent::add_exception(const Exception &p_exception) {

--- a/src/sentry/android/android_event.h
+++ b/src/sentry/android/android_event.h
@@ -57,6 +57,8 @@ public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
+	virtual Ref<SentryFeedback> get_feedback() const override;
+
 	virtual void add_exception(const Exception &p_exception) override;
 
 	virtual int get_exception_count() const override;

--- a/src/sentry/android/android_feedback.cpp
+++ b/src/sentry/android/android_feedback.cpp
@@ -1,0 +1,60 @@
+#include "android_feedback.h"
+
+#include "android_string_names.h"
+
+#include <godot_cpp/core/error_macros.hpp>
+
+namespace sentry::android {
+
+void AndroidFeedback::set_name(const String &p_name) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(feedbackSetName), handle, p_name);
+}
+
+String AndroidFeedback::get_name() const {
+	ERR_FAIL_NULL_V(android_plugin, String());
+	return android_plugin->call(ANDROID_SN(feedbackGetName), handle);
+}
+
+void AndroidFeedback::set_contact_email(const String &p_contact_email) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(feedbackSetContactEmail), handle, p_contact_email);
+}
+
+String AndroidFeedback::get_contact_email() const {
+	ERR_FAIL_NULL_V(android_plugin, String());
+	return android_plugin->call(ANDROID_SN(feedbackGetContactEmail), handle);
+}
+
+void AndroidFeedback::set_message(const String &p_message) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(feedbackSetMessage), handle, p_message);
+}
+
+String AndroidFeedback::get_message() const {
+	ERR_FAIL_NULL_V(android_plugin, String());
+	return android_plugin->call(ANDROID_SN(feedbackGetMessage), handle);
+}
+
+void AndroidFeedback::set_associated_event_id(const String &p_associated_event_id) {
+	ERR_FAIL_NULL(android_plugin);
+	android_plugin->call(ANDROID_SN(feedbackSetAssociatedEventId), handle, p_associated_event_id);
+}
+
+String AndroidFeedback::get_associated_event_id() const {
+	ERR_FAIL_NULL_V(android_plugin, String());
+	return android_plugin->call(ANDROID_SN(feedbackGetAssociatedEventId), handle);
+}
+
+AndroidFeedback::AndroidFeedback(Object *p_android_plugin, int32_t p_feedback_handle) :
+		android_plugin(p_android_plugin), handle(p_feedback_handle) {
+	ERR_FAIL_NULL(p_android_plugin);
+}
+
+AndroidFeedback::~AndroidFeedback() {
+	if (android_plugin) {
+		android_plugin->call(ANDROID_SN(releaseFeedback), handle);
+	}
+}
+
+} //namespace sentry::android

--- a/src/sentry/android/android_feedback.h
+++ b/src/sentry/android/android_feedback.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "sentry/sentry_feedback_impl.h"
+
+#include <godot_cpp/classes/object.hpp>
+
+using namespace godot;
+
+namespace sentry::android {
+
+class AndroidFeedback : public SentryFeedbackImpl {
+	SENTRY_CASTABLE(AndroidFeedback, SentryFeedbackImpl);
+
+private:
+	Object *android_plugin = nullptr;
+	int32_t handle = 0;
+
+public:
+	virtual void set_name(const String &p_name) override;
+	virtual String get_name() const override;
+
+	virtual void set_contact_email(const String &p_contact_email) override;
+	virtual String get_contact_email() const override;
+
+	virtual void set_message(const String &p_message) override;
+	virtual String get_message() const override;
+
+	virtual void set_associated_event_id(const String &p_associated_event_id) override;
+	virtual String get_associated_event_id() const override;
+
+	AndroidFeedback(Object *p_android_plugin, int32_t p_feedback_handle);
+	virtual ~AndroidFeedback() override;
+};
+
+} //namespace sentry::android

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -62,6 +62,7 @@ AndroidStringNames::AndroidStringNames() {
 	eventSetFingerprint = StringName("eventSetFingerprint");
 	eventSetContext = StringName("eventSetContext");
 	eventMergeContext = StringName("eventMergeContext");
+	eventGetFeedback = StringName("eventGetFeedback");
 	eventIsCrash = StringName("eventIsCrash");
 	eventToJson = StringName("eventToJson");
 
@@ -71,6 +72,17 @@ AndroidStringNames::AndroidStringNames() {
 	eventSetExceptionValue = StringName("eventSetExceptionValue");
 	eventGetExceptionValue = StringName("eventGetExceptionValue");
 	eventAddThreadStackTrace = StringName("eventAddThreadStackTrace");
+
+	// Feedback.
+	releaseFeedback = StringName("releaseFeedback");
+	feedbackSetMessage = StringName("feedbackSetMessage");
+	feedbackGetMessage = StringName("feedbackGetMessage");
+	feedbackSetContactEmail = StringName("feedbackSetContactEmail");
+	feedbackGetContactEmail = StringName("feedbackGetContactEmail");
+	feedbackSetName = StringName("feedbackSetName");
+	feedbackGetName = StringName("feedbackGetName");
+	feedbackSetAssociatedEventId = StringName("feedbackSetAssociatedEventId");
+	feedbackGetAssociatedEventId = StringName("feedbackGetAssociatedEventId");
 
 	// Breadcrumbs.
 	createBreadcrumb = StringName("createBreadcrumb");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -73,6 +73,7 @@ public:
 	StringName eventSetFingerprint;
 	StringName eventSetContext;
 	StringName eventMergeContext;
+	StringName eventGetFeedback;
 	StringName eventIsCrash;
 	StringName eventToJson;
 
@@ -82,6 +83,17 @@ public:
 	StringName eventSetExceptionValue;
 	StringName eventGetExceptionValue;
 	StringName eventAddThreadStackTrace;
+
+	// Feedback.
+	StringName releaseFeedback;
+	StringName feedbackSetMessage;
+	StringName feedbackGetMessage;
+	StringName feedbackSetContactEmail;
+	StringName feedbackGetContactEmail;
+	StringName feedbackSetName;
+	StringName feedbackGetName;
+	StringName feedbackSetAssociatedEventId;
+	StringName feedbackGetAssociatedEventId;
 
 	// Breadcrumbs.
 	StringName createBreadcrumb;

--- a/src/sentry/cocoa/cocoa_event.h
+++ b/src/sentry/cocoa/cocoa_event.h
@@ -53,6 +53,8 @@ public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
+	virtual Ref<SentryFeedback> get_feedback() const override;
+
 	virtual void add_exception(const Exception &p_exception) override;
 
 	virtual int get_exception_count() const override;

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -226,6 +226,12 @@ void CocoaEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	cocoa_event.context = mut_contexts;
 }
 
+Ref<SentryFeedback> CocoaEvent::get_feedback() const {
+	// sentry-cocoa doesn't export before-send-feedback, so feedback is never
+	// handed to user code through an event on this platform.
+	return Ref<SentryFeedback>();
+}
+
 void CocoaEvent::add_exception(const Exception &p_exception) {
 	ERR_FAIL_NULL(cocoa_event);
 

--- a/src/sentry/disabled/disabled_event.h
+++ b/src/sentry/disabled/disabled_event.h
@@ -57,6 +57,8 @@ public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override {}
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override {}
 
+	virtual Ref<SentryFeedback> get_feedback() const override { return Ref<SentryFeedback>(); }
+
 	virtual void add_exception(const Exception &p_exception) override {}
 
 	virtual int get_exception_count() const override { return 0; }

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -346,6 +346,10 @@ class SentryBridge {
     event.user = makeUser(id, username, email, ip);
   }
 
+  public eventGetFeedback(event: Sentry.Event): Record<string, unknown> | null {
+    return event.contexts?.feedback ?? null;
+  }
+
   public createScope(): Sentry.Scope {
     const scope = new Sentry.Scope();
     scope.setClient(Sentry.getClient());

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -55,6 +55,7 @@ try {
 			"setUser",
 			"removeUser",
 			"eventSetUser",
+			"eventGetFeedback",
 			"createScope",
 			"scopeSetContext",
 			"scopeSetFingerprint",
@@ -356,6 +357,16 @@ try {
 			assertEqual(seen.contexts.feedback.contact_email, "test@example.com", "the callback should see the submitted email");
 			const scoped = bridge.captureFeedback("Test feedback", "", "", "", bridge.createScope());
 			assertEqual(typeof scoped, "string", "Scoped captureFeedback should return a string");
+		});
+
+		runTest("eventGetFeedback()", () => {
+			const feedbackEvent = feedbackEvents[feedbackEvents.length - 1];
+			const feedback = bridge.eventGetFeedback(feedbackEvent);
+			assert(feedback !== null, "eventGetFeedback should return the feedback context of a feedback event");
+			assertEqual(feedback.message, "Test feedback", "eventGetFeedback should return the submitted message");
+			feedback.message = "Rewritten feedback";
+			assertEqual(feedbackEvent.contexts.feedback.message, "Rewritten feedback", "writes through the returned object should reach the event");
+			assertEqual(bridge.eventGetFeedback({}), null, "eventGetFeedback should return null for an event carrying no feedback");
 		});
 
 		runTest("storeBytes() / takeBytes()", () => {

--- a/src/sentry/javascript/javascript_event.cpp
+++ b/src/sentry/javascript/javascript_event.cpp
@@ -1,5 +1,6 @@
 #include "javascript_event.h"
 
+#include "sentry/javascript/javascript_feedback.h"
 #include "sentry/util/json_writer.h"
 #include "sentry/uuid.h"
 
@@ -229,6 +230,16 @@ void JavaScriptEvent::merge_context(const String &p_key, const Dictionary &p_val
 			context_jso->merge_properties_from_json(JSON::stringify(p_value).utf8());
 		}
 	}
+}
+
+Ref<SentryFeedback> JavaScriptEvent::get_feedback() const {
+	ERR_FAIL_COND_V(!js_obj, Ref<SentryFeedback>());
+	JSObjectPtr feedback_jso = js_bridge()->call("eventGetFeedback", js_obj).as_object();
+	if (!feedback_jso) {
+		return Ref<SentryFeedback>();
+	}
+	JavaScriptFeedback *impl = memnew(JavaScriptFeedback(feedback_jso));
+	return Ref<SentryFeedback>(memnew(SentryFeedback(impl)));
 }
 
 void JavaScriptEvent::add_exception(const Exception &p_exception) {

--- a/src/sentry/javascript/javascript_event.h
+++ b/src/sentry/javascript/javascript_event.h
@@ -57,6 +57,8 @@ public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
+	virtual Ref<SentryFeedback> get_feedback() const override;
+
 	virtual void add_exception(const Exception &p_exception) override;
 
 	virtual int get_exception_count() const override;

--- a/src/sentry/javascript/javascript_feedback.cpp
+++ b/src/sentry/javascript/javascript_feedback.cpp
@@ -1,0 +1,41 @@
+#include "javascript_feedback.h"
+
+namespace sentry::javascript {
+
+void JavaScriptFeedback::set_name(const String &p_name) {
+	js_obj->set_or_remove_string_property("name", p_name.utf8());
+}
+
+String JavaScriptFeedback::get_name() const {
+	return js_obj->get("name").as_string();
+}
+
+void JavaScriptFeedback::set_contact_email(const String &p_contact_email) {
+	js_obj->set_or_remove_string_property("contact_email", p_contact_email.utf8());
+}
+
+String JavaScriptFeedback::get_contact_email() const {
+	return js_obj->get("contact_email").as_string();
+}
+
+void JavaScriptFeedback::set_message(const String &p_message) {
+	js_obj->set("message", p_message.utf8());
+}
+
+String JavaScriptFeedback::get_message() const {
+	return js_obj->get("message").as_string();
+}
+
+void JavaScriptFeedback::set_associated_event_id(const String &p_associated_event_id) {
+	js_obj->set_or_remove_string_property("associated_event_id", p_associated_event_id.utf8());
+}
+
+String JavaScriptFeedback::get_associated_event_id() const {
+	return js_obj->get("associated_event_id").as_string();
+}
+
+JavaScriptFeedback::JavaScriptFeedback(const JSObjectPtr &p_js_feedback_object) :
+		js_obj(p_js_feedback_object) {
+}
+
+} //namespace sentry::javascript

--- a/src/sentry/javascript/javascript_feedback.h
+++ b/src/sentry/javascript/javascript_feedback.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "sentry/javascript/javascript_interop.h"
+#include "sentry/sentry_feedback_impl.h"
+
+namespace sentry::javascript {
+
+// Backed by the JS feedback context object of an event, which is guaranteed to be valid.
+class JavaScriptFeedback : public SentryFeedbackImpl {
+	SENTRY_CASTABLE(JavaScriptFeedback, SentryFeedbackImpl);
+
+private:
+	JSObjectPtr js_obj;
+
+public:
+	virtual void set_name(const String &p_name) override;
+	virtual String get_name() const override;
+
+	virtual void set_contact_email(const String &p_contact_email) override;
+	virtual String get_contact_email() const override;
+
+	virtual void set_message(const String &p_message) override;
+	virtual String get_message() const override;
+
+	virtual void set_associated_event_id(const String &p_associated_event_id) override;
+	virtual String get_associated_event_id() const override;
+
+	JavaScriptFeedback(const JSObjectPtr &p_js_feedback_object);
+};
+
+} //namespace sentry::javascript

--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -1,6 +1,7 @@
 #include "native_event.h"
 
 #include "sentry/level.h"
+#include "sentry/native/native_feedback.h"
 #include "sentry/native/native_util.h"
 
 #include <sentry.h>
@@ -222,6 +223,16 @@ void NativeEvent::set_context(const String &p_key, const Dictionary &p_value) {
 void NativeEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't merge context with an empty key.");
 	sentry_event_merge_context(native_event, p_key.utf8(), p_value);
+}
+
+Ref<SentryFeedback> NativeEvent::get_feedback() const {
+	sentry_value_t contexts = sentry_value_get_by_key(native_event, "contexts");
+	sentry_value_t feedback = sentry_value_get_by_key(contexts, "feedback");
+	if (sentry_value_get_type(feedback) != SENTRY_VALUE_TYPE_OBJECT) {
+		return Ref<SentryFeedback>();
+	}
+	NativeFeedback *impl = memnew(NativeFeedback(feedback));
+	return Ref<SentryFeedback>(memnew(SentryFeedback(impl)));
 }
 
 void NativeEvent::add_exception(const Exception &p_exception) {

--- a/src/sentry/native/native_event.h
+++ b/src/sentry/native/native_event.h
@@ -56,6 +56,8 @@ public:
 	virtual void set_context(const String &p_key, const Dictionary &p_value) override;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) override;
 
+	virtual Ref<SentryFeedback> get_feedback() const override;
+
 	virtual void add_exception(const Exception &p_exception) override;
 
 	virtual int get_exception_count() const override;

--- a/src/sentry/native/native_feedback.cpp
+++ b/src/sentry/native/native_feedback.cpp
@@ -1,0 +1,52 @@
+#include "native_feedback.h"
+
+#include "sentry/native/native_util.h"
+
+namespace sentry::native {
+
+void NativeFeedback::set_name(const String &p_name) {
+	sentry_value_set_or_remove_string_by_key(native_feedback, "name", p_name);
+}
+
+String NativeFeedback::get_name() const {
+	sentry_value_t name = sentry_value_get_by_key(native_feedback, "name");
+	return String::utf8(sentry_value_as_string(name));
+}
+
+void NativeFeedback::set_contact_email(const String &p_contact_email) {
+	sentry_value_set_or_remove_string_by_key(native_feedback, "contact_email", p_contact_email);
+}
+
+String NativeFeedback::get_contact_email() const {
+	sentry_value_t contact_email = sentry_value_get_by_key(native_feedback, "contact_email");
+	return String::utf8(sentry_value_as_string(contact_email));
+}
+
+void NativeFeedback::set_message(const String &p_message) {
+	sentry_value_set_by_key(native_feedback, "message", sentry_value_new_string(p_message.utf8()));
+}
+
+String NativeFeedback::get_message() const {
+	sentry_value_t message = sentry_value_get_by_key(native_feedback, "message");
+	return String::utf8(sentry_value_as_string(message));
+}
+
+void NativeFeedback::set_associated_event_id(const String &p_associated_event_id) {
+	sentry_value_set_or_remove_string_by_key(native_feedback, "associated_event_id", p_associated_event_id);
+}
+
+String NativeFeedback::get_associated_event_id() const {
+	sentry_value_t associated_event_id = sentry_value_get_by_key(native_feedback, "associated_event_id");
+	return String::utf8(sentry_value_as_string(associated_event_id));
+}
+
+NativeFeedback::NativeFeedback(sentry_value_t p_feedback) :
+		native_feedback(p_feedback) {
+	sentry_value_incref(p_feedback); // acquire ownership
+}
+
+NativeFeedback::~NativeFeedback() {
+	sentry_value_decref(native_feedback); // release ownership
+}
+
+} //namespace sentry::native

--- a/src/sentry/native/native_feedback.h
+++ b/src/sentry/native/native_feedback.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "sentry/sentry_feedback_impl.h"
+#include "sentry.h"
 
-#include <sentry.h>
+#include "sentry/sentry_feedback_impl.h"
 
 namespace sentry::native {
 

--- a/src/sentry/native/native_feedback.h
+++ b/src/sentry/native/native_feedback.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "sentry/sentry_feedback_impl.h"
+
+#include <sentry.h>
+
+namespace sentry::native {
+
+class NativeFeedback : public SentryFeedbackImpl {
+	SENTRY_CASTABLE(NativeFeedback, SentryFeedbackImpl);
+
+private:
+	sentry_value_t native_feedback;
+
+public:
+	virtual void set_name(const String &p_name) override;
+	virtual String get_name() const override;
+
+	virtual void set_contact_email(const String &p_contact_email) override;
+	virtual String get_contact_email() const override;
+
+	virtual void set_message(const String &p_message) override;
+	virtual String get_message() const override;
+
+	virtual void set_associated_event_id(const String &p_associated_event_id) override;
+	virtual String get_associated_event_id() const override;
+
+	NativeFeedback(sentry_value_t p_feedback);
+	virtual ~NativeFeedback() override;
+};
+
+} //namespace sentry::native

--- a/src/sentry/sentry_event.cpp
+++ b/src/sentry/sentry_event.cpp
@@ -29,6 +29,7 @@ void SentryEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentryEvent::set_user);
 	ClassDB::bind_method(D_METHOD("set_fingerprint", "fingerprint"), &SentryEvent::set_fingerprint);
 	ClassDB::bind_method(D_METHOD("set_context", "key", "value"), &SentryEvent::set_context);
+	ClassDB::bind_method(D_METHOD("get_feedback"), &SentryEvent::get_feedback);
 	ClassDB::bind_method(D_METHOD("is_crash"), &SentryEvent::is_crash);
 	ClassDB::bind_method(D_METHOD("to_json"), &SentryEvent::to_json);
 

--- a/src/sentry/sentry_event.h
+++ b/src/sentry/sentry_event.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sentry/level.h"
+#include "sentry/sentry_feedback.h"
 #include "sentry/sentry_timestamp.h"
 #include "sentry/sentry_user.h"
 
@@ -76,6 +77,8 @@ public:
 
 	virtual void set_context(const String &p_key, const Dictionary &p_value) = 0;
 	virtual void merge_context(const String &p_key, const Dictionary &p_value) = 0;
+
+	virtual Ref<SentryFeedback> get_feedback() const = 0;
 
 	virtual void add_exception(const Exception &p_exception) = 0;
 

--- a/src/sentry/sentry_feedback.cpp
+++ b/src/sentry/sentry_feedback.cpp
@@ -11,4 +11,16 @@ void SentryFeedback::_bind_methods() {
 	BIND_PROPERTY(SentryFeedback, PropertyInfo(Variant::STRING, "associated_event_id"), set_associated_event_id, get_associated_event_id);
 }
 
+SentryFeedback::SentryFeedback() {
+	_impl = memnew(PlainFeedback);
+}
+
+SentryFeedback::SentryFeedback(SentryFeedbackImpl *p_impl) :
+		_impl(p_impl) {
+}
+
+SentryFeedback::~SentryFeedback() {
+	memdelete(_impl);
+}
+
 } //namespace sentry

--- a/src/sentry/sentry_feedback.h
+++ b/src/sentry/sentry_feedback.h
@@ -1,35 +1,40 @@
 #pragma once
 
+#include "sentry/sentry_feedback_impl.h"
+
 #include <godot_cpp/classes/ref_counted.hpp>
 
 using namespace godot;
 
 namespace sentry {
 
+// Godot-exported representation of user feedback.
+// Implementations are provided by SentryFeedbackImpl subclasses.
 class SentryFeedback : public RefCounted {
 	GDCLASS(SentryFeedback, RefCounted);
 
 private:
-	String name;
-	String contact_email;
-	String message;
-	String associated_event_id;
+	SentryFeedbackImpl *_impl;
 
 protected:
 	static void _bind_methods();
 
 public:
-	String get_name() const { return name; }
-	void set_name(const String &p_name) { name = p_name; }
+	String get_name() const { return _impl->get_name(); }
+	void set_name(const String &p_name) { _impl->set_name(p_name); }
 
-	String get_contact_email() const { return contact_email; }
-	void set_contact_email(const String &p_contact_email) { contact_email = p_contact_email; }
+	String get_contact_email() const { return _impl->get_contact_email(); }
+	void set_contact_email(const String &p_contact_email) { _impl->set_contact_email(p_contact_email); }
 
-	String get_message() const { return message; }
-	void set_message(const String &p_message) { message = p_message; }
+	String get_message() const { return _impl->get_message(); }
+	void set_message(const String &p_message) { _impl->set_message(p_message); }
 
-	String get_associated_event_id() const { return associated_event_id; }
-	void set_associated_event_id(const String &p_associated_event_id) { associated_event_id = p_associated_event_id; }
+	String get_associated_event_id() const { return _impl->get_associated_event_id(); }
+	void set_associated_event_id(const String &p_associated_event_id) { _impl->set_associated_event_id(p_associated_event_id); }
+
+	SentryFeedback();
+	SentryFeedback(SentryFeedbackImpl *p_impl);
+	~SentryFeedback();
 };
 
 } //namespace sentry

--- a/src/sentry/sentry_feedback_impl.h
+++ b/src/sentry/sentry_feedback_impl.h
@@ -9,10 +9,6 @@ using namespace godot;
 namespace sentry {
 
 // Base class for user feedback implementations; see Godot-facing SentryFeedback.
-// Splitting the implementation from SentryFeedback keeps SentryFeedback.new()
-// working, which an abstract class with a create() factory would break.
-// Kept as a pure C++ class instead of a Godot class to avoid ClassDB
-// registration and reduce overhead.
 // Lifetime governed by SentryFeedback.
 class SentryFeedbackImpl : public Castable {
 	SENTRY_CASTABLE(SentryFeedbackImpl, Castable);

--- a/src/sentry/sentry_feedback_impl.h
+++ b/src/sentry/sentry_feedback_impl.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "sentry/castable.h"
+
+#include <godot_cpp/variant/string.hpp>
+
+using namespace godot;
+
+namespace sentry {
+
+// Base class for user feedback implementations; see Godot-facing SentryFeedback.
+// Splitting the implementation from SentryFeedback keeps SentryFeedback.new()
+// working, which an abstract class with a create() factory would break.
+// Kept as a pure C++ class instead of a Godot class to avoid ClassDB
+// registration and reduce overhead.
+// Lifetime governed by SentryFeedback.
+class SentryFeedbackImpl : public Castable {
+	SENTRY_CASTABLE(SentryFeedbackImpl, Castable);
+
+public:
+	virtual void set_name(const String &p_name) = 0;
+	virtual String get_name() const = 0;
+
+	virtual void set_contact_email(const String &p_contact_email) = 0;
+	virtual String get_contact_email() const = 0;
+
+	virtual void set_message(const String &p_message) = 0;
+	virtual String get_message() const = 0;
+
+	virtual void set_associated_event_id(const String &p_associated_event_id) = 0;
+	virtual String get_associated_event_id() const = 0;
+
+	virtual ~SentryFeedbackImpl() = default;
+};
+
+// Holds the submitted fields in memory until a backend reads them at capture time.
+class PlainFeedback : public SentryFeedbackImpl {
+	SENTRY_CASTABLE(PlainFeedback, SentryFeedbackImpl);
+
+private:
+	String name;
+	String contact_email;
+	String message;
+	String associated_event_id;
+
+public:
+	virtual void set_name(const String &p_name) override { name = p_name; }
+	virtual String get_name() const override { return name; }
+
+	virtual void set_contact_email(const String &p_contact_email) override { contact_email = p_contact_email; }
+	virtual String get_contact_email() const override { return contact_email; }
+
+	virtual void set_message(const String &p_message) override { message = p_message; }
+	virtual String get_message() const override { return message; }
+
+	virtual void set_associated_event_id(const String &p_associated_event_id) override { associated_event_id = p_associated_event_id; }
+	virtual String get_associated_event_id() const override { return associated_event_id; }
+};
+
+} //namespace sentry


### PR DESCRIPTION
The `before_send_feedback` callback receives the prepared feedback event, but the fields the user submitted, the message, name, contact email, and associated event id, sit in that event's `feedback` context, which had no getter. A callback could discard the feedback or tag it, but could not read or scrub what was typed short of inspecting `to_json()`, and had no way to write anything back. This PR adds `SentryEvent.get_feedback()`, which returns the feedback as a live view of the event: reading it gives back what the user submitted, and writing to it modifies the event before it is sent. It returns null for events that carry no feedback, including the ones reaching `before_send`. iOS and macOS are the exception, since `before_send_feedback` is not implemented there yet.
