### PR TITLE
chore: Update clang-format configuration for Clang 22

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,194 +1,47 @@
-# Commented out parameters are those with the same value as base LLVM style.
-# We can uncomment them if we want to change their value, or enforce the
-# chosen value in case the base style changes (last sync: Clang 13.0).
----
-### General config, applies to all languages ###
-BasedOnStyle:  LLVM
+BasedOnStyle: LLVM
 AccessModifierOffset: -4
-AlignAfterOpenBracket: DontAlign
-# AlignArrayOfStructures: None
-# AlignConsecutiveMacros: None
-# AlignConsecutiveAssignments: None
-# AlignConsecutiveBitFields: None
-# AlignConsecutiveDeclarations: None
-# AlignEscapedNewlines: Right
-AlignOperands:   DontAlign
-AlignTrailingComments: false
-# AllowAllArgumentsOnNextLine: true
-# AllowAllConstructorInitializersOnNextLine: true
+AlignAfterOpenBracket: false
+AlignOperands: DontAlign
+AlignTrailingComments:
+  Kind: Never
+  OverEmptyLines: 0
 AllowAllParametersOfDeclarationOnNextLine: false
-# AllowShortEnumsOnASingleLine: true
-# AllowShortBlocksOnASingleLine: Never
-# AllowShortCaseLabelsOnASingleLine: false
-# AllowShortFunctionsOnASingleLine: All
-# AllowShortLambdasOnASingleLine: All
-# AllowShortIfStatementsOnASingleLine: Never
-# AllowShortLoopsOnASingleLine: false
-# AlwaysBreakAfterDefinitionReturnType: None
-# AlwaysBreakAfterReturnType: None
-# AlwaysBreakBeforeMultilineStrings: false
-# AlwaysBreakTemplateDeclarations: MultiLine
-# AttributeMacros:
-#   - __capability
-# BinPackArguments: true
-# BinPackParameters: true
-# BraceWrapping:
-#   AfterCaseLabel:  false
-#   AfterClass:      false
-#   AfterControlStatement: Never
-#   AfterEnum:       false
-#   AfterFunction:   false
-#   AfterNamespace:  false
-#   AfterObjCDeclaration: false
-#   AfterStruct:     false
-#   AfterUnion:      false
-#   AfterExternBlock: false
-#   BeforeCatch:     false
-#   BeforeElse:      false
-#   BeforeLambdaBody: false
-#   BeforeWhile:     false
-#   IndentBraces:    false
-#   SplitEmptyFunction: true
-#   SplitEmptyRecord: true
-#   SplitEmptyNamespace: true
-# BreakBeforeBinaryOperators: None
-# BreakBeforeConceptDeclarations: true
-# BreakBeforeBraces: Attach
-# BreakBeforeInheritanceComma: false
-# BreakInheritanceList: BeforeColon
-# BreakBeforeTernaryOperators: true
-# BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
-# BreakStringLiterals: true
-ColumnLimit:     0
-# CommentPragmas:  '^ IWYU pragma:'
-# CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ColumnLimit: 0
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: false
-# DeriveLineEnding: true
-# DerivePointerAlignment: false
-# DisableFormat:   false
-# EmptyLineAfterAccessModifier: Never
-# EmptyLineBeforeAccessModifier: LogicalBlock
-# ExperimentalAutoDetectBinPacking: false
-# FixNamespaceComments: true
-# ForEachMacros:
-#   - foreach
-#   - Q_FOREACH
-#   - BOOST_FOREACH
-# IfMacros:
-#   - KJ_IF_MAYBE
-# IncludeBlocks:   Preserve
 IncludeCategories:
-  - Regex:           '".*"'
-    Priority:        1
-  - Regex:           '^<.*\.h>'
-    Priority:        2
-  - Regex:           '^<.*'
-    Priority:        3
-# IncludeIsMainRegex: '(Test)?$'
-# IncludeIsMainSourceRegex: ''
-# IndentAccessModifiers: false
+  - Regex: '".*"'
+    Priority: 1
+  - Regex: '^<.*\.h>'
+    Priority: 2
+  - Regex: '^<.*'
+    Priority: 3
 IndentCaseLabels: true
-# IndentCaseBlocks: false
-# IndentGotoLabels: true
-# IndentPPDirectives: None
-# IndentExternBlock: AfterExternBlock
-# IndentRequires:  false
-IndentWidth:     4
-# IndentWrappedFunctionNames: false
-# InsertTrailingCommas: None
-# JavaScriptQuotes: Leave
-# JavaScriptWrapImports: true
+IndentWidth: 4
 KeepEmptyLinesAtTheStartOfBlocks: false
