### PR TITLE
ref(native): Use sentry-native Wine and Proton context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Deprecate the `SentryOptions.enable_logs` and `SentryOptions.enable_metrics` options and their Project Settings counterparts, to be removed in v3; logs and metrics are only sent when you use `SentrySDK.logger` or `SentrySDK.metrics`, or enable automatic log capture with `godot_logger.log_mask` ([#869](https://github.com/getsentry/sentry-godot/pull/869))
 - The bundled user feedback form now waits a frame for the UI to hide before capturing, so a screenshot attached to the feedback shows the game instead of the form and the text typed into it ([#880](https://github.com/getsentry/sentry-godot/pull/880))
+- Report Wine and Proton metadata through the Native SDK's separate `wine` runtime context instead of the generic `runtime` context ([#890](https://github.com/getsentry/sentry-godot/pull/890), [sentry-native#1995](https://github.com/getsentry/sentry-native/pull/1995))
 
 ### Fixes
 

--- a/src/sentry/contexts.cpp
+++ b/src/sentry/contexts.cpp
@@ -384,7 +384,7 @@ Dictionary make_os_context_override() {
 	} else if (info.is_bazzite) {
 		os_context["name"] = "Bazzite";
 		prefer_distro_version = true;
-	} else if (info.wine_proton.is_wine) {
+	} else if (info.is_wine) {
 		// Windows build running on other Linux distro using Wine/Proton.
 		os_context["name"] = "Linux";
 		prefer_distro_version = false;
@@ -431,23 +431,6 @@ Dictionary make_os_context_override() {
 #endif // SDK_NATIVE
 
 	return os_context;
-}
-
-Dictionary make_runtime_context() {
-	Dictionary runtime_context;
-
-#ifdef SDK_NATIVE
-	const auto &info = sentry::native::detect_platform();
-	if (info.wine_proton.is_wine) {
-		const String &runtime_name = info.wine_proton.runtime_name;
-		runtime_context["name"] = !runtime_name.is_empty() ? runtime_name : "Wine";
-		if (!info.wine_proton.version.is_empty()) {
-			runtime_context["version"] = info.wine_proton.version;
-		}
-	}
-#endif // SDK_NATIVE
-
-	return runtime_context;
 }
 
 Dictionary make_godot_engine_context() {

--- a/src/sentry/contexts.h
+++ b/src/sentry/contexts.h
@@ -24,7 +24,6 @@ Dictionary make_gpu_context();
 Dictionary make_culture_context();
 Dictionary make_display_context();
 Dictionary make_os_context_override();
-Dictionary make_runtime_context();
 Dictionary make_godot_engine_context();
 Dictionary make_environment_context();
 Dictionary make_performance_context();

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -481,7 +481,7 @@ void NativeSDK::init() {
 	// Enable crashpad stack capture adjustment for Wine/Proton compatibility.
 	// Under Wine, TEB stack bounds may be incorrect, causing oversized captures.
 	const auto &platform_info = sentry::native::detect_platform();
-	if (platform_info.wine_proton.is_wine) {
+	if (platform_info.is_wine) {
 		sentry::logging::print_debug("Enabling Crashpad stack capture limit for Wine/Proton compatibility");
 		sentry_options_set_crashpad_limit_stack_capture_to_sp(options, 1);
 	}

--- a/src/sentry/native/platform_detection.cpp
+++ b/src/sentry/native/platform_detection.cpp
@@ -14,109 +14,17 @@ namespace {
 
 #ifdef WINDOWS_ENABLED
 
-void _detect_wine(sentry::native::WineProtonInfo &r_info) {
-	// Detect Wine via wine_get_version export from ntdll.dll.
+bool _detect_wine() {
 	HMODULE h_ntdll = GetModuleHandleW(L"ntdll.dll");
-	if (h_ntdll != nullptr) {
-		typedef const char *(CDECL * wine_get_version_t)(void);
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4191) // unsafe conversion from FARPROC
-#endif
-		wine_get_version_t wine_get_version =
-				reinterpret_cast<wine_get_version_t>(GetProcAddress(h_ntdll, "wine_get_version"));
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
-		if (wine_get_version != nullptr) {
-			const char *version = wine_get_version();
-			if (version == nullptr) {
-				version = "";
-			}
-			r_info.is_wine = true;
-			r_info.runtime_name = "Wine";
-			r_info.version = String::utf8(version);
-
-			sentry::logging::print_debug("Detected Wine version: ", r_info.version);
-		}
-	}
-}
-
-// Detects the precise Proton version from the filesystem.
-// Approach: STEAM_COMPAT_DATA_PATH/config_info contains paths to the Proton install directory.
-// The Proton install directory contains a "version" file with format: "<timestamp> <git-tag>".
-void _detect_proton(const String &p_steam_compat_path, sentry::native::WineProtonInfo &r_info) {
-	if (p_steam_compat_path.is_empty()) {
-		return;
+	if (h_ntdll == nullptr) {
+		return false;
 	}
 
-	// Read config_info to find the Proton install directory.
-	Ref<FileAccess> f = FileAccess::open("Z:" + p_steam_compat_path + "/config_info", FileAccess::READ);
-	if (!f.is_valid()) {
-		return;
+	const bool is_wine = GetProcAddress(h_ntdll, "wine_get_version") != nullptr;
+	if (is_wine) {
+		sentry::logging::print_debug("Detected Wine/Proton compatibility environment.");
 	}
-
-	f->get_line(); // Skip line 1 (CURRENT_PREFIX_VERSION).
-	String fonts_dir = f->get_line().strip_edges(); // Line 2: Proton fonts directory path.
-	f.unref();
-
-	// Extract Proton root by stripping the known suffix.
-	// Modern Proton uses "files/", older versions used "dist/".
-	String proton_root;
-	if (fonts_dir.ends_with("/files/share/fonts/")) {
-		proton_root = fonts_dir.trim_suffix("/files/share/fonts/");
-	} else if (fonts_dir.ends_with("/dist/share/fonts/")) {
-		proton_root = fonts_dir.trim_suffix("/dist/share/fonts/");
-	} else {
-		sentry::logging::print_debug("Unexpected config_info fonts path: ", fonts_dir);
-		return;
-	}
-
-	// Read the version file from the compatibility tool install directory.
-	Ref<FileAccess> vf = FileAccess::open("Z:" + proton_root + "/version", FileAccess::READ);
-	if (!vf.is_valid()) {
-		return;
-	}
-	String version_line = vf->get_line().strip_edges();
-	vf.unref();
-
-	// Format: "<timestamp> <git-tag>", e.g., "1769167055 proton-10.0-4".
-	String git_tag = version_line.get_slice(" ", 1).strip_edges();
-	if (git_tag.is_empty()) {
-		return;
-	}
-
-	// Determine the runtime name and version.
-	if (FileAccess::file_exists("Z:" + proton_root + "/proton")) {
-		r_info.is_proton = true;
-		if (git_tag.begins_with("proton-")) {
-			// proton-10.0-4 -> "Proton" "10.0-4"
-			r_info.runtime_name = "Proton";
-			r_info.version = git_tag.trim_prefix("proton-");
-		} else if (git_tag.begins_with("experimental-")) {
-			// experimental-10.0-20260113 -> "Proton Experimental" "10.0-20260113"
-			r_info.runtime_name = "Proton Experimental";
-			r_info.version = git_tag.trim_prefix("experimental-");
-		} else if (git_tag.begins_with("GE-Proton")) {
-			// GE-Proton9-27 -> "GE-Proton" "9-27"
-			r_info.runtime_name = "GE-Proton";
-			r_info.version = git_tag.trim_prefix("GE-Proton");
-		} else if (git_tag.begins_with("hotfix-")) {
-			// hotfix-20251031 -> "Proton Hotfix" "20251031"
-			r_info.runtime_name = "Proton Hotfix";
-			r_info.version = git_tag.trim_prefix("hotfix-");
-		} else {
-			// Unrecognized Proton-like tool.
-			r_info.runtime_name = "Proton Custom";
-			r_info.version = git_tag;
-		}
-	} else {
-		// Other Wine-like tool: tag might still be more informative.
-		r_info.version = git_tag;
-	}
-
-	sentry::logging::print_debug("Detected Steam compatibility tool: ", r_info.runtime_name, " ", r_info.version);
+	return is_wine;
 }
 
 // Read a REG_SZ string value from an open registry key.
@@ -131,21 +39,6 @@ String _read_registry_string(HKEY p_key, LPCWSTR p_value_name) {
 	return String();
 }
 
-sentry::native::WineProtonInfo _detect_wine_proton() {
-	sentry::native::WineProtonInfo info;
-
-	_detect_wine(info);
-
-	if (info.is_wine) {
-		String steam_compat_path = OS::get_singleton()->get_environment("STEAM_COMPAT_DATA_PATH");
-		if (!steam_compat_path.is_empty()) {
-			sentry::logging::print_debug("Detected Steam compatibility environment.");
-			_detect_proton(steam_compat_path, info);
-		}
-	}
-
-	return info;
-}
 #endif // WINDOWS_ENABLED
 
 String _read_rootfs_file(const String &p_rootfs_path) {
@@ -332,8 +225,8 @@ const PlatformInfo &detect_platform() {
 		cached_info.distro = _read_distro_info();
 		cached_info.kernel_version = _read_kernel_version();
 #elif defined(WINDOWS_ENABLED)
-		cached_info.wine_proton = _detect_wine_proton();
-		if (cached_info.wine_proton.is_wine) {
+		cached_info.is_wine = _detect_wine();
+		if (cached_info.is_wine) {
 			cached_info.distro = _read_distro_info();
 			cached_info.kernel_version = _read_kernel_version();
 		}

--- a/src/sentry/native/platform_detection.h
+++ b/src/sentry/native/platform_detection.h
@@ -6,13 +6,6 @@ using namespace godot;
 
 namespace sentry::native {
 
-struct WineProtonInfo {
-	bool is_wine = false;
-	bool is_proton = false;
-	String version; // "10.0-4", "10.0-20260113", "9-27"
-	String runtime_name; // "Wine", "Proton", "Proton Experimental", "GE-Proton"
-};
-
 struct DistroInfo {
 	String name; // "SteamOS", "Bazzite"
 	String pretty_name; // "Ubuntu 24.04.3 LTS"
@@ -32,9 +25,9 @@ struct ProductInfo {
 
 struct PlatformInfo {
 	ProductInfo product;
-	WineProtonInfo wine_proton;
 	DistroInfo distro;
 	String kernel_version;
+	bool is_wine = false;
 	bool is_steamos = false;
 	bool is_bazzite = false;
 	bool is_steam = false;

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -398,7 +398,7 @@ void SentrySDK::_init_contexts() {
 	internal_sdk->set_context("godot_engine", sentry::contexts::make_godot_engine_context());
 	internal_sdk->set_context("environment", sentry::contexts::make_environment_context());
 
-	// Linux distro and Proton/Wine compatibility layer enrichment.
+	// Linux distro and Steam.
 #if defined(SDK_NATIVE)
 	{
 		// Contexts.
@@ -406,11 +406,6 @@ void SentrySDK::_init_contexts() {
 		if (!os_override.is_empty()) {
 			internal_sdk->set_context("os", os_override);
 		}
-		Dictionary runtime_ctx = sentry::contexts::make_runtime_context();
-		if (!runtime_ctx.is_empty()) {
-			internal_sdk->set_context("runtime", runtime_ctx);
-		}
-
 		// Tags.
 		const auto &platform_info = sentry::native::detect_platform();
 		if (platform_info.is_steam) {


### PR DESCRIPTION
Delegate Wine and Proton runtime metadata to sentry-native 0.16.4, which reports it in a dedicated `wine` context and avoids a competing generic `runtime` context in sentry-godot. Keep minimal Wine detection for Linux host enrichment and the Crashpad stack-capture workaround.

- Refs https://github.com/getsentry/sentry-native/pull/1995
