### PR TITLE
test(android): Add local E2E test runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,7 +360,8 @@ Install-Module -Name Pester -Force -SkipPublisherCheck
 - `SENTRY_AUTH_TOKEN`: Sentry API token for retrieving and validating events
 
 **Optional:**
-- `SENTRY_TEST_PLATFORM`: Target platform: Linux, macOS, Windows, Android, etc (see [`app-runner`](https://github.com/getsentry/app-runner) submodule)
+- `SENTRY_TEST_PLATFORM`: Target platform, such as Linux, macOS, Windows, or Adb (see the [`app-runner`](https://github.com/getsentry/app-runner) submodule)
+- `SENTRY_TEST_DEVICE`: Device identifier for the selected provider, such as an ADB serial
 - `SENTRY_TEST_DSN`: Sentry project DSN where test events will be sent (defaults to reading from project.godot)
 - `SENTRY_TEST_EXECUTABLE`: Path to test executable (defaults to `$env:GODOT`)
 
@@ -379,6 +380,55 @@ Invoke-Pester -Path Integration.Tests.ps1
 ```
 
 Tests validate crash capture, message capture, runtime error capture, and event metadata. Results are saved to `tests/integration/results/`.
+
+#### Run on a local Android device
+
+Install the matching Godot Android export templates, configure the Android SDK and Java 17 in Godot, and connect an unlocked device with USB debugging enabled. Confirm that ADB reports it as authorized:
+
+```bash
+adb devices
+```
+
+Set the API token and run the local Android integration-test script from the repository root:
+
+```powershell
+$env:SENTRY_AUTH_TOKEN = "<token>"
+pwsh scripts/run-android-integration-tests.ps1
+```
+
+The script exports `exports/android.apk`, selects the only online ADB device, and runs the GDScript integration suite through the app-runner `AdbProvider`. Select the .NET suite or both suites with `-Suite`:
+
+```powershell
+$env:GODOT = "/path/to/godot"
+$env:GODOT_DOTNET = "/path/to/godot-dotnet"
+pwsh scripts/run-android-integration-tests.ps1 -Suite Dotnet
+pwsh scripts/run-android-integration-tests.ps1 -Suite All
+```
+
+`GODOT` may point to either a standard or .NET Godot executable. When it points to a .NET build, the script builds `project/Sentry demo project.csproj` before exporting the GDScript suite and verifies that the Android APK contains the Mono runtime.
+
+The `Dotnet` mode requires the `dotnet` CLI, a Godot .NET executable, and matching Mono Android export templates. The `All` mode uses `GODOT` to export and run the GDScript suite first, then builds the project and uses `GODOT_DOTNET` to export and run the .NET suite.
+
+If more than one device is online, select one by its ADB serial:
+
+```powershell
+pwsh scripts/run-android-integration-tests.ps1 -DeviceSerial "<serial>"
+```
+
+An emulator uses the same path. Start it separately, wait until `adb devices` reports it as `device`, then pass its serial to the script. For example, this starts the first configured AVD without a window:
+
+```bash
+emulator -avd "$(emulator -list-avds | head -n 1)" \
+  -no-window \
+  -no-snapshot-save \
+  -gpu swiftshader_indirect \
+  -noaudio \
+  -no-boot-anim \
+  -camera-back none \
+  -camera-front none
+```
+
+The integration-test script does not start or stop the emulator.
 
 ## Releasing
 

--- a/scripts/run-android-integration-tests.ps1
+++ b/scripts/run-android-integration-tests.ps1
@@ -307,6 +307,13 @@ if ($failedContainersCount -gt 0) {
 }
 Write-Host
 
+foreach ($result in $results | Where-Object { $_.Result -eq "Failed" }) {
+    foreach ($container in $result.Containers) {
+        $failedPath = [System.IO.Path]::GetRelativePath($repoRoot, $container.Item.FullName)
+        Write-Host "Failed: $failedPath" -ForegroundColor Red
+    }
+}
+
 if ($results.Result -contains "Failed") {
     exit 1
 }

--- a/scripts/run-android-integration-tests.ps1
+++ b/scripts/run-android-integration-tests.ps1
@@ -1,0 +1,284 @@
+#!/usr/bin/env pwsh
+
+param (
+    [ValidateSet("GDScript", "Dotnet", "All")]
+    [string]$Suite = "GDScript",
+    [string]$DeviceSerial = $env:SENTRY_TEST_DEVICE,
+    [switch]$Help
+)
+
+Set-StrictMode -Version latest
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+    Write-Host @"
+Usage: run-android-integration-tests.ps1 [-Suite GDScript|Dotnet|All] [-DeviceSerial <serial>] [-Help]
+
+Export and run the integration tests on a local Android device available to ADB.
+
+OPTIONS:
+  -Suite           Test suite to run. Defaults to GDScript.
+  -DeviceSerial    ADB serial to use. Required when multiple devices are online.
+  -Help            Display this help message.
+
+ENVIRONMENT VARIABLES:
+  SENTRY_AUTH_TOKEN    Sentry API token used to retrieve test events (required)
+  SENTRY_TEST_DSN      Test project DSN (defaults to the value in project.godot)
+  SENTRY_TEST_DEVICE   ADB serial to use (same as -DeviceSerial)
+  GODOT               Path to Godot (standard or .NET) for GDScript and All
+  GODOT_DOTNET        Path to Godot .NET for Dotnet and All
+"@
+}
+
+function Stop-WithError {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Message
+    )
+
+    Write-Host $Message -ForegroundColor Red
+    exit 1
+}
+
+function Get-AdbDevices {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$AdbPath
+    )
+
+    $output = & $AdbPath devices
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "Failed to list Android devices with ADB."
+    }
+
+    return @($output | ForEach-Object {
+        if ($_ -match '^(\S+)\s+(\S+)') {
+            [PSCustomObject]@{
+                Serial = $matches[1]
+                State = $matches[2]
+            }
+        }
+    })
+}
+
+function Select-AdbDevice {
+    param (
+        [Parameter(Mandatory=$true)]
+        [AllowEmptyCollection()]
+        [object[]]$Devices,
+        [string]$RequestedSerial
+    )
+
+    if (-not [string]::IsNullOrEmpty($RequestedSerial)) {
+        $selectedDevice = $Devices | Where-Object { $_.Serial -eq $RequestedSerial } | Select-Object -First 1
+        if ($null -eq $selectedDevice) {
+            Stop-WithError "ADB device '$RequestedSerial' was not found."
+        }
+        if ($selectedDevice.State -ne "device") {
+            Stop-WithError "ADB device '$RequestedSerial' is $($selectedDevice.State). Authorize it and try again."
+        }
+        return $selectedDevice
+    }
+
+    $onlineDevices = @($Devices | Where-Object { $_.State -eq "device" })
+    if ($onlineDevices.Count -eq 0) {
+        $knownDevices = ($Devices | ForEach-Object { "$($_.Serial) ($($_.State))" }) -join ", "
+        if ([string]::IsNullOrEmpty($knownDevices)) {
+            $knownDevices = "none"
+        }
+        Stop-WithError "No authorized Android device is online. ADB devices: $knownDevices."
+    }
+    if ($onlineDevices.Count -gt 1) {
+        $serials = ($onlineDevices.Serial | Sort-Object) -join ", "
+        Stop-WithError "Multiple Android devices are online ($serials). Select one with -DeviceSerial."
+    }
+
+    return $onlineDevices[0]
+}
+
+function Resolve-GodotExecutable {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Executable,
+        [switch]$RequireDotnet
+    )
+
+    $command = Get-Command $Executable -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        Stop-WithError "Godot executable '$Executable' was not found."
+    }
+
+    $version = & $command.Source --version
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "Could not determine the Godot version for '$Executable'."
+    }
+
+    $isDotnet = $version -match '\.mono\.'
+    if ($RequireDotnet -and -not $isDotnet) {
+        Stop-WithError "Godot executable '$Executable' is not a .NET build."
+    }
+
+    return [PSCustomObject]@{
+        Path = $command.Source
+        IsDotnet = $isDotnet
+    }
+}
+
+function Test-ApkContainsMonoRuntime {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$ApkPath
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($ApkPath)
+    try {
+        return $null -ne ($archive.Entries | Where-Object {
+            $_.FullName -match '(^|/)libmonosgen-2\.0\.so$'
+        } | Select-Object -First 1)
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+if ([string]::IsNullOrEmpty($env:SENTRY_AUTH_TOKEN)) {
+    Stop-WithError "SENTRY_AUTH_TOKEN is not set."
+}
+
+$requiresGdScript = $Suite -in @("GDScript", "All")
+$requiresDotnet = $Suite -in @("Dotnet", "All")
+
+$adbCommand = Get-Command "adb" -ErrorAction SilentlyContinue
+if ($null -eq $adbCommand) {
+    Stop-WithError "ADB was not found in PATH."
+}
+
+$godotInfo = $null
+if ($requiresGdScript) {
+    $godot = if ([string]::IsNullOrEmpty($env:GODOT)) { "godot" } else { $env:GODOT }
+    $godotInfo = Resolve-GodotExecutable -Executable $godot
+}
+
+$godotDotnetInfo = $null
+if ($requiresDotnet) {
+    $godotDotnet = if (-not [string]::IsNullOrEmpty($env:GODOT_DOTNET)) {
+        $env:GODOT_DOTNET
+    } elseif ($Suite -eq "Dotnet" -and -not [string]::IsNullOrEmpty($env:GODOT)) {
+        $env:GODOT
+    } else {
+        "godot"
+    }
+    $godotDotnetInfo = Resolve-GodotExecutable -Executable $godotDotnet -RequireDotnet
+}
+
+$requiresDotnetBuild = $requiresDotnet -or ($requiresGdScript -and $godotInfo.IsDotnet)
+
+$pesterModule = Get-Module -ListAvailable "Pester" | Sort-Object Version -Descending | Select-Object -First 1
+if ($null -eq $pesterModule) {
+    Stop-WithError "Pester is not installed. Run: Install-Module -Name Pester -Force -SkipPublisherCheck"
+}
+
+$dotnetCommand = $null
+if ($requiresDotnetBuild) {
+    $dotnetCommand = Get-Command "dotnet" -ErrorAction SilentlyContinue
+    if ($null -eq $dotnetCommand) {
+        Stop-WithError "The dotnet CLI was not found in PATH."
+    }
+}
+
+$adbDevices = @(Get-AdbDevices -AdbPath $adbCommand.Source)
+$selectedDevice = Select-AdbDevice -Devices $adbDevices -RequestedSerial $DeviceSerial
+Write-Host "Using Android device: $($selectedDevice.Serial)" -ForegroundColor Cyan
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$projectDir = Join-Path $repoRoot "project"
+$exportDir = Join-Path $repoRoot "exports"
+$apkPath = Join-Path $exportDir "android.apk"
+$integrationDir = Join-Path $repoRoot "tests/integration"
+$testRuns = @()
+if ($requiresGdScript) {
+    $testRuns += [PSCustomObject]@{
+        Name = "GDScript"
+        BuildDotnet = $godotInfo.IsDotnet
+        GodotExecutable = $godotInfo.Path
+        TestScript = Join-Path $integrationDir "Integration.Tests.ps1"
+    }
+}
+if ($requiresDotnet) {
+    $testRuns += [PSCustomObject]@{
+        Name = "Dotnet"
+        BuildDotnet = $true
+        GodotExecutable = $godotDotnetInfo.Path
+        TestScript = Join-Path $integrationDir "Integration.Dotnet.Tests.ps1"
+    }
+}
+
+# Snapshot CSharp project to restore it later.
+$dotnetProject = Join-Path $projectDir "Sentry demo project.csproj"
+$dotnetProjectOldPath = "$dotnetProject.old"
+$dotnetProjectContents = [System.IO.File]::ReadAllBytes($dotnetProject)
+$dotnetProjectOldExisted = Test-Path $dotnetProjectOldPath -PathType Leaf
+$dotnetProjectOldContents = $null
+if ($dotnetProjectOldExisted) {
+    $dotnetProjectOldContents = [System.IO.File]::ReadAllBytes($dotnetProjectOldPath)
+}
+
+$results = @()
+try {
+    Import-Module $pesterModule.Path
+    foreach ($testRun in $testRuns) {
+        if ($testRun.BuildDotnet) {
+            Write-Host "Building .NET project..." -ForegroundColor Cyan
+            & $dotnetCommand.Source build $dotnetProject --nologo
+            if ($LASTEXITCODE -ne 0) {
+                Stop-WithError ".NET project build failed (exit code $LASTEXITCODE)."
+            }
+        }
+
+        New-Item -ItemType Directory -Path $exportDir -Force | Out-Null
+        Remove-Item -Path $apkPath -Force -ErrorAction SilentlyContinue
+
+        Write-Host "Exporting Android test APK for $($testRun.Name)..." -ForegroundColor Cyan
+        & $testRun.GodotExecutable `
+            --headless `
+            --disable-crash-handler `
+            --path $projectDir `
+            --install-android-build-template `
+            --export-debug "Android Tests" `
+            $apkPath
+        $exportExitCode = $LASTEXITCODE
+
+        if ($exportExitCode -ne 0) {
+            Write-Warning "Godot returned exit code $exportExitCode while exporting. Checking the APK before continuing."
+        }
+        if (-not (Test-Path $apkPath -PathType Leaf)) {
+            Stop-WithError "Android test APK was not created at '$apkPath' (export exit code $exportExitCode). Check the Android export templates and SDK configuration."
+        }
+        if ($testRun.BuildDotnet -and -not (Test-ApkContainsMonoRuntime -ApkPath $apkPath)) {
+            Stop-WithError "The Android test APK does not contain the Mono runtime. Check that matching Godot .NET Android export templates are installed."
+        }
+
+        $env:SENTRY_TEST_PLATFORM = "Adb"
+        $env:SENTRY_TEST_DEVICE = $selectedDevice.Serial
+        $env:SENTRY_TEST_EXECUTABLE = $apkPath
+
+        $results += Invoke-Pester -Path $testRun.TestScript -PassThru
+    }
+}
+finally {
+    [System.IO.File]::WriteAllBytes($dotnetProject, $dotnetProjectContents)
+    if ($dotnetProjectOldExisted) {
+        [System.IO.File]::WriteAllBytes($dotnetProjectOldPath, $dotnetProjectOldContents)
+    } else {
+        Remove-Item -Path $dotnetProjectOldPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($results.Result -contains "Failed") {
+    exit 1
+}

--- a/scripts/run-android-integration-tests.ps1
+++ b/scripts/run-android-integration-tests.ps1
@@ -279,6 +279,34 @@ finally {
     }
 }
 
+$passedCount = ($results.PassedCount | Measure-Object -Sum).Sum
+$failedCount = ($results.FailedCount | Measure-Object -Sum).Sum
+$skippedCount = ($results.SkippedCount | Measure-Object -Sum).Sum
+$inconclusiveCount = ($results.InconclusiveCount | Measure-Object -Sum).Sum
+$notRunCount = ($results.NotRunCount | Measure-Object -Sum).Sum
+$failedBlocksCount = ($results.FailedBlocksCount | Measure-Object -Sum).Sum
+$failedContainersCount = ($results.FailedContainersCount | Measure-Object -Sum).Sum
+$failedColor = if ($failedCount -gt 0) { "Red" } else { "DarkGray" }
+$skippedColor = if ($skippedCount -gt 0) { "Yellow" } else { "DarkGray" }
+
+Write-Host "Overall:" -ForegroundColor Cyan -NoNewline
+Write-Host " Passed: $passedCount" -ForegroundColor Green -NoNewline
+Write-Host " Failed: $failedCount" -ForegroundColor $failedColor -NoNewline
+Write-Host " Skipped: $skippedCount" -ForegroundColor $skippedColor -NoNewline
+if ($inconclusiveCount -gt 0) {
+    Write-Host " Inconclusive: $inconclusiveCount" -ForegroundColor DarkGray -NoNewline
+}
+if ($notRunCount -gt 0) {
+    Write-Host " Not run: $notRunCount" -ForegroundColor DarkGray -NoNewline
+}
+if ($failedBlocksCount -gt 0) {
+    Write-Host " Failed blocks: $failedBlocksCount" -ForegroundColor Red -NoNewline
+}
+if ($failedContainersCount -gt 0) {
+    Write-Host " Failed containers: $failedContainersCount" -ForegroundColor Red -NoNewline
+}
+Write-Host
+
 if ($results.Result -contains "Failed") {
     exit 1
 }

--- a/scripts/run-android-integration-tests.ps1
+++ b/scripts/run-android-integration-tests.ps1
@@ -52,7 +52,7 @@ function Get-AdbDevices {
     }
 
     return @($output | ForEach-Object {
-        if ($_ -match '^(\S+)\s+(\S+)') {
+        if ($_ -match '^(\S+)\t(\S+)') {
             [PSCustomObject]@{
                 Serial = $matches[1]
                 State = $matches[2]

--- a/tests/integration/Integration.Dotnet.Tests.ps1
+++ b/tests/integration/Integration.Dotnet.Tests.ps1
@@ -8,6 +8,7 @@
 #   SENTRY_TEST_DSN: test DSN
 #   SENTRY_AUTH_TOKEN: authentication token for Sentry API
 #   SENTRY_TEST_PLATFORM: test platform (aka device provider) such as "Local"
+#   SENTRY_TEST_DEVICE: optional device identifier for the selected provider
 #   GODOT_DOTNET: path to a Godot mono binary, used when SENTRY_TEST_EXECUTABLE is unset
 
 Set-StrictMode -Version latest
@@ -93,7 +94,15 @@ $DotnetCommonTestCases = @(
             param($SentryEvent)
             # Without an attached image, the symbolicator can't bind the frame to any image and reports unknown_image.
             $frames = $SentryEvent.exception.values[0].stacktrace.frames
-            $unknown = @($frames | Where-Object { $_.data.symbolicator_status -eq "unknown_image" })
+            $unknown = @($frames | Where-Object {
+                    $dataProperty = $_.PSObject.Properties["data"]
+                    if ($null -eq $dataProperty -or $null -eq $dataProperty.Value) {
+                        return $false
+                    }
+
+                    $statusProperty = $dataProperty.Value.PSObject.Properties["symbolicator_status"]
+                    return $null -ne $statusProperty -and $statusProperty.Value -eq "unknown_image"
+                })
             $unknown.Count | Should -Be 0
         }
     }
@@ -187,6 +196,7 @@ BeforeAll {
         Dsn = $env:SENTRY_TEST_DSN
         AuthToken = $env:SENTRY_AUTH_TOKEN
         Platform = $env:SENTRY_TEST_PLATFORM
+        Device = $env:SENTRY_TEST_DEVICE
         AndroidComponent = "io.sentry.godot.project/com.godot.game.GodotApp"
         IsAndroid = ($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs"))
         IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or $env:SENTRY_TEST_PLATFORM -match "iOS" -or
@@ -251,8 +261,7 @@ AfterAll {
 Describe ".NET Integration Tests" {
     BeforeAll {
         try {
-            Connect-Device -Platform $script:TestSetup.Platform
-            Install-DeviceApp -Path $script:TestSetup.Executable
+            Connect-IntegrationTestDevice -TestSetup $script:TestSetup
 
             $script:dotnetInitRunResult      = Invoke-TestAction -Action "dotnet-capture-via-dotnet-init"
             $script:bareRethrowRunResult    = Invoke-TestAction -Action "dotnet-exception-capture" -AdditionalArgs @("bare-rethrow")

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -8,6 +8,7 @@
 #   SENTRY_TEST_DSN: test DSN
 #   SENTRY_AUTH_TOKEN: authentication token for Sentry API
 #   SENTRY_TEST_PLATFORM: test platform (aka device provider) such as "Local" or "Android"
+#   SENTRY_TEST_DEVICE: optional device identifier for the selected provider
 
 Set-StrictMode -Version latest
 $ErrorActionPreference = "Stop"
@@ -64,7 +65,7 @@ BeforeAll {
         # Launch app again to ensure crash report is sent
         # NOTE: On Cocoa & Android, crashes are sent during the next app launch.
         if (
-            ($Action -eq "crash-capture" -or $runResult.ExitCode -ne 0) -and
+            ($Action -eq "crash-capture" -or ($null -ne $runResult.ExitCode -and $runResult.ExitCode -ne 0)) -and
                 $script:TestSetup.Platform -in @("macOS", "Local", "Adb", "AndroidSauceLabs", "iOSSauceLabs")
         ) {
             Write-Host "Running crash-send to ensure crash report is sent..."
@@ -135,6 +136,7 @@ BeforeAll {
         Dsn = $env:SENTRY_TEST_DSN
         AuthToken = $env:SENTRY_AUTH_TOKEN
         Platform = $env:SENTRY_TEST_PLATFORM
+        Device = $env:SENTRY_TEST_DEVICE
         AndroidComponent = "io.sentry.godot.project/com.godot.game.GodotApp"
         IsAndroid = ($env:SENTRY_TEST_PLATFORM -in @("Adb", "AndroidSauceLabs"))
         IsCocoa = ($env:SENTRY_TEST_PLATFORM -ieq "macOS" -or $env:SENTRY_TEST_PLATFORM -match "iOS" -or
@@ -207,8 +209,7 @@ Describe "Platform Integration Tests" {
         # sits idle during Sentry API polling (up to 120s per event) between launches.
         try {
             if (-not $script:TestSetup.IsWeb) {
-                Connect-Device -Platform $script:TestSetup.Platform
-                Install-DeviceApp -Path $script:TestSetup.Executable
+                Connect-IntegrationTestDevice -TestSetup $script:TestSetup
             }
 
             if (-not $script:TestSetup.IsWeb) {

--- a/tests/integration/Utils.ps1
+++ b/tests/integration/Utils.ps1
@@ -38,3 +38,46 @@ function script:ConvertTo-AndroidExtras {
 
     return $extras
 }
+
+function script:Connect-IntegrationTestDevice {
+    param (
+        [Parameter(Mandatory=$true)]
+        [PSCustomObject]$TestSetup
+    )
+
+    $connectParameters = @{ Platform = $TestSetup.Platform }
+    if (-not [string]::IsNullOrEmpty($TestSetup.Device)) {
+        $connectParameters.Target = $TestSetup.Device
+    }
+
+    Connect-Device @connectParameters
+    Install-DeviceApp -Path $TestSetup.Executable
+
+    if ($TestSetup.Platform -eq "Adb") {
+        $TestSetup.AndroidComponent = Resolve-AdbActivityComponent `
+            -Component $TestSetup.AndroidComponent `
+            -DeviceSerial (Get-DeviceSession).Identifier
+    }
+}
+
+function script:Resolve-AdbActivityComponent {
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Component,
+        [Parameter(Mandatory=$true)]
+        [string]$DeviceSerial
+    )
+
+    $componentParts = $Component -split "/", 2
+    $packageName = $componentParts[0]
+    $resolvedOutput = & adb -s $DeviceSerial shell cmd package resolve-activity --brief $packageName 2>$null
+    $resolveExitCode = $LASTEXITCODE
+    $resolvedComponents = @($resolvedOutput | Where-Object { $_ -like "$packageName/*" })
+
+    if ($resolveExitCode -eq 0 -and $resolvedComponents.Count -gt 0) {
+        return $resolvedComponents[-1].Trim()
+    }
+
+    Write-Warning "Could not resolve the Android launcher activity. Falling back to '$Component'."
+    return $Component
+}


### PR DESCRIPTION
Add a local Android integration test runner for USB-connected devices and emulators using the existing app-runner ADB support. It can export and run the GDScript suite, the .NET suite, or both sequentially, selecting the appropriate Godot executable and verifying Mono APKs when needed. This is for local development.