### PR TITLE
test(spans): Add E2E coverage for spans

### DIFF
--- a/project/cli/cli_commands.gd
+++ b/project/cli/cli_commands.gd
@@ -41,6 +41,7 @@ func _register_commands() -> void:
 	_parser.add_command("attachment-capture", _cmd_attachment_capture, "Capture a message with custom attachments")
 	_parser.add_command("log-capture", _cmd_log_capture, "Capture a structured log to Sentry")
 	_parser.add_command("metric-capture", _cmd_metric_capture, "Capture metrics to Sentry")
+	_parser.add_command("span-capture", _cmd_span_capture, "Capture a trace with a span tree")
 	_parser.add_command("pii-capture", _cmd_pii_capture, "Capture a message with send_default_pii enabled")
 	_parser.add_command("run-tests", _cmd_run_tests, "Run unit tests")
 	_parser.add_command("dotnet-exception-capture", _cmd_dotnet_exception_capture, "Capture a .NET exception (scenario: plain | bare-rethrow | wrapped-rethrow)")
@@ -248,6 +249,48 @@ func _before_send_metric(metric: SentryMetric) -> SentryMetric:
 	metric.set_attribute("handler_added", "added_value")
 	metric.remove_attribute("deleted_metric_attribute")
 	return metric
+
+
+## Captures a trace with a small span tree (transaction).
+func _cmd_span_capture() -> int:
+	await _init_sentry(func(options: SentryOptions) -> void:
+		options.traces_sample_rate = 1.0
+		options.before_send = func(event: SentryEvent) -> SentryEvent:
+			var data: Variant = JSON.parse_string(event.to_json())
+			print("SPAN_TRIGGERED: ", data.get("contexts", {}).get("trace", {}).get("trace_id", ""))
+			return event
+	)
+	_add_integration_test_context("span-capture")
+
+	var root_name := "span-capture-" + _generate_uuid()
+	print("SPAN_NAME: ", root_name)
+
+	var root := SentrySDK.start_span(root_name, {
+		"sentry.op": "test.span_capture",
+		"root_attribute": "root_value",
+	})
+	root.set_attribute("late_root_attribute", "late_value")
+
+	var child := SentrySDK.start_span("child-span", {"sentry.op": "test.child"})
+	child.set_attribute("child_attribute", "child_value")
+	child.set_status(SentrySpan.SPAN_STATUS_ERROR)
+	child.end()
+
+	SentrySDK.with_span("with-span-child", func(span: SentrySpan) -> void:
+		span.set_attribute("with_span_attribute", "with_span_value")
+		)
+
+	var event_id := SentrySDK.capture_message("Span capture test message")
+	print("EVENT_CAPTURED: ", event_id)
+
+	root.set_status(SentrySpan.SPAN_STATUS_OK)
+	root.end()
+
+	SentrySDK.close()
+	await get_tree().create_timer(1.0).timeout
+
+	_print_test_result("span-capture", true, "Test complete")
+	return 0
 
 
 ## Captures a message with `send_default_pii` enabled to verify correct PII forwarding.

