### PR TITLE
feat(web): Add trace lifecycle option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
-  - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans (Web-only currently)
+  - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans ([#895](https://github.com/getsentry/sentry-godot/pull/895))
   - Not supported on macOS, iOS, or Android yet, where the SDK returns a no-op span with a warning
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
+  - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans (Web-only currently)
   - Not supported on macOS, iOS, or Android yet, where the SDK returns a no-op span with a warning
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
-  - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans ([#895](https://github.com/getsentry/sentry-godot/pull/895))
+  - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans; it currently only affects Web ([#895](https://github.com/getsentry/sentry-godot/pull/895))
   - Not supported on macOS, iOS, or Android yet, where the SDK returns a no-op span with a warning
 
 ### Improvements

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -177,6 +177,10 @@
 		<member name="shutdown_timeout_ms" type="int" setter="set_shutdown_timeout_ms" getter="get_shutdown_timeout_ms" default="2000">
 			The maximum time in milliseconds the SDK will wait for pending events to be sent when [method SentrySDK.close] is called. If the timeout expires, the SDK will perform a forced shutdown and any unsent events may be lost.
 		</member>
+		<member name="trace_lifecycle" type="int" setter="set_trace_lifecycle" getter="get_trace_lifecycle" enum="SentryOptions.TraceLifecycle" default="0">
+			Selects whether the SDK sends traces as transactions or streams completed spans. The default is [constant TRACE_LIFECYCLE_STATIC].
+			[b]Platform support:[/b] This option currently only affects Web. Other platforms ignore it.
+		</member>
 		<member name="traces_sample_rate" type="float" setter="set_traces_sample_rate" getter="get_traces_sample_rate" default="0.0">
 			Configures the sample rate for performance traces, in the range of 0.0 to 1.0. The default is 0.0, which prevents spans from being sent. If set to 1.0, all traces are sent. If set to 0.1, approximately 10% of traces are sent.
 			The sampling decision is made randomly per trace, so either all spans in a trace are sent or none of them are. See [method SentrySDK.start_span] for information on recording spans.
@@ -184,6 +188,12 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="TRACE_LIFECYCLE_STATIC" value="0" enum="TraceLifecycle">
+			Sends each trace as a transaction when its root span ends.
+		</constant>
+		<constant name="TRACE_LIFECYCLE_STREAM" value="1" enum="TraceLifecycle">
+			Streams completed spans independently.
+		</constant>
 		<constant name="MASK_NONE" value="0" enum="GodotLoggerEventMask" is_bitfield="true">
 			No logger errors or messages will be captured.
 		</constant>

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -180,6 +180,7 @@
 		<member name="trace_lifecycle" type="int" setter="set_trace_lifecycle" getter="get_trace_lifecycle" enum="SentryOptions.TraceLifecycle" default="0">
 			Selects whether the SDK sends traces as transactions or streams completed spans. The default is [constant TRACE_LIFECYCLE_STATIC].
 			[b]Platform support:[/b] This option currently only affects Web. Other platforms ignore it.
+			[b]Note:[/b] Streaming sends spans in the Span v2 format. Sentry SaaS currently ingests this format, but self-hosted Sentry does not.
 		</member>
 		<member name="traces_sample_rate" type="float" setter="set_traces_sample_rate" getter="get_traces_sample_rate" default="0.0">
 			Configures the sample rate for performance traces, in the range of 0.0 to 1.0. The default is 0.0, which prevents spans from being sent. If set to 1.0, all traces are sent. If set to 0.1, approximately 10% of traces are sent.

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -85,6 +85,12 @@ func test_traces_sample_rate() -> void:
 	assert_float(options.traces_sample_rate).is_equal_approx(0.5, 0.01)
 
 
+func test_trace_lifecycle() -> void:
+	assert_int(options.trace_lifecycle).is_equal(SentryOptions.TRACE_LIFECYCLE_STATIC)
+	options.trace_lifecycle = SentryOptions.TRACE_LIFECYCLE_STREAM
+	assert_int(options.trace_lifecycle).is_equal(SentryOptions.TRACE_LIFECYCLE_STREAM)
+
+
 ## SentryOptions.max_breadcrumbs should be set to the specified value.
 func test_max_breadcrumbs() -> void:
 	options.max_breadcrumbs = 42

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -149,6 +149,7 @@ class SentryBridge {
     environment: string,
     sampleRate: number,
     tracesSampleRate: number,
+    traceLifecycle: number,
     maxBreadcrumbs: number,
     sendDefaultPii: boolean,
     sdkVersion: string,
@@ -165,6 +166,7 @@ class SentryBridge {
       environment,
       sampleRate,
       tracesSampleRate,
+      traceLifecycle: traceLifecycle === 1 ? "stream" : "static",
       maxBreadcrumbs,
       sendDefaultPii,
       _metadata: {
@@ -183,6 +185,9 @@ class SentryBridge {
           return !excludedIntegrations.includes(integration.name);
         });
         filtered.push(wasmIntegration());
+        if (traceLifecycle === 1) {
+          filtered.push(Sentry.spanStreamingIntegration());
+        }
         filtered.push(
           Sentry.breadcrumbsIntegration({
             console: false, // very noisy in Godot SDK

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -45,6 +45,11 @@ const SPAN_STATUS_ERROR = 1;
 const OTEL_CODE_OK = 1;
 const OTEL_CODE_ERROR = 2;
 
+enum TraceLifecycle {
+  Static = 0,
+  Stream = 1,
+}
+
 // Handed to the C++ layer to have it read one file; it leaves the bytes unset if the read fails.
 interface AttachmentRequest {
   path: string;
@@ -105,6 +110,8 @@ function makeUser(id: string, username: string, email: string, ip: string): User
 // *** SentryBridge
 
 class SentryBridge {
+  public readonly TraceLifecycle = TraceLifecycle;
+
   constructor() {}
 
   private _byteStore = new IdStore<Uint8Array>();
@@ -149,7 +156,7 @@ class SentryBridge {
     environment: string,
     sampleRate: number,
     tracesSampleRate: number,
-    traceLifecycle: number,
+    traceLifecycle: TraceLifecycle,
     maxBreadcrumbs: number,
     sendDefaultPii: boolean,
     sdkVersion: string,
@@ -166,7 +173,7 @@ class SentryBridge {
       environment,
       sampleRate,
       tracesSampleRate,
-      traceLifecycle: traceLifecycle === 1 ? "stream" : "static",
+      traceLifecycle: traceLifecycle === TraceLifecycle.Stream ? "stream" : "static",
       maxBreadcrumbs,
       sendDefaultPii,
       _metadata: {
@@ -185,7 +192,7 @@ class SentryBridge {
           return !excludedIntegrations.includes(integration.name);
         });
         filtered.push(wasmIntegration());
-        if (traceLifecycle === 1) {
+        if (traceLifecycle === TraceLifecycle.Stream) {
           filtered.push(Sentry.spanStreamingIntegration());
         }
         filtered.push(

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -8,6 +8,9 @@ console.log("🔍 Testing Final Sentry Bridge Bundle...\n");
 let failureCount = 0;
 let passCount = 0;
 
+const TRACE_LIFECYCLE_STATIC = 0;
+const TRACE_LIFECYCLE_STREAM = 1;
+
 function assert(condition, message) {
 	if (!condition) {
 		throw new Error(message || "Assertion failed");
@@ -130,9 +133,13 @@ try {
 		const beforeSendFeedback = (event) => {
 			feedbackEvents.push(event);
 		};
+		const initBridge = (traceLifecycle) => {
+			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false,
+					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, 100, false, "0.1.0");
+		};
 
 		runTest("init()", () => {
-			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false, "1.0.0", "1", "production", 1.0, 1.0, 100, false, "0.1.0");
+			initBridge(TRACE_LIFECYCLE_STREAM);
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during
@@ -500,6 +507,16 @@ try {
 
 		runTest("removeAttribute()", () => {
 			bridge.removeAttribute("test-attr");
+		});
+
+		runTest("static trace lifecycle", () => {
+			bridge.close(2000);
+			initBridge(TRACE_LIFECYCLE_STATIC);
+			const client = bridge.createScope().getClient();
+			assertEqual(client.getOptions().traceLifecycle, "static",
+					"init should preserve the static trace lifecycle");
+			assertEqual(client.getIntegrationByName("SpanStreaming"), undefined,
+					"init should not register span streaming in static mode");
 		});
 
 		runTest("close()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -320,10 +320,12 @@ try {
 			assert(cleared.getClient() !== undefined, "scopeClear should keep the client bound");
 		});
 
-		runTest("spans become transactions", () => {
+		runTest("spans stream instead of becoming transactions", () => {
 			const client = bridge.createScope().getClient();
-			assertEqual(client.getIntegrationByName("SpanStreaming"), undefined,
-					"init should not register span streaming");
+			assertEqual(client.getOptions().traceLifecycle, "stream",
+					"init should put the client on the streaming trace lifecycle");
+			assert(client.getIntegrationByName("SpanStreaming"),
+					"init should register the integration that streams ended spans");
 		});
 
 		runTest("startSpan()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -8,9 +8,6 @@ console.log("🔍 Testing Final Sentry Bridge Bundle...\n");
 let failureCount = 0;
 let passCount = 0;
 
-const TRACE_LIFECYCLE_STATIC = 0;
-const TRACE_LIFECYCLE_STREAM = 1;
-
 function assert(condition, message) {
 	if (!condition) {
 		throw new Error(message || "Assertion failed");
@@ -139,7 +136,7 @@ try {
 		};
 
 		runTest("init()", () => {
-			initBridge(TRACE_LIFECYCLE_STREAM);
+			initBridge(bridge.TraceLifecycle.Stream);
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during
@@ -511,7 +508,7 @@ try {
 
 		runTest("static trace lifecycle", () => {
 			bridge.close(2000);
-			initBridge(TRACE_LIFECYCLE_STATIC);
+			initBridge(bridge.TraceLifecycle.Static);
 			const client = bridge.createScope().getClient();
 			assertEqual(client.getOptions().traceLifecycle, "static",
 					"init should preserve the static trace lifecycle");

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -365,6 +365,7 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_environment().utf8(),
 			SENTRY_OPTIONS()->get_sample_rate(),
 			SENTRY_OPTIONS()->get_traces_sample_rate(),
+			(int)SENTRY_OPTIONS()->get_trace_lifecycle(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),
 			SENTRY_OPTIONS()->is_send_default_pii_enabled(),
 			SENTRY_GODOT_SDK_VERSION);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -128,6 +128,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(sentry::make_level_enum_property("sentry/options/diagnostic_level"), p_options->diagnostic_level);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate, false);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/traces_sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->traces_sample_rate, false);
+	_define_setting(PropertyInfo(Variant::INT, "sentry/options/trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), p_options->trace_lifecycle, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/shutdown_timeout_ms", PROPERTY_HINT_RANGE, "0,30000"), p_options->shutdown_timeout_ms, false);
 	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -218,6 +219,7 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 
 	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/sample_rate", p_options->sample_rate);
 	p_options->traces_sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/traces_sample_rate", p_options->traces_sample_rate);
+	p_options->trace_lifecycle = (SentryOptions::TraceLifecycle)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/trace_lifecycle", p_options->trace_lifecycle);
 	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/options/max_breadcrumbs", p_options->max_breadcrumbs);
 	p_options->shutdown_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/shutdown_timeout_ms", p_options->shutdown_timeout_ms);
 	p_options->send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -401,6 +403,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "environment"), set_environment, get_environment);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "traces_sample_rate"), set_traces_sample_rate, get_traces_sample_rate);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), set_trace_lifecycle, get_trace_lifecycle);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_breadcrumbs"), set_max_breadcrumbs, get_max_breadcrumbs);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "shutdown_timeout_ms", PROPERTY_HINT_RANGE, "0,30000"), set_shutdown_timeout_ms, get_shutdown_timeout_ms);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "send_default_pii"), set_send_default_pii, is_send_default_pii_enabled);
@@ -423,6 +426,9 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "experimental", PROPERTY_HINT_TYPE_STRING, "SentryExperimental", PROPERTY_USAGE_NONE), get_experimental);
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "android", PROPERTY_HINT_TYPE_STRING, "SentryAndroidOptions", PROPERTY_USAGE_NONE), get_android);
 	BIND_PROPERTY_READONLY(SentryOptions, PropertyInfo(Variant::OBJECT, "godot_logger", PROPERTY_HINT_TYPE_STRING, "SentryGodotLoggerOptions", PROPERTY_USAGE_NONE), get_godot_logger);
+
+	BIND_ENUM_CONSTANT(TRACE_LIFECYCLE_STATIC);
+	BIND_ENUM_CONSTANT(TRACE_LIFECYCLE_STREAM);
 
 	{
 		using namespace sentry;

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -96,6 +96,11 @@ public:
 	using GodotErrorType = sentry::GodotErrorType;
 	using GodotLoggerEventMask = sentry::GodotLoggerEventMask;
 
+	enum TraceLifecycle {
+		TRACE_LIFECYCLE_STATIC,
+		TRACE_LIFECYCLE_STREAM
+	};
+
 private:
 	enum class DebugMode {
 		DEBUG_OFF = 0,
@@ -114,6 +119,7 @@ private:
 	String environment = "{auto}";
 	double sample_rate = 1.0;
 	double traces_sample_rate = 0.0;
+	TraceLifecycle trace_lifecycle = TRACE_LIFECYCLE_STATIC;
 	int max_breadcrumbs = 100;
 	int shutdown_timeout_ms = 2000;
 	bool send_default_pii = false;
@@ -185,6 +191,9 @@ public:
 
 	_FORCE_INLINE_ double get_traces_sample_rate() const { return traces_sample_rate; }
 	_FORCE_INLINE_ void set_traces_sample_rate(double p_traces_sample_rate) { traces_sample_rate = p_traces_sample_rate; }
+
+	_FORCE_INLINE_ TraceLifecycle get_trace_lifecycle() const { return trace_lifecycle; }
+	_FORCE_INLINE_ void set_trace_lifecycle(TraceLifecycle p_trace_lifecycle) { trace_lifecycle = p_trace_lifecycle; }
 
 	_FORCE_INLINE_ int get_max_breadcrumbs() const { return max_breadcrumbs; }
 	_FORCE_INLINE_ void set_max_breadcrumbs(int p_max_breadcrumbs) { max_breadcrumbs = p_max_breadcrumbs; }
@@ -300,4 +309,5 @@ public:
 
 } // namespace sentry
 
+VARIANT_ENUM_CAST(sentry::SentryOptions::TraceLifecycle);
 VARIANT_BITFIELD_CAST(sentry::SentryOptions::GodotLoggerEventMask);

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -96,6 +96,8 @@ TEST_SUITE("[.NET] Options interop") {
 				crossed.insert(option_name(option));
 			}
 			const HashSet<String> not_crossed = {
+				// Only affects the JavaScript SDK on Web.
+				"trace_lifecycle",
 				// Deprecated no-ops.
 				"enable_logs", "enable_metrics",
 				// Deprecated aliases for the properties above.


### PR DESCRIPTION
This adds `SentryOptions.trace_lifecycle` following Sentry’s [span implementation spec](https://develop.sentry.dev/sdk/telemetry/spans/implementation/), allowing users to choose how traces are sent. Static mode remains the default and sends each trace as a transaction when its root span ends, while stream mode sends completed spans individually. The option currently only takes effect on Web, other platforms to be added in the future when they support streaming spans.

- Refs #861
- Docs PR https://github.com/getsentry/sentry-docs/pull/19210
