### PR TITLE
feat(dotnet): Sync native trace changes to the .NET layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
   - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans; it currently only affects Web ([#895](https://github.com/getsentry/sentry-godot/pull/895))
   - Not supported on macOS or iOS yet, where the SDK returns a no-op span with a warning
 - Add `SentrySDK.start_new_trace()` to start a trace unconnected to the current one, so the telemetry captured afterwards is grouped separately ([#909](https://github.com/getsentry/sentry-godot/pull/909))
+- Synchronize traces started in the native layer with the .NET layer, so telemetry captured from C# is associated with the same trace ([#910](https://github.com/getsentry/sentry-godot/pull/910))
 
 ### Improvements
 

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -94,6 +94,7 @@ struct ManagedFunctions {
 	void (*set_user)(const char16_t *id, int32_t id_len, const char16_t *username, int32_t username_len, const char16_t *email, int32_t email_len, const char16_t *ip, int32_t ip_len);
 	void (*remove_user)();
 	uint8_t (*process_native_event)(void *event_handle); // Returns 1 to keep, 0 to discard.
+	void (*set_trace)(const char16_t *trace_id, int32_t trace_id_len, const char16_t *parent_span_id, int32_t parent_span_id_len);
 };
 
 static ManagedFunctions s_managed_funcs = {};
@@ -739,6 +740,16 @@ void set_user(const Ref<SentryUser> &p_user) {
 void remove_user() {
 	if (s_managed_funcs.remove_user) {
 		s_managed_funcs.remove_user();
+	}
+}
+
+void set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	if (s_managed_funcs.set_trace) {
+		Char16String trace_id_utf16 = p_trace_id.utf16();
+		Char16String parent_span_id_utf16 = p_parent_span_id.utf16();
+		s_managed_funcs.set_trace(
+				trace_id_utf16.get_data(), trace_id_utf16.length(),
+				parent_span_id_utf16.get_data(), parent_span_id_utf16.length());
 	}
 }
 

--- a/src/sentry/dotnet/csharp_interop.h
+++ b/src/sentry/dotnet/csharp_interop.h
@@ -34,6 +34,8 @@ void remove_tag(const String &p_key);
 void set_user(const Ref<SentryUser> &p_user);
 void remove_user();
 
+void set_trace(const String &p_trace_id, const String &p_parent_span_id);
+
 // Forwards a native/engine event to the options.Native.SetBeforeSend callback in the .NET layer.
 // Returns true to keep the event, false to discard it. Mutates the event in place.
 // No-op returning true when the .NET layer or callback is unavailable.

--- a/src/sentry/dotnet/dotnet_scope_observer.cpp
+++ b/src/sentry/dotnet/dotnet_scope_observer.cpp
@@ -50,4 +50,12 @@ void DotnetScopeObserver::remove_user() {
 	sentry::dotnet::remove_user();
 }
 
+void DotnetScopeObserver::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
+	if (SyncGuard::is_syncing()) {
+		return;
+	}
+	SyncGuard guard;
+	sentry::dotnet::set_trace(p_trace_id, p_parent_span_id);
+}
+
 } //namespace sentry::dotnet

--- a/src/sentry/dotnet/dotnet_scope_observer.h
+++ b/src/sentry/dotnet/dotnet_scope_observer.h
@@ -39,6 +39,8 @@ public:
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;
 	virtual void remove_user() override;
+
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) override;
 };
 
 } //namespace sentry::dotnet

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -264,6 +264,7 @@ internal static partial class NativeBridge
         public delegate* unmanaged[Cdecl]<char*, int, char*, int, char*, int, char*, int, void> set_user;
         public delegate* unmanaged[Cdecl]<void> remove_user;
         public delegate* unmanaged[Cdecl]<IntPtr, byte> process_native_event;
+        public delegate* unmanaged[Cdecl]<char*, int, char*, int, void> set_trace;
     }
 
     [LibraryImport(Lib)]
@@ -303,6 +304,7 @@ internal static partial class NativeBridge
             set_user = &SetUserCallback,
             remove_user = &RemoveUserCallback,
             process_native_event = &ProcessNativeEventCallback,
