### PR TITLE
feat(spans): Add SentrySDK.with_span()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Not supported on macOS and iOS yet, where feedback is still sent but the callback never runs
 - Add Spans support to the GDScript API for measuring operations and grouping telemetry captured while they run ([#863](https://github.com/getsentry/sentry-godot/pull/863), [#875](https://github.com/getsentry/sentry-godot/pull/875), [#886](https://github.com/getsentry/sentry-godot/pull/886))
   - `SentrySDK.start_span()` starts a span and makes it active, and `SentrySDK.get_active_span()` returns the active span for the calling thread
+  - `SentrySDK.with_span()` runs a callable with an active span and ends it on return ([#892](https://github.com/getsentry/sentry-godot/pull/892))
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -270,7 +270,7 @@
 				Nested calls create nested spans. When the callable returns, the enclosing active span and scope are restored.
 				[b]Note:[/b] The span covers the synchronous part of [param callable] only. If the callable awaits, the span is ended at the first [code]await[/code] and a warning is printed.
 				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code].
-				[b]Platform support:[/b] Spans are not supported on macOS, iOS, Android, or Web yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
+				[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -82,7 +82,7 @@
 			<return type="SentrySpan" />
 			<description>
 				Returns the span currently bound to the calling thread's current scope, or [code]null[/code] if no span is active. Events captured while a span is active are associated with that span's trace context.
-				Active spans are created by [method SentrySDK.start_span]. When an active span ends, the SDK restores the previously active span, if any.
+				Active spans are created by [method SentrySDK.start_span] and [method SentrySDK.with_span]. When an active span ends, the SDK restores the previously active span, if any.
 				[b]Note:[/b] The returned span belongs to the calling thread. Span methods must be called from the thread that created the span.
 			</description>
 		</method>
@@ -251,6 +251,26 @@
 				For more information, see [SentryScope] class.
 				[b]Note:[/b] The fork covers the synchronous part of [param callable] only. If the callable awaits, the fork is discarded at the first [code]await[/code] and a warning is printed.
 				[b]Note:[/b] The SDK does not support scopes on macOS and iOS yet. On those platforms it still captures telemetry, but discards the data written to the forked scope and prints a warning.
+			</description>
+		</method>
+		<method name="with_span">
+			<return type="Variant" />
+			<param index="0" name="name" type="String" />
+			<param index="1" name="callable" type="Callable" />
+			<description>
+				Starts an active span named [param name], calls [param callable] with that [SentrySpan], ends the span when the callable returns, and returns the callable's return value. If [param name] is empty, the SDK prints an error and runs [param callable] with a no-op span.
+				Use this helper when the operation fits in one synchronous callable. Use [method SentrySDK.start_span] instead when you need to set initial attributes, choose a parent span, keep a span open across multiple functions, or create an inactive span.
+				[codeblock]
+				var result: Variant = SentrySDK.with_span("generate_chunk", func(span: SentrySpan) -&gt; Variant:
+					span.set_attribute("chunk_x", chunk_x)
+					span.set_attribute("chunk_y", chunk_y)
+					return generate_chunk(chunk_x, chunk_y)
+				)
+				[/codeblock]
+				Nested calls create nested spans. When the callable returns, the enclosing active span and scope are restored.
+				[b]Note:[/b] The span covers the synchronous part of [param callable] only. If the callable awaits, the span is ended at the first [code]await[/code] and a warning is printed.
+				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code].
+				[b]Platform support:[/b] Spans are not supported on macOS, iOS, Android, or Web yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -5,17 +5,17 @@
 	</brief_description>
 	<description>
 		A span measures an operation and records its duration, outcome, and attributes. Nested spans show how work is divided within a trace.
-		Create spans with [method SentrySDK.start_span]. Telemetry captured on the same thread while a span is active carries that span's trace context.
+		Create spans with [method SentrySDK.start_span] or [method SentrySDK.with_span]. Telemetry captured on the same thread while a span is active carries that span's trace context.
 		Use [method set_attribute] or [method set_attributes] to add details to the operation, [method set_status] to set its outcome, and [method end] to end the span.
 		[codeblock]
-		var span := SentrySDK.start_span("load_level")
-		span.set_attribute("level", level_name)
-		load_level(level_name)
-		span.set_status(SentrySpan.SPAN_STATUS_OK)
-		span.end()
+		SentrySDK.with_span("load_level", func(span: SentrySpan) -&gt; void:
+			span.set_attribute("level", level_name)
+			load_level(level_name)
+			span.set_status(SentrySpan.SPAN_STATUS_OK)
+		)
 		[/codeblock]
 		Call [method end] on every span created with [method SentrySDK.start_span]. End all child spans before their root span. An unended root span is not sent.
-		Each unended active span also leaves a scope fork on the calling thread; the SDK warns if the scope stack grows unusually deep.
+		Each unended active span also leaves a scope fork on the calling thread; the SDK warns if the scope stack grows unusually deep. [method SentrySDK.with_span] ends its span automatically.
 		Set [code]sentry.op[/code] to categorize the work the span measures, such as [code]asset.load[/code] or [code]db.query[/code]. Sentry groups and filters spans by operation. Pass it in the [code]attributes[/code] dictionary of [method SentrySDK.start_span], since some platforms fix the operation when the span starts.
 		[b]Note:[/b] Spans are thread-local. Call span methods only from the thread that created the span.
 		[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -282,3 +282,99 @@ func test_span_stays_on_the_current_trace() -> void:
 		.at("/contexts/trace/trace_id") \
 		.is_equal(_trace_id(json_before)) \
 		.verify()
+
+
+func test_with_span_stamps_events_and_clears_the_slot() -> void:
+	var json_before: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	SentrySDK.with_span("test.with_span", func(span: SentrySpan) -> void:
+		assert_object(SentrySDK.get_active_span()).is_same(span)
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	assert_object(SentrySDK.get_active_span()).is_null()
+
+	var json_inside: String = await wait_for_captured_event_json()
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_inside).describe("events captured inside with_span carry its span") \
+		.at("/contexts/trace/span_id") \
+		.is_not_equal(_span_id(json_before)) \
+		.verify()
+
+	assert_json(json_after).describe("events captured after with_span returns carry the same id as before it started") \
+		.at("/contexts/trace/span_id") \
+		.is_equal(_span_id(json_before)) \
+		.verify()
+
+
+func test_with_span_tolerates_the_callable_ending_the_span() -> void:
+	SentrySDK.with_scope(func(scope: SentryScope) -> void:
+		scope.set_tag("enclosing", "scope")
+
+		SentrySDK.with_span("test.with_span_early_end", func(span: SentrySpan) -> void:
+			span.end()
+			assert_object(SentrySDK.get_active_span()).is_null()
+			)
+
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+
+	var json_after: String = await wait_for_captured_event_json()
+
+	assert_json(json_after).describe("a callable that ends its own span leaves the enclosing scope intact") \
+		.at("/tags") \
+		.must_contain("enclosing", "scope") \
+		.verify()
+
+
+func test_with_span_returns_the_callable_result() -> void:
+	var result: Variant = SentrySDK.with_span("test.with_span_result", func(_span: SentrySpan) -> int:
+		return 42
+		)
+
+	assert_int(result).is_equal(42)
+
+
+func test_nested_with_span_stamps_with_the_inner_span() -> void:
+	SentrySDK.with_span("test.with_span_outer", func(outer: SentrySpan) -> void:
+		SentrySDK.capture_event(SentrySDK.create_event())
+		SentrySDK.with_span("test.with_span_inner", func(_inner: SentrySpan) -> void:
+			SentrySDK.capture_event(SentrySDK.create_event())
+			)
+		assert_object(SentrySDK.get_active_span()).is_same(outer)
+		)
+
+	var json_outer: String = await wait_for_captured_event_json()
+	var json_inner: String = await wait_for_captured_event_json()
+
+	assert_json(json_inner).describe("a nested with_span stamps events with the inner span") \
+		.at("/contexts/trace/span_id") \
+		.is_not_equal(_span_id(json_outer)) \
+		.verify()
+
+
+func test_with_span_inside_a_started_span_nests_under_it() -> void:
+	var span := SentrySDK.start_span("test.manual_parent")
+	SentrySDK.capture_event(SentrySDK.create_event())
+
+	SentrySDK.with_span("test.with_span_child", func(_child: SentrySpan) -> void:
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	assert_object(SentrySDK.get_active_span()).is_same(span)
+
+	SentrySDK.capture_event(SentrySDK.create_event())
+	span.end()
+
+	var json_in_parent: String = await wait_for_captured_event_json()
+	var json_in_child: String = await wait_for_captured_event_json()
+	var json_after_child: String = await wait_for_captured_event_json()
+
+	assert_json(json_in_child).describe("with_span inside an active span stamps with its own span") \
+		.at("/contexts/trace/span_id") \
+		.is_not_equal(_span_id(json_in_parent)) \
+		.verify()
+
+	assert_json(json_after_child).describe("the enclosing span stamps again once with_span returns") \
+		.at("/contexts/trace/span_id") \
+		.is_equal(_span_id(json_in_parent)) \
+		.verify()

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -224,6 +224,21 @@ void SentrySDK::notify_span_ended(const SentrySpan *p_span) {
 	}
 }
 
+Variant SentrySDK::with_span(const String &p_name, const Callable &p_callable) {
+	Ref<SentrySpan> active_span = start_span(p_name);
+	Variant result = p_callable.call(active_span);
+	static bool first_warning = true; // acceptable race: several warnings are OK.
+	if (first_warning) {
+		if (Object *obj = result.get_validated_object();
+				unlikely(obj != nullptr && obj->get_class() == "GDScriptFunctionState")) {
+			first_warning = false;
+			WARN_PRINT("Sentry: with_span() does not support await - the span is only active until the first await.");
+		}
+	}
+	active_span->end();
+	return result;
+}
+
 Ref<SentrySpan> SentrySDK::get_active_span() const {
 	return get_current_scope()->get_span();
 }
@@ -655,6 +670,7 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("with_scope", "callable"), &SentrySDK::with_scope);
 
 	ClassDB::bind_method(D_METHOD("start_span", "name", "attributes", "parent_span", "active"), &SentrySDK::start_span, DEFVAL(Dictionary()), DEFVAL(SentrySpan::unassigned()), DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("with_span", "name", "callable"), &SentrySDK::with_span);
 	ClassDB::bind_method(D_METHOD("get_active_span"), &SentrySDK::get_active_span);
 
 	// Hidden API methods -- used in testing.

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -138,6 +138,7 @@ public:
 
 	Ref<SentrySpan> start_span(const String &p_name, const Dictionary &p_attributes = {},
 			const Ref<SentrySpan> &p_parent_span = SentrySpan::unassigned(), bool p_active = true);
+	Variant with_span(const String &p_name, const Callable &p_callable);
 	Ref<SentrySpan> get_active_span() const;
 
 	// * Hidden API methods -- used in testing


### PR DESCRIPTION
Adds `SentrySDK.with_span()`, a convenience wrapper over `start_span()` that starts an active span, calls a callable with that span, ends it when the callable returns, and hands back whatever the callable returned. It fits operations that live in a single synchronous callable, while `start_span()` stays the right choice when the span needs initial attributes, an explicit parent, an inactive mode, or a lifetime spanning several functions. Nested calls nest their spans, and the enclosing span and scope are restored on return. Split out of #863 so it can be reviewed on its own.

- Refs #861
- Docs PR https://github.com/getsentry/sentry-docs/pull/19210

Because the span ends the moment the callable returns, it only covers the callable's synchronous part. A callable that awaits hands control back at the first `await` and returns a coroutine state object rather than its eventual result, so the span ends early. The SDK detects that case and prints a one-time warning.
