### PR TITLE
feat(tracing): Add SentrySDK.start_new_trace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
   - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans; it currently only affects Web ([#895](https://github.com/getsentry/sentry-godot/pull/895))
   - Not supported on macOS or iOS yet, where the SDK returns a no-op span with a warning
+- Add `SentrySDK.start_new_trace()` to start a trace unconnected to the current one, so the telemetry captured afterwards is grouped separately ([#909](https://github.com/getsentry/sentry-godot/pull/909))
 
 ### Improvements
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -11,6 +11,7 @@ import io.sentry.ISerializer
 import io.sentry.ISpan
 import io.sentry.JsonUnknown
 import io.sentry.NoOpLogger
+import io.sentry.PropagationContext
 import io.sentry.Scope
 import io.sentry.ScopeType
 import io.sentry.Scopes
@@ -26,7 +27,6 @@ import io.sentry.SentryOptions
 import io.sentry.SpanId
 import io.sentry.TransactionContext
 import io.sentry.TransactionOptions
-import io.sentry.android.core.InternalSentrySdk
 import io.sentry.android.core.SentryAndroid
 import io.sentry.logger.ILoggerApi
 import io.sentry.logger.SentryLogParameters
@@ -40,6 +40,7 @@ import io.sentry.protocol.SentryStackFrame
 import io.sentry.protocol.SentryStackTrace
 import io.sentry.protocol.SentryThread
 import io.sentry.protocol.User
+import io.sentry.util.TracingUtils
 import java.io.File
 import java.io.StringWriter
 import kotlin.random.Random
@@ -519,7 +520,16 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
 
     @UsedByGodot
     fun setTrace(traceId: String, parentSpanId: String) {
-        InternalSentrySdk.setTrace(traceId, parentSpanId, null, null)
+        TracingUtils.setTrace(
+            Sentry.getCurrentScopes(),
+            PropagationContext(
+                SentryId(traceId),
+                SpanId(),
+                if (parentSpanId.isEmpty()) null else SpanId(parentSpanId),
+                null,
+                null,
+            ),
+        )
     }
 
     @UsedByGodot

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -204,7 +204,7 @@
 			<description>
 				Starts a new trace, unconnected to the current one. Telemetry captured from this point on carries the new trace ID and no link back to the trace it replaces.
 				Use this to draw a clean trace boundary where one piece of work ends and unrelated work begins. Without it, everything captured in a session shares the trace the SDK starts at initialization.
-				[b]Note:[/b] A span started with [method SentrySDK.start_span] keeps the trace it began on, and so does the telemetry captured while that span is active. Start the new trace once the operation it measures has finished.
+				[b]Note:[/b] A span started with [method SentrySDK.start_span] keeps the trace it began on, and so does the telemetry captured while that span is active. The new trace takes effect once that span ends.
 				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 			</description>
 		</method>

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -202,7 +202,7 @@
 		<method name="start_new_trace">
 			<return type="void" />
 			<description>
-				Starts a new trace, unconnected to the current one. Telemetry captured from this point on carries the new trace ID and no link back to the trace it replaces.
+				Starts a new trace with a new trace ID. A trace groups connected events and operations under one trace ID. A new trace begins a separate group in Sentry.
 				Use this to draw a clean trace boundary where one piece of work ends and unrelated work begins. Without it, everything captured in a session shares the trace the SDK starts at initialization.
 				[b]Note:[/b] A span started with [method SentrySDK.start_span] keeps the trace it began on, and so does the telemetry captured while that span is active. The new trace takes effect once that span ends.
 				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -199,6 +199,15 @@
 				Assigns user data. See [SentryUser].
 			</description>
 		</method>
+		<method name="start_new_trace">
+			<return type="void" />
+			<description>
+				Starts a new trace, unconnected to the current one. Telemetry captured from this point on carries the new trace ID and no link back to the trace it replaces.
+				Use this to draw a clean trace boundary where one piece of work ends and unrelated work begins. Without it, everything captured in a session shares the trace the SDK starts at initialization.
+				[b]Note:[/b] A span started with [method SentrySDK.start_span] keeps the trace it began on, and so does the telemetry captured while that span is active. Start the new trace once the operation it measures has finished.
+				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
+			</description>
+		</method>
 		<method name="start_span">
 			<return type="SentrySpan" />
 			<param index="0" name="name" type="String" />

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -1,5 +1,5 @@
 extends SentryTestSuite
-## Verifies telemetry stays on a single trace across scope operations.
+## Verifies telemetry stays on a single trace across scope operations, and moves off it when a new trace is started.
 
 
 # TODO: widen the platform list as scopes are implemented on other backends.
@@ -57,4 +57,28 @@ func test_scope_clear_keeps_trace() -> void:
 	assert_json(json_after_clear).describe("clear() does not change the trace") \
 		.at("/contexts/trace/trace_id") \
 		.is_equal(_trace_id(json_before)) \
+		.verify()
+
+
+func test_start_new_trace_replaces_the_trace() -> void:
+	var json_before: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	SentrySDK.start_new_trace()
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_after).describe("start_new_trace() moves later events onto another trace") \
+		.at("/contexts/trace/trace_id") \
+		.is_not_equal(_trace_id(json_before)) \
+		.verify()
+
+
+func test_events_after_start_new_trace_share_trace() -> void:
+	SentrySDK.start_new_trace()
+
+	var json_first: String = await capture_event_and_get_json(SentrySDK.create_event())
+	var json_second: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_second).describe("events captured after start_new_trace() share one trace") \
+		.at("/contexts/trace/trace_id") \
+		.is_equal(_trace_id(json_first)) \
 		.verify()

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -1,8 +1,7 @@
 extends SentryTestSuite
 ## Verifies telemetry stays on a single trace across scope operations, and moves off it when a new trace is started.
-
-
-# TODO: drop the skips when Cocoa gains scope support.
+##
+## TODO: drop the skips when Cocoa gains scope support.
 
 
 func _trace_id(json: String) -> Variant:

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -2,10 +2,7 @@ extends SentryTestSuite
 ## Verifies telemetry stays on a single trace across scope operations, and moves off it when a new trace is started.
 
 
-# TODO: widen the platform list as scopes are implemented on other backends.
-func before(_do_skip = OS.get_name() not in ["Windows", "Linux", "Android", "Web"],
-		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
-	super()
+# TODO: drop the skips when Cocoa gains scope support.
 
 
 func _trace_id(json: String) -> Variant:
@@ -13,7 +10,8 @@ func _trace_id(json: String) -> Variant:
 	return data.get("contexts", {}).get("trace", {}).get("trace_id")
 
 
-func test_scoped_event_shares_trace() -> void:
+func test_scoped_event_shares_trace(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	var json_outside: String = await capture_event_and_get_json(SentrySDK.create_event())
 
 	SentrySDK.with_scope(func(_scope: SentryScope) -> void:
@@ -27,7 +25,8 @@ func test_scoped_event_shares_trace() -> void:
 		.verify()
 
 
-func test_nested_with_scope_keeps_trace() -> void:
+func test_nested_with_scope_keeps_trace(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	SentrySDK.with_scope(func(_outer: SentryScope) -> void:
 		SentrySDK.capture_event(SentrySDK.create_event())
 
@@ -45,7 +44,8 @@ func test_nested_with_scope_keeps_trace() -> void:
 		.verify()
 
 
-func test_scope_clear_keeps_trace() -> void:
+func test_scope_clear_keeps_trace(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
 	var json_before: String = await capture_event_and_get_json(SentrySDK.create_event())
 
 	SentrySDK.with_scope(func(scope: SentryScope) -> void:

--- a/project/test/suites/test_trace.gd
+++ b/project/test/suites/test_trace.gd
@@ -59,6 +59,22 @@ func test_scope_clear_keeps_trace(_do_skip = OS.get_name() in ["macOS", "iOS"],
 		.verify()
 
 
+func test_start_new_trace_reaches_forked_scope(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Scopes are not implemented on this platform yet.") -> void:
+	SentrySDK.with_scope(func(_scope: SentryScope) -> void:
+		SentrySDK.start_new_trace()
+		SentrySDK.capture_event(SentrySDK.create_event())
+		)
+	var json_in_scope: String = await wait_for_captured_event_json()
+
+	var json_after: String = await capture_event_and_get_json(SentrySDK.create_event())
+
+	assert_json(json_in_scope).describe("an event captured in a forked scope after start_new_trace() is on the new trace") \
+		.at("/contexts/trace/trace_id") \
+		.is_equal(_trace_id(json_after)) \
+		.verify()
+
+
 func test_start_new_trace_replaces_the_trace() -> void:
 	var json_before: String = await capture_event_and_get_json(SentrySDK.create_event())
 

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -366,6 +366,15 @@ class SentryBridge {
     Sentry.setUser(null);
   }
 
+  public setTrace(traceId: string, parentSpanId: string): void {
+    Sentry.getCurrentScope().setPropagationContext({
+      traceId,
+      parentSpanId: parentSpanId || undefined,
+      propagationSpanId: generateSpanId(),
+      sampleRand: Math.random(),
+    });
+  }
+
   public eventSetUser(event: Sentry.Event, id: string, username: string, email: string, ip: string): void {
     event.user = makeUser(id, username, email, ip);
   }

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -428,6 +428,14 @@ class SentryBridge {
     return fresh;
   }
 
+  public scopeClone(scope: Sentry.Scope): Sentry.Scope {
+    const cloned = scope.clone();
+    // WORKAROUND: clone() copies the propagation context instead of sharing it, which would strand
+    // the fork on the trace it was made with. Re-share it so a forked scope keeps following setTrace().
+    cloned.setPropagationContext(scope.getPropagationContext());
+    return cloned;
+  }
+
   public scopeSetSpan(scope: Sentry.Scope, span?: Sentry.Span): void {
     // No public alternative: setActiveSpanInBrowser binds only to the current scope.
     _INTERNAL_setSpanForScope(scope, span ?? undefined);

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -374,6 +374,8 @@ class SentryBridge {
     context.parentSpanId = parentSpanId || undefined;
     context.propagationSpanId = generateSpanId();
     context.sampleRand = Math.random();
+    context.dsc = undefined;
+    context.sampled = undefined;
   }
 
   public eventSetUser(event: Sentry.Event, id: string, username: string, email: string, ip: string): void {

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -367,12 +367,13 @@ class SentryBridge {
   }
 
   public setTrace(traceId: string, parentSpanId: string): void {
-    Sentry.getCurrentScope().setPropagationContext({
-      traceId,
-      parentSpanId: parentSpanId || undefined,
-      propagationSpanId: generateSpanId(),
-      sampleRand: Math.random(),
-    });
+    // Scopes share this propagation context by reference via createScope(). Mutate it in place so
+    // all existing scopes move to the new trace; replacing it would strand them on the old trace.
+    const context = Sentry.getCurrentScope().getPropagationContext();
+    context.traceId = traceId;
+    context.parentSpanId = parentSpanId || undefined;
+    context.propagationSpanId = generateSpanId();
+    context.sampleRand = Math.random();
   }
 
   public eventSetUser(event: Sentry.Event, id: string, username: string, email: string, ip: string): void {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -65,6 +65,7 @@ try {
 			"scopeAddBytesAttachment",
 			"scopeAddFileAttachment",
 			"scopeClear",
+			"scopeClone",
 			"scopeSetSpan",
 			"startSpan",
 			"spanSetStatus",
@@ -218,6 +219,17 @@ try {
 					"setTrace should drop the frozen baggage of the trace it replaces");
 			assertEqual(continued.getPropagationContext().sampled, undefined,
 					"setTrace should drop the sampling decision of the trace it replaces");
+		});
+
+		runTest("scopeClone()", () => {
+			const base = bridge.createScope();
+			const fork = bridge.scopeClone(base);
+
+			bridge.setTrace("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee", "");
+			assertEqual(fork.getPropagationContext().traceId, "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+					"a forked scope should follow a trace change");
+			assertEqual(fork.getPropagationContext().traceId, base.getPropagationContext().traceId,
+					"a forked scope should stay on the trace of the scope it was forked from");
 		});
 
 		runTest("eventSetUser()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -177,6 +177,10 @@ try {
 		});
 
 		runTest("setTrace()", () => {
+			// Scopes hold the propagation context by reference, so one made before the call has to move
+			// onto the new trace too, and values have to be read out before the next call changes them.
+			const existing = bridge.createScope();
+
 			bridge.setTrace("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb");
 			const withParent = bridge.createScope().getPropagationContext();
 			assertEqual(withParent.traceId, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -185,6 +189,9 @@ try {
 					"setTrace should adopt the given parent span id");
 			assert(withParent.propagationSpanId !== undefined,
 					"setTrace should mint a span id for captures outside a span");
+			assertEqual(existing.getPropagationContext().traceId, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					"setTrace should move a scope that already exists onto the new trace");
+			const firstSpanId = withParent.propagationSpanId;
 
 			bridge.setTrace("cccccccccccccccccccccccccccccccc", "");
 			const noParent = bridge.createScope().getPropagationContext();
@@ -192,8 +199,10 @@ try {
 					"setTrace should replace the trace id");
 			assertEqual(noParent.parentSpanId, undefined,
 					"setTrace should leave the parent unset when none is given");
-			assert(noParent.propagationSpanId !== withParent.propagationSpanId,
+			assert(noParent.propagationSpanId !== firstSpanId,
 					"setTrace should mint a fresh span id on every call");
+			assertEqual(existing.getPropagationContext().parentSpanId, undefined,
+					"setTrace should clear the parent on a scope that already exists");
 		});
 
 		runTest("eventSetUser()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -56,6 +56,7 @@ try {
 			"removeTag",
 			"setUser",
 			"removeUser",
+			"setTrace",
 			"eventSetUser",
 			"createScope",
 			"scopeSetContext",
@@ -173,6 +174,26 @@ try {
 
 		runTest("removeUser()", () => {
 			bridge.removeUser();
+		});
+
+		runTest("setTrace()", () => {
+			bridge.setTrace("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb");
+			const withParent = bridge.createScope().getPropagationContext();
+			assertEqual(withParent.traceId, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					"setTrace should adopt the given trace id");
+			assertEqual(withParent.parentSpanId, "bbbbbbbbbbbbbbbb",
+					"setTrace should adopt the given parent span id");
+			assert(withParent.propagationSpanId !== undefined,
+					"setTrace should mint a span id for captures outside a span");
+
+			bridge.setTrace("cccccccccccccccccccccccccccccccc", "");
+			const noParent = bridge.createScope().getPropagationContext();
+			assertEqual(noParent.traceId, "cccccccccccccccccccccccccccccccc",
+					"setTrace should replace the trace id");
+			assertEqual(noParent.parentSpanId, undefined,
+					"setTrace should leave the parent unset when none is given");
+			assert(noParent.propagationSpanId !== withParent.propagationSpanId,
+					"setTrace should mint a fresh span id on every call");
 		});
 
 		runTest("eventSetUser()", () => {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -36,7 +36,7 @@ function runTest(name, testFn) {
 try {
 	require("./dist/sentry-bundle.js");
 
-	const { spanToStreamedSpanJSON } = require("@sentry/core");
+	const { spanToStreamedSpanJSON, getCurrentScope, propagationContextFromHeaders } = require("@sentry/core");
 
 	console.log("✅ Bundle loaded successfully\n");
 
@@ -203,6 +203,21 @@ try {
 					"setTrace should mint a fresh span id on every call");
 			assertEqual(existing.getPropagationContext().parentSpanId, undefined,
 					"setTrace should clear the parent on a scope that already exists");
+		});
+
+		runTest("setTrace() over a continued trace", () => {
+			getCurrentScope().setPropagationContext(propagationContextFromHeaders(
+					"12345678123456781234567812345678-1234567812345678-1",
+					"sentry-trace_id=12345678123456781234567812345678,sentry-sample_rate=0.5"));
+			const continued = bridge.createScope();
+
+			bridge.setTrace("dddddddddddddddddddddddddddddddd", "");
+			assertEqual(continued.getPropagationContext().traceId, "dddddddddddddddddddddddddddddddd",
+					"setTrace should replace a continued trace");
+			assertEqual(continued.getPropagationContext().dsc, undefined,
+					"setTrace should drop the frozen baggage of the trace it replaces");
+			assertEqual(continued.getPropagationContext().sampled, undefined,
+					"setTrace should drop the sampling decision of the trace it replaces");
 		});
 
 		runTest("eventSetUser()", () => {

--- a/src/sentry/javascript/javascript_scope.cpp
+++ b/src/sentry/javascript/javascript_scope.cpp
@@ -102,7 +102,7 @@ void JavaScriptScope::clear() {
 }
 
 SentryScopeImpl *JavaScriptScope::clone() const {
-	JSObjectPtr cloned_obj = js_obj->call("clone").as_object();
+	JSObjectPtr cloned_obj = js_bridge()->call("scopeClone", js_obj).as_object();
 	ERR_FAIL_COND_V_MSG(!cloned_obj, memnew(DisabledScope), "Sentry: Failed to clone scope object.");
 	return memnew(JavaScriptScope(cloned_obj));
 }

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -331,7 +331,8 @@ SentrySpanImpl *JavaScriptSDK::create_span(const String &p_name, const Dictionar
 }
 
 void JavaScriptSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
-	SENTRY_PRINT_ONCE(sentry::LEVEL_DEBUG, "Setting trace info not implemented on Web platform - skipped.");
+	ERR_FAIL_COND(!js_bridge());
+	js_bridge()->call("setTrace", p_trace_id.utf8(), p_parent_span_id.utf8());
 }
 
 void JavaScriptSDK::init() {

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -425,6 +425,10 @@ void SentrySDK::remove_user() {
 	}
 }
 
+void SentrySDK::start_new_trace() {
+	set_trace(sentry::uuid::make_uuid_no_dashes(), String());
+}
+
 void SentrySDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
 	// Cache locally so get_trace_context() stays consistent with the backend.
 	trace_context.trace_id = p_trace_id;
@@ -665,6 +669,7 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_attachments"), &SentrySDK::clear_attachments);
 	ClassDB::bind_method(D_METHOD("set_attribute", "name", "value"), &SentrySDK::set_attribute);
 	ClassDB::bind_method(D_METHOD("remove_attribute", "name"), &SentrySDK::remove_attribute);
+	ClassDB::bind_method(D_METHOD("start_new_trace"), &SentrySDK::start_new_trace);
 
 	ClassDB::bind_method(D_METHOD("get_current_scope"), &SentrySDK::get_current_scope);
 	ClassDB::bind_method(D_METHOD("with_scope", "callable"), &SentrySDK::with_scope);

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -109,6 +109,7 @@ public:
 	void set_user(const Ref<SentryUser> &p_user);
 	void remove_user();
 
+	void start_new_trace();
 	void set_trace(const String &p_trace_id, const String &p_parent_span_id);
 
 	_FORCE_INLINE_ SentryLogger *get_logger() const { return logger; }


### PR DESCRIPTION
Adds `SentrySDK.start_new_trace()`[^1], which starts a trace unconnected to the one in progress so that telemetry captured afterwards is grouped separately from what came before. A game is a long-running process, and until now everything captured in a session shared the single trace the SDK starts at initialization. The new trace ID is minted in the SDK's own layer and routed through the existing internal `set_trace()` path, which keeps the cached trace context consistent with what the backend holds and needs no new backend interface.

- Refs #907

[^1]: [startNewTrace in trace propagation spec](https://develop.sentry.dev/sdk/foundations/trace-propagation/#startnewtrace)
