### PR TITLE
fix(options): Make deprecated logs and metrics options no-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+> [!IMPORTANT]
+> Structured logging and metrics are now always enabled, having been on by default since `2.0.0`. The corresponding `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options and Project Settings are deprecated and no longer have any effect.
+>
+> We recognize that this change may inconvenience applications that relied on the opt-out. Use `SentryOptions.before_send_log` or `SentryOptions.before_send_metric` to filter logs or metrics before they are sent. This deliberate tradeoff keeps these features consistent across SDK integrations.
+
 ### Features
 
 - Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835), [#836](https://github.com/getsentry/sentry-godot/pull/836))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Improvements
 
-- Deprecate the `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options and their Project Settings counterparts, to be removed in v3; logs and metrics are only sent when you use `SentrySDK.logger` or `SentrySDK.metrics`, or enable automatic log capture with `godot_logger.log_mask` ([#869](https://github.com/getsentry/sentry-godot/pull/869))
+- Make the deprecated `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options no-ops, and remove their Project Settings counterparts ([#869](https://github.com/getsentry/sentry-godot/pull/869), [#887](https://github.com/getsentry/sentry-godot/pull/887))
 - The bundled user feedback form now waits a frame for the UI to hide before capturing, so a screenshot attached to the feedback shows the game instead of the form and the text typed into it ([#880](https://github.com/getsentry/sentry-godot/pull/880))
 
 ### Fixes

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -264,6 +264,8 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.maxBreadcrumbs = maxBreadcrumbs
                 options.sdkVersion?.name = "sentry.java.android.godot"
                 options.nativeSdkName = "sentry.native.android.godot"
+                // sentry-android disables logs by default, unlike metrics.
+                options.logs.isEnabled = true
                 options.isAnrEnabled = enableAnrDetection
                 options.anrTimeoutIntervalMillis = anrTimeoutIntervalMs
                 options.isAttachAnrThreadDump = attachAnrThreadDump
@@ -510,7 +512,13 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     @UsedByGodot
-    fun captureFeedback(scopeHandle: Int, message: String, contactEmail: String, name: String, associatedEventId: String) {
+    fun captureFeedback(
+        scopeHandle: Int,
+        message: String,
+        contactEmail: String,
+        name: String,
+        associatedEventId: String
+    ) {
         val feedback = Feedback(message)
         feedback.contactEmail = contactEmail.ifEmpty { null }
         feedback.name = name.ifEmpty { null }

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -249,8 +249,6 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val environment = optionsData["environment"] as String
             val sampleRate = optionsData["sample_rate"].toDoubleOrThrow()
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
-            val enableLogs = optionsData["enable_logs"] as Boolean
-            val enableMetrics = optionsData["enable_metrics"] as Boolean
             val enableAnrDetection = optionsData["enable_anr_detection"] as Boolean
             val anrTimeoutIntervalMs = optionsData["anr_timeout_interval_ms"].toLongOrThrow()
             val attachAnrThreadDump = optionsData["attach_anr_thread_dump"] as Boolean
@@ -266,8 +264,6 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.maxBreadcrumbs = maxBreadcrumbs
                 options.sdkVersion?.name = "sentry.java.android.godot"
                 options.nativeSdkName = "sentry.native.android.godot"
-                options.logs.isEnabled = enableLogs
-                options.metrics.isEnabled = enableMetrics
                 options.isAnrEnabled = enableAnrDetection
                 options.anrTimeoutIntervalMillis = anrTimeoutIntervalMs
                 options.isAttachAnrThreadDump = attachAnrThreadDump

--- a/doc_classes/SentryExperimental.xml
+++ b/doc_classes/SentryExperimental.xml
@@ -22,8 +22,8 @@
 				return metric
 			[/codeblock]
 		</member>
-		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Will be removed in v3. Metrics are only sent if you use [member SentrySDK.metrics].">
-			Enables Sentry metrics functionality. When enabled, you can emit custom metrics using the [SentryMetrics] API available through [member SentrySDK.metrics].
+		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Has no effect and will be removed in v3. Use [member SentrySDK.metrics] to send metrics.">
+			This compatibility property always returns [code]true[/code], and assigning it has no effect. Metrics are sent when you use the [SentryMetrics] API available through [member SentrySDK.metrics].
 		</member>
 	</members>
 </class>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -113,13 +113,13 @@
 			If [code]true[/code], enables automatic detection and reporting of application hangs. The SDK will monitor the main thread and report hang events when it becomes unresponsive for longer than the duration specified in [member app_hang_timeout_ms]. This helps identify performance issues where the application becomes frozen or unresponsive.
 			[b]Note:[/b] This feature applies to iOS and macOS only. On Android, [member android] configures ANR (Application Not Responding) detection instead.
 		</member>
-		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true" deprecated="Will be removed in v3. Logs are only sent if you use [member SentrySDK.logger] or set [member SentryGodotLoggerOptions.log_mask].">
-			Enables Sentry's structured logging. If [code]true[/code], log entries can be emitted through [member SentrySDK.logger], and Godot logger events listed in [member SentryGodotLoggerOptions.log_mask] are automatically captured as Sentry Logs. [member SentryGodotLoggerOptions.log_mask] is empty by default, so no events are auto-captured.
+		<member name="enable_logs" type="bool" setter="set_enable_logs" getter="get_enable_logs" default="true" deprecated="Has no effect and will be removed in v3. Use [member SentrySDK.logger] or [member SentryGodotLoggerOptions.log_mask] to send logs.">
+			This compatibility property always returns [code]true[/code], and assigning it has no effect. Log entries are sent when you use [member SentrySDK.logger], and Godot logger events listed in [member SentryGodotLoggerOptions.log_mask] are automatically captured as Sentry Logs. [member SentryGodotLoggerOptions.log_mask] is empty by default, so no events are auto-captured.
 			See [member godot_logger] for options to capture Godot errors as Sentry events or breadcrumbs.
 			For more information, see [url=https://docs.sentry.io/platforms/godot/logs/]Sentry Logs[/url] documentation.
 		</member>
-		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Will be removed in v3. Metrics are only sent if you use [member SentrySDK.metrics].">
-			Enables Sentry metrics functionality. When enabled, you can emit custom metrics using the [SentryMetrics] API available through [member SentrySDK.metrics].
+		<member name="enable_metrics" type="bool" setter="set_enable_metrics" getter="get_enable_metrics" default="true" deprecated="Has no effect and will be removed in v3. Use [member SentrySDK.metrics] to send metrics.">
+			This compatibility property always returns [code]true[/code], and assigning it has no effect. Metrics are sent when you use the [SentryMetrics] API available through [member SentrySDK.metrics].
 		</member>
 		<member name="environment" type="String" setter="set_environment" getter="get_environment" default="&quot;{auto}&quot;">
 			Environments indicate where an error occurred, such as in a release export, headless server, QA build, or another deployment. The SDK automatically detects Godot-specific environments, such as [code]headless_server[/code] and [code]export_release[/code], but you can also assign it in a configuration callback using manual initialization (see [method SentrySDK.init]).

--- a/project/project.godot
+++ b/project/project.godot
@@ -58,7 +58,7 @@ textures/vram_compression/import_etc2_astc=true
 
 options/auto_init=false
 options/dsn="https://3f1e095cf2e14598a0bd5b4ff324f712@o447951.ingest.us.sentry.io/6680910"
-schema_version=4
+schema_version=5
 options/attach_scene_tree=true
 godot_logger/include_variables=true
 godot_logger/logs=143

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -25,6 +25,28 @@ func test_bool_properties(property: String, test_parameters := [
 	assert_bool(options.get(property)).is_false()
 
 
+@warning_ignore("unused_parameter")
+func test_deprecated_enable_options_are_noop(property: String, test_parameters := [
+		["enable_logs"],
+		["enable_metrics"],
+]) -> void:
+	options.set(property, false)
+	assert_bool(options.get(property)).is_true()
+
+
+func test_deprecated_experimental_enable_metrics_is_noop() -> void:
+	options.experimental.enable_metrics = false
+	assert_bool(options.experimental.enable_metrics).is_true()
+
+
+@warning_ignore("unused_parameter")
+func test_deprecated_enable_project_settings_are_removed(setting: String, test_parameters := [
+		["sentry/options/enable_logs"],
+		["sentry/options/enable_metrics"],
+]) -> void:
+	assert_bool(ProjectSettings.has_setting(setting)).is_false()
+
+
 ## Test simple bool properties on godot_logger options.
 @warning_ignore("unused_parameter")
 func test_godot_logger_bool_properties(property: String, test_parameters := [

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -398,8 +398,6 @@ void AndroidSDK::init() {
 	optionsData["environment"] = SENTRY_OPTIONS()->get_environment();
 	optionsData["sample_rate"] = SENTRY_OPTIONS()->get_sample_rate();
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();
-	optionsData["enable_logs"] = SENTRY_OPTIONS()->get_enable_logs();
-	optionsData["enable_metrics"] = SENTRY_OPTIONS()->get_enable_metrics();
 	optionsData["enable_anr_detection"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_detection();
 	optionsData["anr_timeout_interval_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_interval_ms();
 	optionsData["attach_anr_thread_dump"] = SENTRY_OPTIONS()->get_android()->get_attach_anr_thread_dump();

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -386,6 +386,9 @@ void CocoaSDK::init() {
 		// NOTE: This only works for captureMessage(), unfortunately.
 		options.attachStacktrace = false;
 
+		// sentry-cocoa disables logs by default, unlike metrics.
+		options.enableLogs = YES;
+
 		options.initialScope = ^(SentryObjCScope *scope) {
 			_add_default_attachments(scope);
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -386,9 +386,6 @@ void CocoaSDK::init() {
 		// NOTE: This only works for captureMessage(), unfortunately.
 		options.attachStacktrace = false;
 
-		options.enableLogs = SENTRY_OPTIONS()->get_enable_logs();
-		options.enableMetrics = SENTRY_OPTIONS()->get_enable_metrics();
-
 		options.initialScope = ^(SentryObjCScope *scope) {
 			_add_default_attachments(scope);
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -141,7 +141,6 @@ struct NativeOptions {
 	int32_t max_breadcrumbs;
 	double shutdown_timeout_ms;
 	uint8_t send_default_pii;
-	uint8_t enable_logs;
 
 	// Godot-specific
 	uint8_t attach_log;
@@ -158,9 +157,6 @@ struct NativeOptions {
 	int32_t logger_event_mask;
 	int32_t logger_breadcrumb_mask;
 	int32_t logger_log_mask;
-
-	// Experimental
-	uint8_t enable_metrics;
 
 	// Android
 	uint8_t android_enable_anr_detection;
@@ -204,7 +200,6 @@ struct ManagedOptions {
 	int32_t max_breadcrumbs;
 	double shutdown_timeout_ms;
 	uint8_t send_default_pii;
-	uint8_t enable_logs;
 
 	uint8_t attach_log;
 	uint8_t attach_scene_tree;
@@ -219,8 +214,6 @@ struct ManagedOptions {
 	int32_t logger_event_mask;
 	int32_t logger_breadcrumb_mask;
 	int32_t logger_log_mask;
-
-	uint8_t enable_metrics;
 
 	// Flags indicating which native-layer hooks are implemented in managed code; see ManagedDefinedHooks.
 	uint32_t defined_hooks;
@@ -252,7 +245,6 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->set_max_breadcrumbs(data.max_breadcrumbs);
 	options->set_shutdown_timeout_ms(data.shutdown_timeout_ms);
 	options->set_send_default_pii(data.send_default_pii);
-	options->set_enable_logs(data.enable_logs);
 	options->set_attach_log(data.attach_log);
 	options->set_attach_scene_tree(data.attach_scene_tree);
 	options->set_attach_screenshot(data.attach_screenshot);
@@ -265,7 +257,6 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->get_godot_logger()->set_event_mask(data.logger_event_mask);
 	options->get_godot_logger()->set_breadcrumb_mask(data.logger_breadcrumb_mask);
 	options->get_godot_logger()->set_log_mask(data.logger_log_mask);
-	options->set_enable_metrics(data.enable_metrics);
 	options->get_android()->set_enable_anr_detection(data.android_enable_anr_detection);
 	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
 	options->get_android()->set_attach_anr_thread_dump(data.android_attach_anr_thread_dump);
@@ -290,7 +281,6 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.max_breadcrumbs = options->get_max_breadcrumbs();
 	r_data.shutdown_timeout_ms = options->get_shutdown_timeout_ms();
 	r_data.send_default_pii = options->is_send_default_pii_enabled();
-	r_data.enable_logs = options->get_enable_logs();
 	r_data.attach_log = options->is_attach_log_enabled();
 	r_data.attach_scene_tree = options->is_attach_scene_tree_enabled();
 	r_data.attach_screenshot = options->is_attach_screenshot_enabled();
@@ -303,7 +293,6 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.logger_event_mask = options->get_godot_logger()->get_event_mask();
 	r_data.logger_breadcrumb_mask = options->get_godot_logger()->get_breadcrumb_mask();
 	r_data.logger_log_mask = options->get_godot_logger()->get_log_mask();
-	r_data.enable_metrics = options->get_enable_metrics();
 	r_data.android_enable_anr_detection = options->get_android()->get_enable_anr_detection();
 	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();
 	r_data.android_attach_anr_thread_dump = options->get_android()->get_attach_anr_thread_dump();

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -120,7 +120,6 @@ internal static partial class NativeBridge
         public int max_breadcrumbs;
         public double shutdown_timeout_ms;
         public byte send_default_pii;
-        public byte enable_logs;
         public byte attach_log;
         public byte attach_scene_tree;
         public byte attach_screenshot;
@@ -133,7 +132,6 @@ internal static partial class NativeBridge
         public int logger_event_mask;
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
-        public byte enable_metrics;
         public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
         public byte android_attach_anr_thread_dump;
@@ -158,7 +156,6 @@ internal static partial class NativeBridge
         public int max_breadcrumbs;
         public double shutdown_timeout_ms;
         public byte send_default_pii;
-        public byte enable_logs;
         public byte attach_log;
         public byte attach_scene_tree;
         public byte attach_screenshot;
@@ -171,7 +168,6 @@ internal static partial class NativeBridge
         public int logger_event_mask;
         public int logger_breadcrumb_mask;
         public int logger_log_mask;
-        public byte enable_metrics;
         public uint defined_hooks;
         public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
@@ -517,7 +513,6 @@ internal static partial class NativeBridge
         opts.MaxBreadcrumbs = data.max_breadcrumbs;
         opts.ShutdownTimeout = TimeSpan.FromMilliseconds(data.shutdown_timeout_ms);
         opts.SendDefaultPii = data.send_default_pii != 0;
-        opts.EnableLogs = data.enable_logs != 0;
         opts.AttachLog = data.attach_log != 0;
         opts.AttachSceneTree = data.attach_scene_tree != 0;
         opts.AttachScreenshot = data.attach_screenshot != 0;
@@ -530,7 +525,6 @@ internal static partial class NativeBridge
         opts.GodotLogger.EventMask = (GodotLoggerEventMask)data.logger_event_mask;
         opts.GodotLogger.BreadcrumbMask = (GodotLoggerEventMask)data.logger_breadcrumb_mask;
         opts.GodotLogger.LogMask = (GodotLoggerEventMask)data.logger_log_mask;
-        opts.EnableMetrics = data.enable_metrics != 0;
         opts.Android.EnableAnrDetection = data.android_enable_anr_detection != 0;
         opts.Android.AnrTimeoutInterval = TimeSpan.FromMilliseconds(data.android_anr_timeout_interval_ms);
         opts.Android.AttachAnrThreadDump = data.android_attach_anr_thread_dump != 0;
@@ -816,7 +810,6 @@ internal static partial class NativeBridge
                 max_breadcrumbs = opts.MaxBreadcrumbs,
                 shutdown_timeout_ms = opts.ShutdownTimeout.TotalMilliseconds,
                 send_default_pii = (byte)(opts.SendDefaultPii ? 1 : 0),
-                enable_logs = (byte)(opts.EnableLogs ? 1 : 0),
                 attach_log = (byte)(opts.AttachLog ? 1 : 0),
                 attach_scene_tree = (byte)(opts.AttachSceneTree ? 1 : 0),
                 attach_screenshot = (byte)(opts.AttachScreenshot ? 1 : 0),
@@ -829,7 +822,6 @@ internal static partial class NativeBridge
                 logger_event_mask = (int)opts.GodotLogger.EventMask,
                 logger_breadcrumb_mask = (int)opts.GodotLogger.BreadcrumbMask,
                 logger_log_mask = (int)opts.GodotLogger.LogMask,
-                enable_metrics = (byte)(opts.EnableMetrics ? 1 : 0),
                 defined_hooks = (uint)GetManagedDefinedHooks(opts),
                 android_enable_anr_detection = (byte)(opts.Android.EnableAnrDetection ? 1 : 0),
                 android_anr_timeout_interval_ms = (int)opts.Android.AnrTimeoutInterval.TotalMilliseconds,

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -16,6 +16,9 @@ public sealed class SentryGodotOptions : SentryOptions
         // Native layer owns sessions; .NET-side tracking would double-count.
         AutoSessionTracking = false;
 
+        // sentry-dotnet disables logs by default, unlike metrics.
+        EnableLogs = true;
+
         AddInAppExclude("Godot");
         AddIntegration(new GodotSdkIntegration());
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -225,9 +225,6 @@ public sealed class SentryGodotLoggerOptions
     /// Accepts a single value or a bitwise combination of <see cref="GodotLoggerEventMask"/> masks.
     /// Empty by default, so no events are captured as logs.
     /// </summary>
-    /// <remarks>
-    /// Log capture requires <see cref="SentryOptions.EnableLogs"/> to be enabled.
-    /// </remarks>
     public GodotLoggerEventMask LogMask { get; set; } = GodotLoggerEventMask.None;
 
     /// <summary>

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentrySdk.cs
@@ -115,6 +115,11 @@ public static partial class SentrySdk
     {
         CurrentOptions = godotOptions;
         GodotLog.Debug("Initializing Sentry in .NET...");
+
+        // Deprecated no-ops in the Godot API, enforced here so the user callback can't disable them.
+        godotOptions.EnableLogs = true;
+        godotOptions.EnableMetrics = true;
+
         ConfigureAssemblyReader(godotOptions);
         ConfigureCocoaDebugImagesOnIOS(godotOptions);
         Sentry.SentrySdk.Init(godotOptions);

--- a/src/sentry/javascript/bridge/README.md
+++ b/src/sentry/javascript/bridge/README.md
@@ -26,7 +26,7 @@ bridge/
 The bridge exposes `window.SentryBridge`. Example usage:
 
 ```typescript
-SentryBridge.init(beforeSendCallback, beforeSendLogCallback, dsn, debug, release, dist, environment, sampleRate, maxBreadcrumbs, enableLogs)
+SentryBridge.init(beforeSendCallback, beforeSendLogCallback, dsn, debug, release, dist, environment, sampleRate, maxBreadcrumbs)
 SentryBridge.setTag(key, value)
 SentryBridge.setUser(id, username, email, ip)
 SentryBridge.captureEvent(event)

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -141,8 +141,6 @@ class SentryBridge {
     environment: string,
     sampleRate: number,
     maxBreadcrumbs: number,
-    enableLogs: boolean,
-    enableMetrics: boolean,
     sendDefaultPii: boolean,
     sdkVersion: string,
   ): void {
@@ -158,8 +156,6 @@ class SentryBridge {
       environment,
       sampleRate,
       maxBreadcrumbs,
-      enableLogs,
-      enableMetrics,
       sendDefaultPii,
       _metadata: {
         sdk: {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -127,7 +127,7 @@ try {
 		};
 
 		runTest("init()", () => {
-			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, false, false, "0.1.0");
+			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 100, false, "0.1.0");
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -359,8 +359,6 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_environment().utf8(),
 			SENTRY_OPTIONS()->get_sample_rate(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),
-			SENTRY_OPTIONS()->get_enable_logs(),
-			SENTRY_OPTIONS()->get_enable_metrics(),
 			SENTRY_OPTIONS()->is_send_default_pii_enabled(),
 			SENTRY_GODOT_SDK_VERSION);
 

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -415,8 +415,6 @@ void NativeSDK::init() {
 	sentry_options_set_shutdown_timeout(options, SENTRY_OPTIONS()->get_shutdown_timeout_ms());
 	sentry_options_set_sdk_name(options, "sentry.native.godot");
 	sentry_options_set_logger_enabled_when_crashed(options, false);
-	sentry_options_set_enable_logs(options, SENTRY_OPTIONS()->get_enable_logs());
-	sentry_options_set_enable_metrics(options, SENTRY_OPTIONS()->get_enable_metrics());
 
 	// Establish handler path.
 	String handler_fn;

--- a/src/sentry/sentry_metrics.cpp
+++ b/src/sentry/sentry_metrics.cpp
@@ -6,25 +6,16 @@ namespace sentry {
 
 void SentryMetrics::count(const String &p_name, int64_t p_value, const Dictionary &p_attributes) {
 	ERR_FAIL_COND_MSG(p_name.is_empty(), "SentryMetrics.count(): metric name must not be empty.");
-	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
-		return;
-	}
 	INTERNAL_SDK()->metrics_add_count(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_attributes);
 }
 
 void SentryMetrics::gauge(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND_MSG(p_name.is_empty(), "SentryMetrics.gauge(): metric name must not be empty.");
-	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
-		return;
-	}
 	INTERNAL_SDK()->metrics_add_gauge(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_unit, p_attributes);
 }
 
 void SentryMetrics::distribution(const String &p_name, double p_value, const String &p_unit, const Dictionary &p_attributes) {
 	ERR_FAIL_COND_MSG(p_name.is_empty(), "SentryMetrics.distribution(): metric name must not be empty.");
-	if (!SENTRY_OPTIONS()->get_enable_metrics()) {
-		return;
-	}
 	INTERNAL_SDK()->metrics_add_distribution(SentrySDK::get_singleton()->get_current_scope(), p_name, p_value, p_unit, p_attributes);
 }
 

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -76,14 +76,12 @@ SentryGodotLoggerOptions::SentryGodotLoggerOptions() {
 
 // *** SentryExperimental
 
-void SentryExperimental::deprecated_set_enable_metrics(bool p_value) {
-	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
-	ERR_FAIL_NULL(owner);
-	owner->set_enable_metrics(p_value);
+void SentryExperimental::deprecated_set_enable_metrics(bool) {
+	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated, has no effect, and will be removed in version 3.0. Metrics are sent when you use SentrySDK.metrics.");
 }
 
 bool SentryExperimental::deprecated_get_enable_metrics() {
-	return owner ? owner->get_enable_metrics() : true;
+	return true;
 }
 
 void SentryExperimental::deprecated_set_before_send_metric(Callable p_value) {
@@ -135,9 +133,6 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 
 	_define_setting("sentry/options/attach_log", p_options->attach_log, false);
 	_define_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
-
-	_define_setting("sentry/options/enable_logs", p_options->enable_logs, false);
-	_define_setting("sentry/options/enable_metrics", p_options->enable_metrics, false);
 
 	_define_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/app_hang/timeout_ms", PROPERTY_HINT_RANGE, "1000,10000,1"), p_options->app_hang_timeout_ms, false);
@@ -227,17 +222,6 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->attach_log = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_log", p_options->attach_log);
 	p_options->attach_scene_tree = ProjectSettings::get_singleton()->get_setting("sentry/options/attach_scene_tree", p_options->attach_scene_tree);
-
-	p_options->enable_logs = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_logs", p_options->enable_logs);
-	p_options->enable_metrics = ProjectSettings::get_singleton()->get_setting("sentry/options/enable_metrics", p_options->enable_metrics);
-
-	// Only a disabled setting is worth warning about: the enabled default carries no user intent.
-	if (!p_options->enable_logs) {
-		WARN_PRINT_ONCE("Sentry: The \"Enable Logs\" project setting is deprecated and will be removed in version 3.0. Logs are only sent if you use SentrySDK.logger or set \"sentry/godot_logger/logs\".");
-	}
-	if (!p_options->enable_metrics) {
-		WARN_PRINT_ONCE("Sentry: The \"Enable Metrics\" project setting is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
-	}
 
 	p_options->enable_app_hang_tracking = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/tracking", p_options->enable_app_hang_tracking);
 	p_options->app_hang_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/app_hang/timeout_ms", p_options->app_hang_timeout_ms);
@@ -355,14 +339,12 @@ void SentryOptions::deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &
 	godot_logger->deprecated_set_limits(p_limits);
 }
 
-void SentryOptions::deprecated_set_enable_logs(bool p_enabled) {
-	WARN_DEPRECATED_MSG("The \"enable_logs\" option is deprecated and will be removed in version 3.0. Logs are only sent if you use SentrySDK.logger or set \"godot_logger.log_mask\".");
-	set_enable_logs(p_enabled);
+void SentryOptions::deprecated_set_enable_logs(bool) {
+	WARN_DEPRECATED_MSG("The \"enable_logs\" option is deprecated, has no effect, and will be removed in version 3.0. Logs are sent when you use SentrySDK.logger or set \"godot_logger.log_mask\".");
 }
 
-void SentryOptions::deprecated_set_enable_metrics(bool p_enabled) {
-	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated and will be removed in version 3.0. Metrics are only sent if you use SentrySDK.metrics.");
-	set_enable_metrics(p_enabled);
+void SentryOptions::deprecated_set_enable_metrics(bool) {
+	WARN_DEPRECATED_MSG("The \"enable_metrics\" option is deprecated, has no effect, and will be removed in version 3.0. Metrics are sent when you use SentrySDK.metrics.");
 }
 
 void SentryOptions::set_release(const String &p_release) {

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -122,10 +122,8 @@ private:
 	sentry::Level screenshot_level = sentry::LEVEL_FATAL;
 	bool attach_scene_tree = false;
 
-	bool enable_logs = true;
 	Callable before_send_log;
 
-	bool enable_metrics = true;
 	Callable before_send_metric;
 
 	bool enable_app_hang_tracking = true;
@@ -205,14 +203,8 @@ public:
 	_FORCE_INLINE_ void set_attach_scene_tree(bool p_enable) { attach_scene_tree = p_enable; }
 	_FORCE_INLINE_ bool is_attach_scene_tree_enabled() const { return attach_scene_tree; }
 
-	_FORCE_INLINE_ bool get_enable_logs() const { return enable_logs; }
-	_FORCE_INLINE_ void set_enable_logs(bool p_enabled) { enable_logs = p_enabled; }
-
 	_FORCE_INLINE_ Callable get_before_send_log() const { return before_send_log; }
 	_FORCE_INLINE_ void set_before_send_log(const Callable &p_callback) { before_send_log = p_callback; }
-
-	_FORCE_INLINE_ bool get_enable_metrics() const { return enable_metrics; }
-	_FORCE_INLINE_ void set_enable_metrics(bool p_enabled) { enable_metrics = p_enabled; }
 
 	_FORCE_INLINE_ Callable get_before_send_metric() const { return before_send_metric; }
 	_FORCE_INLINE_ void set_before_send_metric(const Callable &p_callback) { before_send_metric = p_callback; }
@@ -238,9 +230,9 @@ public:
 
 	_FORCE_INLINE_ bool should_capture_event(GodotErrorType p_error_type) { return godot_logger->get_event_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
 	_FORCE_INLINE_ bool should_capture_breadcrumb(GodotErrorType p_error_type) { return godot_logger->get_breadcrumb_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
-	_FORCE_INLINE_ bool should_capture_log(GodotErrorType p_error_type) { return enable_logs && godot_logger->get_log_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
+	_FORCE_INLINE_ bool should_capture_log(GodotErrorType p_error_type) { return godot_logger->get_log_mask().has_flag(sentry::godot_error_type_as_mask(p_error_type)); }
 	_FORCE_INLINE_ bool should_capture_message_breadcrumb() { return godot_logger->get_breadcrumb_mask().has_flag(MASK_MESSAGE); }
-	_FORCE_INLINE_ bool should_capture_message_log() { return enable_logs && godot_logger->get_log_mask().has_flag(MASK_MESSAGE); }
+	_FORCE_INLINE_ bool should_capture_message_log() { return godot_logger->get_log_mask().has_flag(MASK_MESSAGE); }
 
 	// Clears every Callable property, dropping user callbacks such as before_send.
 	// Workaround for https://github.com/getsentry/sentry-godot/issues/797
@@ -295,10 +287,10 @@ public:
 	Ref<SentryLoggerLimits> deprecated_get_logger_limits() const { return godot_logger->get_limits(); }
 	void deprecated_set_logger_limits(const Ref<SentryLoggerLimits> &p_limits);
 
-	bool deprecated_get_enable_logs() const { return enable_logs; }
+	bool deprecated_get_enable_logs() const { return true; }
 	void deprecated_set_enable_logs(bool p_enabled);
 
-	bool deprecated_get_enable_metrics() const { return enable_metrics; }
+	bool deprecated_get_enable_metrics() const { return true; }
 	void deprecated_set_enable_metrics(bool p_enabled);
 };
 

--- a/src/sentry/settings_migrations.cpp
+++ b/src/sentry/settings_migrations.cpp
@@ -102,11 +102,18 @@ void _migrate_to_v4() {
 	_rename_setting("sentry/experimental/enable_metrics", "sentry/options/enable_metrics");
 }
 
+void _migrate_to_v5() {
+	ProjectSettings::get_singleton()->set_setting("sentry/experimental/enable_logs", Variant());
+	ProjectSettings::get_singleton()->set_setting("sentry/experimental/enable_metrics", Variant());
+	ProjectSettings::get_singleton()->set_setting("sentry/options/enable_logs", Variant());
+	ProjectSettings::get_singleton()->set_setting("sentry/options/enable_metrics", Variant());
+}
+
 } // unnamed namespace
 
 namespace sentry {
 
-constexpr static int SCHEMA_VERSION = 4;
+constexpr static int SCHEMA_VERSION = 5;
 
 void run_project_settings_migrations() {
 	const String schema_version_key = "sentry/schema_version";
@@ -142,6 +149,10 @@ void run_project_settings_migrations() {
 
 	if (from_version < 4) {
 		_migrate_to_v4();
+	}
+
+	if (from_version < 5) {
+		_migrate_to_v5();
 	}
 
 	if (from_version < SCHEMA_VERSION) {


### PR DESCRIPTION
Makes the deprecated `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` properties always return `true` and ignore assignments, while removing their corresponding Project Settings and cleaning up through a schema migration. Platform integrations no longer forward these, preserving the deprecated scripting API until its removal in v3.