--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -220,6 +220,7 @@ Describe "Platform Integration Tests" {
             $script:runtimeErrorRunResult = Invoke-TestAction -Action "runtime-error-capture"
             $script:logRunResult = Invoke-TestAction -Action "log-capture"
             $script:metricRunResult = Invoke-TestAction -Action "metric-capture"
+            $script:spanRunResult = Invoke-TestAction -Action "span-capture"
             $script:piiRunResult = Invoke-TestAction -Action "pii-capture"
         }
         finally {
@@ -836,6 +837,110 @@ Describe "Platform Integration Tests" {
             $counter.deleted_global_attribute | Should -BeNullOrEmpty
             $distribution.deleted_global_attribute | Should -BeNullOrEmpty
             $gauge.deleted_global_attribute | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Spans" -Skip:$script:IsCocoa {
+        BeforeAll {
+            $runResult = $script:spanRunResult
+
+            $spanTriggeredLines = @($runResult.Output | Where-Object { $_ -match 'SPAN_TRIGGERED: ' })
+            $spanNameLines = @($runResult.Output | Where-Object { $_ -match 'SPAN_NAME: ' })
+            $traceId = $null
+            $spanName = $null
+            $transaction = $null
+            $capturedEvent = $null
+
+            if ($spanNameLines.Count -gt 0) {
+                $spanName = ($spanNameLines[0] -split 'SPAN_NAME: ')[-1].Trim()
+            }
+
+            if ($spanTriggeredLines.Count -gt 0) {
+                $traceId = ($spanTriggeredLines[0] -split 'SPAN_TRIGGERED: ')[-1].Trim()
+                Write-Host "Captured trace ID: $traceId" -ForegroundColor Cyan
+
+                Write-GitHub "::group::Getting transaction"
+                try {
+                    $transaction = Get-SentryTestTransaction -TraceId $traceId
+                }
+                catch {
+                    Write-Host "Warning: $_" -ForegroundColor Red
+                }
+                Write-GitHub "::endgroup::"
+            }
+            else {
+                Write-Host "Warning: No SPAN_TRIGGERED line found in output" -ForegroundColor Yellow
+            }
+
+            $eventId = Get-EventIds -AppOutput $runResult.Output -ExpectedCount 1
+            if ($eventId) {
+                Write-GitHub "::group::Getting event content"
+                $capturedEvent = Get-SentryTestEvent -EventId "$eventId"
+                Write-GitHub "::endgroup::"
+            }
+        }
+
+        It "Outputs the trace ID and the root span name" {
+            $traceId | Should -Not -BeNullOrEmpty
+            $spanName | Should -Not -BeNullOrEmpty
+        }
+
+        It "Exits with code zero" {
+            if ($TestSetup.Platform -in @("Adb", "AndroidSauceLabs")) {
+                # app-runner doesn't support exit code on Android.
+                return
+            }
+            $runResult.ExitCode | Should -Be 0
+        }
+
+        It "Outputs TEST_RESULT with success" {
+            $testResultLine = $runResult.Output | Where-Object { $_ -match 'TEST_RESULT:' }
+            $testResultLine | Should -Not -BeNullOrEmpty
+            $testResultLine | Should -Match '"success":true'
+        }
+
+        It "Sends the trace as a transaction" {
+            $transaction | Should -Not -BeNullOrEmpty
+            $transaction.type | Should -Be 'transaction'
+        }
+
+        It "Names the transaction after the root span" {
+            $transaction.title | Should -Be $spanName
+        }
+
+        It "Has the operation set on the root span" {
+            $transaction.contexts.trace.op | Should -Be 'test.span_capture'
+        }
+
+        It "Has the status set on the root span" {
+            $transaction.contexts.trace.status | Should -Be 'ok'
+        }
+
+        It "Has the attributes set on the root span" {
+            $transaction.contexts.trace.data.root_attribute | Should -Be 'root_value'
+            $transaction.contexts.trace.data.late_root_attribute | Should -Be 'late_value'
+        }
+
+        It "Contains the child span" {
+            $child = $transaction.spans | Where-Object { $_.description -eq 'child-span' }
+            $child | Should -Not -BeNullOrEmpty
+            $child.op | Should -Be 'test.child'
+            $child.parent_span_id | Should -Be $transaction.contexts.trace.span_id
+            $child.data.child_attribute | Should -Be 'child_value'
+            # Platforms differ in the status they report for a generic span failure.
+            $child.status | Should -Match '_error$'
+        }
+
+        It "Contains the span started by with_span" {
+            $withSpan = $transaction.spans | Where-Object { $_.description -eq 'with-span-child' }
+            $withSpan | Should -Not -BeNullOrEmpty
+            $withSpan.parent_span_id | Should -Be $transaction.contexts.trace.span_id
+            $withSpan.data.with_span_attribute | Should -Be 'with_span_value'
+        }
+
+        It "Captures an event on the trace of the span it was captured in" {
+            $capturedEvent | Should -Not -BeNullOrEmpty
+            $capturedEvent.contexts.trace.trace_id | Should -Be $traceId
         }
     }
 


### PR DESCRIPTION
This PR adds end to end coverage for spans to the integration suite. A run builds a small span tree and ends it, and the test then fetches the resulting transaction back from the Sentry API to confirm the operation, status, attributes and parent-child structure survived the round trip, along with the trace of an event captured while the span was open. The unit tests only observe spans inside the SDK, so nothing checked that a trace actually reaches Sentry until now.

- Refs #861

#skip-changelog