-# LambdaBodyIndentation: Signature
-# MacroBlockBegin: ''
-# MacroBlockEnd:   ''
-# MaxEmptyLinesToKeep: 1
-# NamespaceIndentation: None
-# PenaltyBreakAssignment: 2
-# PenaltyBreakBeforeFirstCallParameter: 19
-# PenaltyBreakComment: 300
-# PenaltyBreakFirstLessLess: 120
-# PenaltyBreakString: 1000
-# PenaltyBreakTemplateDeclaration: 10
-# PenaltyExcessCharacter: 1000000
-# PenaltyReturnTypeOnItsOwnLine: 60
-# PenaltyIndentedWhitespace: 0
-# PointerAlignment: Right
-# PPIndentWidth:   -1
-# ReferenceAlignment: Pointer
-# ReflowComments:  true
-# ShortNamespaceLines: 1
-# SortIncludes:    CaseSensitive
-# SortJavaStaticImport: Before
-# SortUsingDeclarations: true
-# SpaceAfterCStyleCast: false
-# SpaceAfterLogicalNot: false
-# SpaceAfterTemplateKeyword: true
-# SpaceBeforeAssignmentOperators: true
-# SpaceBeforeCaseColon: false
-# SpaceBeforeCpp11BracedList: false
-# SpaceBeforeCtorInitializerColon: true
-# SpaceBeforeInheritanceColon: true
-# SpaceBeforeParens: ControlStatements
-# SpaceAroundPointerQualifiers: Default
-# SpaceBeforeRangeBasedForLoopColon: true
-# SpaceInEmptyParentheses: false
-# SpacesBeforeTrailingComments: 1
-# SpaceInEmptyBlock: false
-# SpaceInEmptyParentheses: false
-# SpacesBeforeTrailingComments: 1
-# SpacesInAngles:  Never
-# SpacesInContainerLiterals: true
-# SpacesInConditionalStatement: false
-# SpacesInContainerLiterals: true
-# SpacesInCStyleCastParentheses: false
-## Godot TODO: We'll want to use a min of 1, but we need to see how to fix
-## our comment capitalization at the same time.
+PackConstructorInitializers: NextLine
 SpacesInLineCommentPrefix:
-  Minimum:         0
-  Maximum:         -1
-# SpacesInParentheses: false
-# SpacesInSquareBrackets: false
-# SpaceBeforeSquareBrackets: false
-# BitFieldColonSpacing: Both
-# StatementAttributeLikeMacros:
-#   - Q_EMIT
-# StatementMacros:
-#   - Q_UNUSED
-#   - QT_REQUIRE_VERSION
-TabWidth:        4
-# UseCRLF:         false
-UseTab:          Always
-# WhitespaceSensitiveMacros:
-#   - STRINGIZE
-#   - PP_STRINGIZE
-#   - BOOST_PP_STRINGIZE
-#   - NS_SWIFT_NAME
-#   - CF_SWIFT_NAME
+  Minimum: 0
+  Maximum: -1
+TabWidth: 4
+UseTab: Always
 ---
-### C++ specific config ###
-Language:        Cpp
-Standard:        c++14
+Language: Cpp
+AlignAfterOpenBracket: false
+Standard: c++17
 ---
-### ObjC specific config ###
-Language:        ObjC
-# ObjCBinPackProtocolList: Auto
+Language: ObjC
+AlignAfterOpenBracket: false
 ObjCBlockIndentWidth: 4
-# ObjCBreakBeforeNestedBlockParam: true
-# ObjCSpaceAfterProperty: false
-# ObjCSpaceBeforeProtocolList: true
 ---
-### Java specific config ###
-Language:        Java
-# BreakAfterJavaFieldAnnotations: false
+Language: Java
+AlignAfterOpenBracket: false
 JavaImportGroups: ['org.godotengine', 'android', 'androidx', 'com.android', 'com.google', 'java', 'javax']
 ---
-### JSON specific config ###
 Language: Json
+AlignAfterOpenBracket: false
 IndentWidth: 2
 UseTab: Never
 ...


### PR DESCRIPTION
Updates the clang-format configuration to use current option names and removes the stale commented defaults inherited from Clang 13. The existing formatting behavior and language-specific settings remain intact, while Clang 19 and Clang 22 now produce identical, churn-free output.