+            set_trace = &SetTraceCallback,
         });
     }
 
@@ -462,6 +464,27 @@ internal static partial class NativeBridge
         catch (Exception ex)
         {
             GodotLog.Error($"Failed to forward remove_user to Sentry .NET layer: {ex}");
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
+    private static unsafe void SetTraceCallback(
+        char* traceId, int traceIdLen,
+        char* parentSpanId, int parentSpanIdLen)
+    {
+        try
+        {
+            using var _ = new GodotScopeObserver.SyncGuard();
+            Sentry.Godot.SentrySdk.ContinueTrace(
+                new SentryTraceHeader(
+                    SentryId.Parse(new string(traceId, 0, traceIdLen)),
+                    parentSpanIdLen > 0 ? SpanId.Parse(new string(parentSpanId, 0, parentSpanIdLen)) : SpanId.Empty,
+                    isSampled: null),
+                baggageHeader: null);
+        }
+        catch (Exception ex)
+        {
+            GodotLog.Error($"Failed to forward set_trace to Sentry .NET layer: {ex}");
         }
     }
 

--- a/src/sentry/sentry_scope_observer.h
+++ b/src/sentry/sentry_scope_observer.h
@@ -24,6 +24,8 @@ public:
 	virtual void set_user(const Ref<SentryUser> &p_user) {}
 	virtual void remove_user() {}
 
+	virtual void set_trace(const String &p_trace_id, const String &p_parent_span_id) {}
+
 	virtual ~SentryScopeObserver() = default;
 };
 

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -434,6 +434,9 @@ void SentrySDK::set_trace(const String &p_trace_id, const String &p_parent_span_
 	trace_context.trace_id = p_trace_id;
 	trace_context.parent_span_id = p_parent_span_id;
 	internal_sdk->set_trace(p_trace_id, p_parent_span_id);
+	for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+		observer->set_trace(p_trace_id, p_parent_span_id);
+	}
 }
 
 void SentrySDK::set_context(const godot::String &p_key, const godot::Dictionary &p_value) {

--- a/tests/cpp/tests/test_dotnet_trace_sync.cpp
+++ b/tests/cpp/tests/test_dotnet_trace_sync.cpp
@@ -1,5 +1,5 @@
-// Integration tests verifying that the native layer follows the .NET layer's
-// current trace as it changes.
+// Integration tests verifying that the native and .NET layers follow each
+// other's current trace as it changes.
 
 #if defined(TESTS_ENABLED)
 
@@ -52,6 +52,29 @@ TEST_SUITE("[.NET] Cross-layer trace sync") {
 		CHECK_FALSE(post_trace.is_empty());
 		CHECK(post_trace != tx_trace);
 		CHECK(_native_trace_id() == post_trace);
+	}
+
+	TEST_CASE("The .NET layer follows a trace started in the native layer") {
+		if (!sentry::dotnet::godot_supports_dotnet()) {
+			MESSAGE("Skipping: managed runtime unavailable (non-mono Godot build).");
+			return;
+		}
+
+		InitFixture fixture("Init"); // inits the SDK, closes at scope exit
+		Object *harness = fixture.get_harness();
+		REQUIRE(harness != nullptr);
+		REQUIRE(sentry::dotnet::is_managed_layer_registered());
+
+		const String session_trace = _native_trace_id();
+		CHECK_FALSE(session_trace.is_empty());
+		CHECK(String(harness->call("GetCurrentTraceId")) == session_trace);
+
+		SentrySDK::get_singleton()->start_new_trace();
+
+		const String new_trace = _native_trace_id();
+		CHECK_FALSE(new_trace.is_empty());
+		CHECK(new_trace != session_trace);
+		CHECK(String(harness->call("GetCurrentTraceId")) == new_trace);
 	}
 }
 


### PR DESCRIPTION
This PR adds a `set_trace` hook to the scope observers and forwards it across the interop boundary, so a trace started in the SDK's native layer reaches the .NET layer and both stay on one trace. Until now the trace crossed the boundary only once, at initialization, so managed telemetry stayed on whichever trace it held afterwards. The opposite direction, .NET to native, already worked.

- Refs #650
- Refs #907
