### PR TITLE
feat(spans): Add distributed trace propagation from spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - Not supported on macOS or iOS yet, where the SDK returns a no-op span with a warning
 - Add `SentrySDK.start_new_trace()` to start a trace unconnected to the current one, so the telemetry captured afterwards is grouped separately ([#909](https://github.com/getsentry/sentry-godot/pull/909))
 - Synchronize traces started in the native layer with the .NET layer, so telemetry captured from C# is associated with the same trace ([#910](https://github.com/getsentry/sentry-godot/pull/910))
+- Add distributed trace propagation from spans: `SentrySpan.get_trace_headers()` returns request headers for continuing a trace, with `SentryOptions.trace_propagation_targets`, `propagate_traceparent`, and `org_id` controlling where and how they are sent ([#915](https://github.com/getsentry/sentry-godot/pull/915))
 
 ### Improvements
 

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -1125,7 +1125,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
         span.toBaggageHeader(null)?.let { headers.add("${it.name}: ${it.value}") }
         if (Sentry.getCurrentScopes().options.isPropagateTraceparent) {
             val context = span.spanContext
-            W3CTraceparentHeader(context.traceId, context.spanId, span.isSampled).let {
+            W3CTraceparentHeader(context.traceId, context.spanId, span.isSampled ?: false).let {
                 headers.add("${it.name}: ${it.value}")
             }
         }

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -288,6 +288,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val environment = optionsData["environment"] as String
             val sampleRate = optionsData["sample_rate"].toDoubleOrThrow()
             val tracesSampleRate = optionsData["traces_sample_rate"].toDoubleOrThrow()
+            val tracePropagationTargets = (optionsData["trace_propagation_targets"] as Array<*>).map { it as String }
             val propagateTraceparent = optionsData["propagate_traceparent"] as Boolean
             val orgId = optionsData["org_id"] as String
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
@@ -304,6 +305,7 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.environment = environment.ifEmpty { null }
                 options.sampleRate = sampleRate
                 options.tracesSampleRate = tracesSampleRate
+                options.setTracePropagationTargets(tracePropagationTargets)
                 options.isPropagateTraceparent = propagateTraceparent
                 options.orgId = orgId.ifEmpty { null }
                 options.maxBreadcrumbs = maxBreadcrumbs

--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -27,6 +27,7 @@ import io.sentry.SentryOptions
 import io.sentry.SpanId
 import io.sentry.TransactionContext
 import io.sentry.TransactionOptions
+import io.sentry.W3CTraceparentHeader
 import io.sentry.android.core.SentryAndroid
 import io.sentry.logger.ILoggerApi
 import io.sentry.logger.SentryLogParameters
@@ -287,6 +288,8 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
             val environment = optionsData["environment"] as String
             val sampleRate = optionsData["sample_rate"].toDoubleOrThrow()
             val tracesSampleRate = optionsData["traces_sample_rate"].toDoubleOrThrow()
+            val propagateTraceparent = optionsData["propagate_traceparent"] as Boolean
+            val orgId = optionsData["org_id"] as String
             val maxBreadcrumbs = optionsData["max_breadcrumbs"].toIntOrThrow()
             val enableAnrDetection = optionsData["enable_anr_detection"] as Boolean
             val anrTimeoutIntervalMs = optionsData["anr_timeout_interval_ms"].toLongOrThrow()
@@ -301,6 +304,8 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
                 options.environment = environment.ifEmpty { null }
                 options.sampleRate = sampleRate
                 options.tracesSampleRate = tracesSampleRate
+                options.isPropagateTraceparent = propagateTraceparent
+                options.orgId = orgId.ifEmpty { null }
                 options.maxBreadcrumbs = maxBreadcrumbs
                 options.sdkVersion?.name = "sentry.java.android.godot"
                 options.nativeSdkName = "sentry.native.android.godot"
@@ -1108,6 +1113,21 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     @UsedByGodot
     fun spanEnd(handle: Int) {
         getSpan(handle)?.finish()
+    }
+
+    @UsedByGodot
+    fun spanGetTraceHeaders(handle: Int): Array<String> {
+        val span = getSpan(handle) ?: return emptyArray()
+        val headers = mutableListOf<String>()
+        span.toSentryTrace().let { headers.add("${it.name}: ${it.value}") }
+        span.toBaggageHeader(null)?.let { headers.add("${it.name}: ${it.value}") }
+        if (Sentry.getCurrentScopes().options.isPropagateTraceparent) {
+            val context = span.spanContext
+            W3CTraceparentHeader(context.traceId, context.spanId, span.isSampled).let {
+                headers.add("${it.name}: ${it.value}")
+            }
+        }
+        return headers.toTypedArray()
     }
 
     @UsedByGodot

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -190,10 +190,11 @@
 			[b]Platform support:[/b] This option currently only affects Web. Other platforms ignore it.
 			[b]Note:[/b] Streaming sends spans in the Span v2 format. Sentry SaaS currently ingests this format, but self-hosted Sentry does not.
 		</member>
-		<member name="trace_propagation_targets" type="PackedStringArray" setter="set_trace_propagation_targets" getter="get_trace_propagation_targets" default="PackedStringArray(&quot;.*&quot;)">
-			Lists URL substrings that are allowed to receive trace headers. Matching is case-insensitive. The special [code].*[/code] entry matches every URL and is the only entry by default.
+		<member name="trace_propagation_targets" type="Array" setter="set_trace_propagation_targets" getter="get_trace_propagation_targets" default="[&quot;.*&quot;]">
+			Lists URL patterns that are allowed to receive trace headers. Each entry must be a [String] or [RegEx]. Strings match URL substrings, while regular expressions search the complete URL. The special string [code].*[/code] matches every URL and is the only entry by default.
 			Restrict this list to services you trust to prevent sending trace headers to third parties. Leave this empty to block trace headers for all specified URLs.
 			[b]Note:[/b] This option applies only when [method SentrySpan.get_trace_headers] is called with a URL. Omitting the URL bypasses target filtering.
+			[b]Note:[/b] The Project Settings field accepts only literal strings. Add [RegEx] entries from the configuration callback (see [method SentrySDK.init]).
 		</member>
 		<member name="traces_sample_rate" type="float" setter="set_traces_sample_rate" getter="get_traces_sample_rate" default="0.0">
 			Configures the sample rate for performance traces, in the range of 0.0 to 1.0. The default is 0.0, which prevents spans from being sent. If set to 1.0, all traces are sent. If set to 0.1, approximately 10% of traces are sent.

--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -161,6 +161,14 @@
 		<member name="max_breadcrumbs" type="int" setter="set_max_breadcrumbs" getter="get_max_breadcrumbs" default="100">
 			Maximum number of breadcrumbs to send with an event. You should be aware that Sentry has a maximum payload size and any events exceeding that payload size will be dropped.
 		</member>
+		<member name="org_id" type="String" setter="set_org_id" getter="get_org_id" default="&quot;&quot;">
+			Sets the organization ID included as [code]sentry-org_id[/code] in the [code]baggage[/code] header returned by [method SentrySpan.get_trace_headers]. If empty, the SDK derives it from [member dsn].
+			Set this when the DSN does not include an organization ID, as can happen with self-hosted Sentry or a local Relay. Downstream services use the ID to determine whether an incoming trace belongs to the same organization before continuing it.
+		</member>
+		<member name="propagate_traceparent" type="bool" setter="set_propagate_traceparent" getter="is_propagate_traceparent_enabled" default="false">
+			If [code]true[/code], the headers returned by [method SentrySpan.get_trace_headers] include the W3C [code]traceparent[/code] header alongside [code]sentry-trace[/code] and [code]baggage[/code].
+			Enable this when downstream services use [code]traceparent[/code] to continue traces. [member trace_propagation_targets] controls which URLs receive it and the other trace headers.
+		</member>
 		<member name="release" type="String" setter="set_release" getter="get_release" default="&quot;{app_name}@{app_version}&quot;">
 			Release version of the application. This value must be unique across all projects in your organization. Suggested format is [code]my-game@1.0.0[/code].
 			You can use the [code]{app_name}[/code] and [code]{app_version}[/code] placeholders to insert the application name and version from the Project Settings.
@@ -181,6 +189,11 @@
 			Selects whether the SDK sends traces as transactions or streams completed spans. The default is [constant TRACE_LIFECYCLE_STATIC].
 			[b]Platform support:[/b] This option currently only affects Web. Other platforms ignore it.
 			[b]Note:[/b] Streaming sends spans in the Span v2 format. Sentry SaaS currently ingests this format, but self-hosted Sentry does not.
+		</member>
+		<member name="trace_propagation_targets" type="PackedStringArray" setter="set_trace_propagation_targets" getter="get_trace_propagation_targets" default="PackedStringArray(&quot;.*&quot;)">
+			Lists URL substrings that are allowed to receive trace headers. Matching is case-insensitive. The special [code].*[/code] entry matches every URL and is the only entry by default.
+			Restrict this list to services you trust to prevent sending trace headers to third parties. Leave this empty to block trace headers for all specified URLs.
+			[b]Note:[/b] This option applies only when [method SentrySpan.get_trace_headers] is called with a URL. Omitting the URL bypasses target filtering.
 		</member>
 		<member name="traces_sample_rate" type="float" setter="set_traces_sample_rate" getter="get_traces_sample_rate" default="0.0">
 			Configures the sample rate for performance traces, in the range of 0.0 to 1.0. The default is 0.0, which prevents spans from being sent. If set to 1.0, all traces are sent. If set to 0.1, approximately 10% of traces are sent.

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -32,6 +32,23 @@
 				[b]Note:[/b] End every child span before its root span. If the root ends first, the SDK may drop an unfinished child, give it the root's end time, or send it after the child ends, depending on the platform.
 			</description>
 		</method>
+		<method name="get_trace_headers">
+			<return type="PackedStringArray" />
+			<param index="0" name="url" type="String" default="&quot;&quot;" />
+			<description>
+				Returns this span's distributed tracing headers as [code]Name: Value[/code] strings, in the format [method HTTPRequest.request], [method HTTPClient.request], and [member WebSocketPeer.handshake_headers] accept. Attach them to a request made while this span is open so the service that receives it can continue the same trace.
+				The array holds the [code]sentry-trace[/code] and [code]baggage[/code] lines, plus [code]traceparent[/code] when [member SentryOptions.propagate_traceparent] is enabled. Pass the whole array to the request. Its length depends on the configuration, so treat neither the count nor the order of the lines as fixed.
+				When [param url] is given, the SDK returns an empty array unless the URL matches [member SentryOptions.trace_propagation_targets]. Omitting [param url] skips that check and returns the headers unconditionally.
+				[codeblock]
+				var span := SentrySDK.start_span("fetch_scores")
+				var request := HTTPRequest.new()
+				add_child(request)
+				request.request(url, span.get_trace_headers(url))
+				[/codeblock]
+				[b]Note:[/b] Call this method from the thread that started the span. From any other thread, it prints an error and returns an empty array, leaving the request untraced.
+				[b]Note:[/b] The [code]sentry-trace[/code] header carries the sampling decision of the span. While [member SentryOptions.traces_sample_rate] is at its default of [code]0.0[/code], the span is not sent, and the headers tell the receiving service to leave the trace unsampled as well.
+			</description>
+		</method>
 		<method name="set_attribute">
 			<return type="void" />
 			<param index="0" name="key" type="String" />

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -12,7 +12,11 @@ func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.traces_sample_rate = 1.0
 		# Spelled in mixed case to prove the match ignores case.
-		options.trace_propagation_targets = ["API.Example.com"]
+		options.trace_propagation_targets = [
+			"API.Example.com",
+			"literal\\.example\\.com",
+			RegEx.create_from_string("^https://regex\\.example\\.com/"),
+		]
 		options.propagate_traceparent = true
 	)
 
@@ -42,6 +46,26 @@ func test_non_matching_url_receives_nothing() -> void:
 	assert_array(headers) \
 		.override_failure_message("a URL outside trace_propagation_targets should receive no headers") \
 		.is_empty()
+
+
+func test_plain_string_with_regex_characters_is_matched_literally() -> void:
+	var span := SentrySDK.start_span("test.targets_literal")
+	var headers := span.get_trace_headers("https://literal.example.com/scores")
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("regex characters in a string target should remain literal") \
+		.is_empty()
+
+
+func test_regex_target_receives_headers() -> void:
+	var span := SentrySDK.start_span("test.targets_regex")
+	var headers := span.get_trace_headers("https://regex.example.com/scores")
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("a URL matching a RegEx propagation target should receive headers") \
+		.is_not_empty()
 
 
 func test_omitting_the_url_skips_the_allowlist() -> void:

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -1,0 +1,68 @@
+extends SentryTestSuite
+## Verifies trace header filtering and the W3C traceparent option.
+
+
+# TODO: drop the skip when Cocoa gains span support.
+func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
+	super()
+
+
+func init_sdk() -> void:
+	SentrySDK.init(func(options: SentryOptions) -> void:
+		options.traces_sample_rate = 1.0
+		# Spelled in mixed case to prove the match ignores case.
+		options.trace_propagation_targets = ["API.Example.com"]
+		options.propagate_traceparent = true
+	)
+
+
+func _header_value(headers: PackedStringArray, name: String) -> String:
+	for line in headers:
+		if line.begins_with(name + ": "):
+			return line.substr(name.length() + 2)
+	return ""
+
+
+func test_matching_url_receives_headers() -> void:
+	var span := SentrySDK.start_span("test.targets_match")
+	var headers := span.get_trace_headers("https://api.example.com/scores")
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("a URL matching trace_propagation_targets should receive headers") \
+		.is_not_empty()
+
+
+func test_non_matching_url_receives_nothing() -> void:
+	var span := SentrySDK.start_span("test.targets_no_match")
+	var headers := span.get_trace_headers("https://third-party.example.org/ads")
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("a URL outside trace_propagation_targets should receive no headers") \
+		.is_empty()
+
+
+func test_omitting_the_url_skips_the_allowlist() -> void:
+	var span := SentrySDK.start_span("test.targets_no_url")
+	var headers := span.get_trace_headers()
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("reading headers without a URL should skip the allowlist check") \
+		.is_not_empty()
+
+
+func test_traceparent_is_emitted_when_enabled() -> void:
+	var span := SentrySDK.start_span("test.traceparent")
+	var headers := span.get_trace_headers()
+	var json: String = await capture_event_and_get_json(SentrySDK.create_event())
+	span.end()
+
+	var data: Variant = JSON.parse_string(json)
+	var trace: Dictionary = data.get("contexts", {}).get("trace", {})
+
+	assert_str(_header_value(headers, "traceparent")) \
+		.override_failure_message("traceparent should follow the W3C format and carry the span's own ids") \
+		.is_equal("00-%s-%s-01" % [trace.get("trace_id"), trace.get("span_id")])

--- a/project/test/isolated/test_trace_propagation.gd.uid
+++ b/project/test/isolated/test_trace_propagation.gd.uid
@@ -1,0 +1,1 @@
+uid://b6u3jtndepl26

--- a/project/test/isolated/test_trace_propagation_disabled.gd
+++ b/project/test/isolated/test_trace_propagation_disabled.gd
@@ -11,7 +11,7 @@ func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.traces_sample_rate = 1.0
-		options.trace_propagation_targets = PackedStringArray()
+		options.trace_propagation_targets = []
 	)
 
 

--- a/project/test/isolated/test_trace_propagation_disabled.gd
+++ b/project/test/isolated/test_trace_propagation_disabled.gd
@@ -1,0 +1,35 @@
+extends SentryTestSuite
+## Verifies that an empty trace_propagation_targets list propagates to nothing.
+
+
+# TODO: drop the skip when Cocoa gains span support.
+func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
+		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
+	super()
+
+
+func init_sdk() -> void:
+	SentrySDK.init(func(options: SentryOptions) -> void:
+		options.traces_sample_rate = 1.0
+		options.trace_propagation_targets = PackedStringArray()
+	)
+
+
+func test_no_url_matches_an_empty_target_list() -> void:
+	var span := SentrySDK.start_span("test.targets_empty")
+	var headers := span.get_trace_headers("https://api.example.com/scores")
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("an empty trace_propagation_targets list should propagate to nothing") \
+		.is_empty()
+
+
+func test_omitting_the_url_still_yields_headers() -> void:
+	var span := SentrySDK.start_span("test.targets_empty_no_url")
+	var headers := span.get_trace_headers()
+	span.end()
+
+	assert_array(headers) \
+		.override_failure_message("reading headers without a URL should skip the allowlist check") \
+		.is_not_empty()

--- a/project/test/isolated/test_trace_propagation_disabled.gd.uid
+++ b/project/test/isolated/test_trace_propagation_disabled.gd.uid
@@ -1,0 +1,1 @@
+uid://cgy7xko0iqhlh

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -91,6 +91,11 @@ func test_trace_lifecycle() -> void:
 	assert_int(options.trace_lifecycle).is_equal(SentryOptions.TRACE_LIFECYCLE_STREAM)
 
 
+func test_invalid_trace_propagation_targets_are_filtered_out() -> void:
+	options.trace_propagation_targets = ["valid.example.com", 42]
+	assert_array(options.trace_propagation_targets).contains_exactly(["valid.example.com"])
+
+
 ## SentryOptions.max_breadcrumbs should be set to the specified value.
 func test_max_breadcrumbs() -> void:
 	options.max_breadcrumbs = 42

--- a/project/test/suites/test_options.gd
+++ b/project/test/suites/test_options.gd
@@ -96,6 +96,11 @@ func test_invalid_trace_propagation_targets_are_filtered_out() -> void:
 	assert_array(options.trace_propagation_targets).contains_exactly(["valid.example.com"])
 
 
+func test_empty_trace_propagation_targets_are_filtered_out() -> void:
+	options.trace_propagation_targets = ["valid.example.com", ""]
+	assert_array(options.trace_propagation_targets).contains_exactly(["valid.example.com"])
+
+
 ## SentryOptions.max_breadcrumbs should be set to the specified value.
 func test_max_breadcrumbs() -> void:
 	options.max_breadcrumbs = 42

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -378,3 +378,72 @@ func test_with_span_inside_a_started_span_nests_under_it() -> void:
 		.at("/contexts/trace/span_id") \
 		.is_equal(_span_id(json_in_parent)) \
 		.verify()
+
+
+func _header_value(headers: PackedStringArray, name: String) -> String:
+	for line in headers:
+		if line.begins_with(name + ": "):
+			return line.substr(name.length() + 2)
+	return ""
+
+
+func test_trace_headers_carry_the_spans_own_ids() -> void:
+	var span := SentrySDK.start_span("test.headers")
+	var headers := span.get_trace_headers()
+	var json: String = await capture_event_and_get_json(SentrySDK.create_event())
+	span.end()
+
+	assert_str(_header_value(headers, "sentry-trace")) \
+		.override_failure_message("sentry-trace should carry the trace id and span id of the span it was read from") \
+		.starts_with("%s-%s" % [_trace_id(json), _span_id(json)])
+
+	assert_str(_header_value(headers, "baggage")) \
+		.override_failure_message("baggage should stay on the span's trace") \
+		.contains("sentry-trace_id=%s" % _trace_id(json))
+
+
+func test_child_span_headers_carry_its_own_span_id() -> void:
+	var parent := SentrySDK.start_span("test.headers_parent")
+	var child := SentrySDK.start_span("test.headers_child")
+	var parent_trace := _header_value(parent.get_trace_headers(), "sentry-trace").split("-")
+	var child_trace := _header_value(child.get_trace_headers(), "sentry-trace").split("-")
+	child.end()
+	parent.end()
+
+	assert_str(child_trace[0]) \
+		.override_failure_message("a child span should report the trace of its parent") \
+		.is_equal(parent_trace[0])
+
+	assert_str(child_trace[1]) \
+		.override_failure_message("a child span should report its own span id, not its parent's") \
+		.is_not_equal(parent_trace[1])
+
+
+func test_trace_headers_omit_traceparent_by_default() -> void:
+	var span := SentrySDK.start_span("test.headers_no_traceparent")
+	var headers := span.get_trace_headers()
+	span.end()
+
+	assert_str(_header_value(headers, "traceparent")) \
+		.override_failure_message("propagate_traceparent defaults to false, so the W3C header should be absent") \
+		.is_empty()
+
+
+func test_default_propagation_targets_match_every_url() -> void:
+	var span := SentrySDK.start_span("test.headers_default_targets")
+	var for_url := span.get_trace_headers("https://third-party.example.org/ads")
+	var unfiltered := span.get_trace_headers()
+	span.end()
+
+	assert_array(for_url) \
+		.override_failure_message("the default \".*\" target should let every URL through")	\
+		.is_equal(unfiltered)
+
+
+func test_ended_span_yields_no_trace_headers() -> void:
+	var span := SentrySDK.start_span("test.headers_ended")
+	span.end()
+
+	assert_array(span.get_trace_headers()) \
+		.override_failure_message("an ended span has nothing left to propagate") \
+		.is_empty()

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -19,6 +19,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/variant/callable.hpp>
 
 using namespace godot;
@@ -42,6 +43,24 @@ Dictionary _sanitize_attributes(const Dictionary &p_attributes) {
 		}
 	}
 	return attributes;
+}
+
+PackedStringArray _trace_propagation_targets_to_strings(const Array &p_targets) {
+	PackedStringArray targets;
+	for (const Variant &target : p_targets) {
+		if (target.get_type() == Variant::STRING) {
+			targets.append(target);
+			continue;
+		}
+
+		ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: Ignoring an invalid trace propagation target.");
+		Object *object = target;
+		RegEx *regex = Object::cast_to<RegEx>(object);
+		ERR_CONTINUE_MSG(regex == nullptr || !regex->is_valid(), "Sentry: Ignoring an invalid trace propagation target.");
+		// Android takes each pattern as a string and matches it as both a substring and a regex.
+		targets.append(regex->get_pattern());
+	}
+	return targets;
 }
 
 } // unnamed namespace
@@ -403,7 +422,8 @@ void AndroidSDK::init() {
 	optionsData["environment"] = SENTRY_OPTIONS()->get_environment();
 	optionsData["sample_rate"] = SENTRY_OPTIONS()->get_sample_rate();
 	optionsData["traces_sample_rate"] = SENTRY_OPTIONS()->get_traces_sample_rate();
-	optionsData["trace_propagation_targets"] = SENTRY_OPTIONS()->get_trace_propagation_targets();
+	optionsData["trace_propagation_targets"] = _trace_propagation_targets_to_strings(
+			SENTRY_OPTIONS()->get_trace_propagation_targets());
 	optionsData["propagate_traceparent"] = SENTRY_OPTIONS()->is_propagate_traceparent_enabled();
 	optionsData["org_id"] = SENTRY_OPTIONS()->get_org_id();
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -403,6 +403,8 @@ void AndroidSDK::init() {
 	optionsData["environment"] = SENTRY_OPTIONS()->get_environment();
 	optionsData["sample_rate"] = SENTRY_OPTIONS()->get_sample_rate();
 	optionsData["traces_sample_rate"] = SENTRY_OPTIONS()->get_traces_sample_rate();
+	optionsData["propagate_traceparent"] = SENTRY_OPTIONS()->is_propagate_traceparent_enabled();
+	optionsData["org_id"] = SENTRY_OPTIONS()->get_org_id();
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();
 	optionsData["enable_anr_detection"] = SENTRY_OPTIONS()->get_android()->get_enable_anr_detection();
 	optionsData["anr_timeout_interval_ms"] = SENTRY_OPTIONS()->get_android()->get_anr_timeout_interval_ms();

--- a/src/sentry/android/android_sdk.cpp
+++ b/src/sentry/android/android_sdk.cpp
@@ -403,6 +403,7 @@ void AndroidSDK::init() {
 	optionsData["environment"] = SENTRY_OPTIONS()->get_environment();
 	optionsData["sample_rate"] = SENTRY_OPTIONS()->get_sample_rate();
 	optionsData["traces_sample_rate"] = SENTRY_OPTIONS()->get_traces_sample_rate();
+	optionsData["trace_propagation_targets"] = SENTRY_OPTIONS()->get_trace_propagation_targets();
 	optionsData["propagate_traceparent"] = SENTRY_OPTIONS()->is_propagate_traceparent_enabled();
 	optionsData["org_id"] = SENTRY_OPTIONS()->get_org_id();
 	optionsData["max_breadcrumbs"] = SENTRY_OPTIONS()->get_max_breadcrumbs();

--- a/src/sentry/android/android_span.cpp
+++ b/src/sentry/android/android_span.cpp
@@ -63,6 +63,10 @@ void AndroidSpan::end() {
 	_android_plugin->call(ANDROID_SN(spanEnd), _handle);
 }
 
+PackedStringArray AndroidSpan::get_trace_headers() {
+	return _android_plugin->call(ANDROID_SN(spanGetTraceHeaders), _handle);
+}
+
 void AndroidSpan::_apply_attributes(const Dictionary &p_attributes) {
 	const Array &keys = p_attributes.keys();
 	for (int i = 0; i < keys.size(); i++) {

--- a/src/sentry/android/android_span.h
+++ b/src/sentry/android/android_span.h
@@ -28,6 +28,8 @@ public:
 	virtual void set_status(SpanStatus p_status) override;
 	virtual void end() override;
 
+	virtual PackedStringArray get_trace_headers() override;
+
 	virtual ~AndroidSpan() override;
 };
 

--- a/src/sentry/android/android_string_names.cpp
+++ b/src/sentry/android/android_string_names.cpp
@@ -116,6 +116,7 @@ AndroidStringNames::AndroidStringNames() {
 	spanSetAttributeString = StringName("spanSetAttributeString");
 	spanSetStatus = StringName("spanSetStatus");
 	spanEnd = StringName("spanEnd");
+	spanGetTraceHeaders = StringName("spanGetTraceHeaders");
 
 	// Logs.
 	releaseLog = StringName("releaseLog");

--- a/src/sentry/android/android_string_names.h
+++ b/src/sentry/android/android_string_names.h
@@ -127,6 +127,7 @@ public:
 	StringName spanSetAttributeString;
 	StringName spanSetStatus;
 	StringName spanEnd;
+	StringName spanGetTraceHeaders;
 
 	// Logs.
 	StringName releaseLog;

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -61,6 +61,22 @@ NSDictionary<NSString *, SentryObjCAttributeContent *> *_metric_attributes_to_ob
 	return attributes;
 }
 
+NSArray *_trace_propagation_targets_to_objc(const PackedStringArray &p_targets) {
+	NSMutableArray *targets = [NSMutableArray arrayWithCapacity:p_targets.size()];
+	for (const String &target : p_targets) {
+		if (target == ".*") {
+			NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@".*"
+																				   options:0
+																					 error:nil];
+			ERR_CONTINUE(regex == nil);
+			[targets addObject:regex];
+		} else {
+			[targets addObject:sentry::cocoa::string_to_objc(target)];
+		}
+	}
+	return targets;
+}
+
 void _add_default_attachments(SentryObjCScope *p_scope) {
 	for (const Ref<sentry::SentryAttachment> &att : SENTRY_OPTIONS()->get_default_attachments()) {
 		sentry::logging::print_debug("adding attachment \"", att->get_path(), "\"");
@@ -378,6 +394,8 @@ void CocoaSDK::init() {
 		options.maxBreadcrumbs = (NSUInteger)SENTRY_OPTIONS()->get_max_breadcrumbs();
 		options.sendDefaultPii = SENTRY_OPTIONS()->is_send_default_pii_enabled();
 		options.diagnosticLevel = sentry_level_to_objc(SENTRY_OPTIONS()->get_diagnostic_level());
+		options.tracePropagationTargets = _trace_propagation_targets_to_objc(
+				SENTRY_OPTIONS()->get_trace_propagation_targets());
 
 		String dist = SENTRY_OPTIONS()->get_dist();
 		if (!dist.is_empty()) {

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -394,6 +394,8 @@ void CocoaSDK::init() {
 		options.maxBreadcrumbs = (NSUInteger)SENTRY_OPTIONS()->get_max_breadcrumbs();
 		options.sendDefaultPii = SENTRY_OPTIONS()->is_send_default_pii_enabled();
 		options.diagnosticLevel = sentry_level_to_objc(SENTRY_OPTIONS()->get_diagnostic_level());
+		options.orgId = string_to_objc_or_nil_if_empty(SENTRY_OPTIONS()->get_org_id());
+		options.enablePropagateTraceparent = SENTRY_OPTIONS()->is_propagate_traceparent_enabled();
 		options.tracePropagationTargets = _trace_propagation_targets_to_objc(
 				SENTRY_OPTIONS()->get_trace_propagation_targets());
 

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -18,6 +18,7 @@
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/core/mutex_lock.hpp>
 
 using namespace godot;
@@ -61,18 +62,30 @@ NSDictionary<NSString *, SentryObjCAttributeContent *> *_metric_attributes_to_ob
 	return attributes;
 }
 
-NSArray *_trace_propagation_targets_to_objc(const PackedStringArray &p_targets) {
+NSArray *_trace_propagation_targets_to_objc(const Array &p_targets) {
 	NSMutableArray *targets = [NSMutableArray arrayWithCapacity:p_targets.size()];
-	for (const String &target : p_targets) {
-		if (target == ".*") {
-			NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@".*"
-																				   options:0
-																					 error:nil];
-			ERR_CONTINUE(regex == nil);
-			[targets addObject:regex];
-		} else {
-			[targets addObject:sentry::cocoa::string_to_objc(target)];
+	for (const Variant &target : p_targets) {
+		if (target.get_type() == Variant::STRING && (String)target != ".*") {
+			[targets addObject:sentry::cocoa::string_to_objc((String)target)];
+			continue;
 		}
+
+		String pattern;
+		if (target.get_type() == Variant::STRING) {
+			pattern = target;
+		} else {
+			ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: Ignoring an invalid trace propagation target.");
+			Object *object = target;
+			RegEx *regex = Object::cast_to<RegEx>(object);
+			ERR_CONTINUE_MSG(regex == nullptr || !regex->is_valid(), "Sentry: Ignoring an invalid trace propagation target.");
+			pattern = regex->get_pattern();
+		}
+
+		NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:sentry::cocoa::string_to_objc(pattern)
+																			   options:0
+																				 error:nil];
+		ERR_CONTINUE_MSG(regex == nil, "Sentry: Ignoring a trace propagation target that Cocoa cannot compile.");
+		[targets addObject:regex];
 	}
 	return targets;
 }

--- a/src/sentry/disabled/disabled_span.h
+++ b/src/sentry/disabled/disabled_span.h
@@ -12,6 +12,7 @@ public:
 	virtual void set_attribute(const String &p_key, const Variant &p_value) override {}
 	virtual void set_status(SpanStatus p_status) override {}
 	virtual void end() override {}
+	virtual PackedStringArray get_trace_headers() override { return PackedStringArray(); }
 
 	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) override { return memnew(DisabledSpan); }
 };

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -157,6 +157,7 @@ class SentryBridge {
     sampleRate: number,
     tracesSampleRate: number,
     traceLifecycle: TraceLifecycle,
+    tracePropagationTargetsJson: string,
     propagateTraceparent: boolean,
     orgId: string,
     maxBreadcrumbs: number,
@@ -176,6 +177,9 @@ class SentryBridge {
       sampleRate,
       tracesSampleRate,
       traceLifecycle: traceLifecycle === TraceLifecycle.Stream ? "stream" : "static",
+      tracePropagationTargets: safeParseJSON<string[]>(tracePropagationTargetsJson, []).map((target) =>
+        target === ".*" ? /.*/ : target,
+      ),
       propagateTraceparent,
       ...(orgId && { orgId }),
       maxBreadcrumbs,

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -56,6 +56,11 @@ interface AttachmentRequest {
   data?: Uint8Array;
 }
 
+interface TracePropagationTarget {
+  pattern: string;
+  is_regex: boolean;
+}
+
 // *** Utility Functions
 
 function safeParseJSON<T = any>(json: string, fallback: T): T {
@@ -69,6 +74,23 @@ function safeParseJSON<T = any>(json: string, fallback: T): T {
     console.error("Failed to parse JSON:", error);
     return fallback;
   }
+}
+
+function deserializeTracePropagationTargets(json: string): (string | RegExp)[] {
+  const targets: (string | RegExp)[] = [];
+  for (const target of safeParseJSON<TracePropagationTarget[]>(json, [])) {
+    if (!target.is_regex && target.pattern !== ".*") {
+      targets.push(target.pattern);
+      continue;
+    }
+
+    try {
+      targets.push(new RegExp(target.pattern));
+    } catch (error) {
+      console.error("Failed to compile trace propagation target:", error);
+    }
+  }
+  return targets;
 }
 
 function makeAttachment(filename: string, bytes: Uint8Array, contentType: string, attachmentType: string): Attachment {
@@ -177,9 +199,7 @@ class SentryBridge {
       sampleRate,
       tracesSampleRate,
       traceLifecycle: traceLifecycle === TraceLifecycle.Stream ? "stream" : "static",
-      tracePropagationTargets: safeParseJSON<string[]>(tracePropagationTargetsJson, []).map((target) =>
-        target === ".*" ? /.*/ : target,
-      ),
+      tracePropagationTargets: deserializeTracePropagationTargets(tracePropagationTargetsJson),
       propagateTraceparent,
       ...(orgId && { orgId }),
       maxBreadcrumbs,

--- a/src/sentry/javascript/bridge/src/sentry-bridge.ts
+++ b/src/sentry/javascript/bridge/src/sentry-bridge.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/browser";
 import type { Breadcrumb, User } from "@sentry/browser";
-import { _INTERNAL_setSpanForScope, generateSpanId } from "@sentry/core";
+import { _INTERNAL_setSpanForScope, generateSpanId, getTraceData } from "@sentry/core";
 import type { Attachment, Metric } from "@sentry/core";
 import { wasmIntegration } from "@sentry/wasm";
 
@@ -157,6 +157,8 @@ class SentryBridge {
     sampleRate: number,
     tracesSampleRate: number,
     traceLifecycle: TraceLifecycle,
+    propagateTraceparent: boolean,
+    orgId: string,
     maxBreadcrumbs: number,
     sendDefaultPii: boolean,
     sdkVersion: string,
@@ -174,6 +176,8 @@ class SentryBridge {
       sampleRate,
       tracesSampleRate,
       traceLifecycle: traceLifecycle === TraceLifecycle.Stream ? "stream" : "static",
+      propagateTraceparent,
+      ...(orgId && { orgId }),
       maxBreadcrumbs,
       sendDefaultPii,
       _metadata: {
@@ -451,6 +455,14 @@ class SentryBridge {
 
   public spanSetStatus(span: Sentry.Span, status: number): void {
     span.setStatus({ code: status === SPAN_STATUS_ERROR ? OTEL_CODE_ERROR : OTEL_CODE_OK });
+  }
+
+  public spanGetTraceHeaders(span: Sentry.Span): string {
+    const propagateTraceparent = Sentry.getClient()?.getOptions().propagateTraceparent;
+    const data = getTraceData({ span, propagateTraceparent });
+    return Object.entries(data)
+      .map(([name, value]) => `${name}: ${value}`)
+      .join("\n");
   }
 
   public logTrace(message: string, attributesJson?: string, scope?: Sentry.Scope): void {

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -133,14 +133,18 @@ try {
 		const beforeSendFeedback = (event) => {
 			feedbackEvents.push(event);
 		};
-		const initBridge = (traceLifecycle, propagateTraceparent = false, orgId = "") => {
+		const initBridge = (traceLifecycle, propagateTraceparent = false, orgId = "", tracePropagationTargets = [ ".*" ]) => {
 			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false,
-					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, propagateTraceparent, orgId, 100, false,
+					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, JSON.stringify(tracePropagationTargets),
+					propagateTraceparent, orgId, 100, false,
 					"0.1.0");
 		};
 
 		runTest("init()", () => {
 			initBridge(bridge.TraceLifecycle.Stream);
+			const targets = bridge.createScope().getClient().getOptions().tracePropagationTargets;
+			assert(targets[0] instanceof RegExp, '".*" should become a regular expression');
+			assertEqual(targets[0].source, ".*", '".*" should match every URL');
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -133,7 +133,7 @@ try {
 		const beforeSendFeedback = (event) => {
 			feedbackEvents.push(event);
 		};
-		const initBridge = (traceLifecycle, propagateTraceparent = false, orgId = "", tracePropagationTargets = [ ".*" ]) => {
+		const initBridge = (traceLifecycle, propagateTraceparent = false, orgId = "", tracePropagationTargets = [ { pattern : ".*", is_regex : false } ]) => {
 			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false,
 					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, JSON.stringify(tracePropagationTargets),
 					propagateTraceparent, orgId, 100, false,
@@ -145,6 +145,17 @@ try {
 			const targets = bridge.createScope().getClient().getOptions().tracePropagationTargets;
 			assert(targets[0] instanceof RegExp, '".*" should become a regular expression');
 			assertEqual(targets[0].source, ".*", '".*" should match every URL');
+		});
+
+		runTest("init() preserves trace propagation target types", () => {
+			initBridge(bridge.TraceLifecycle.Stream, false, "", [
+				{ pattern : "api\\.example\\.com", is_regex : false },
+				{ pattern : "api\\.example\\.com", is_regex : true },
+			]);
+			const targets = bridge.createScope().getClient().getOptions().tracePropagationTargets;
+			assertEqual(targets[0], "api\\.example\\.com", "string targets should remain literal strings");
+			assert(targets[1] instanceof RegExp, "regular expression targets should become RegExp values");
+			assertEqual(targets[1].source, "api\\.example\\.com", "regular expression patterns should be preserved");
 		});
 
 		// Observes what actually goes out with an event. The bridge registers its own handler during

--- a/src/sentry/javascript/bridge/test.js
+++ b/src/sentry/javascript/bridge/test.js
@@ -69,6 +69,7 @@ try {
 			"scopeSetSpan",
 			"startSpan",
 			"spanSetStatus",
+			"spanGetTraceHeaders",
 			"logTrace",
 			"logDebug",
 			"logInfo",
@@ -132,9 +133,10 @@ try {
 		const beforeSendFeedback = (event) => {
 			feedbackEvents.push(event);
 		};
-		const initBridge = (traceLifecycle) => {
+		const initBridge = (traceLifecycle, propagateTraceparent = false, orgId = "") => {
 			bridge.init(() => {}, beforeSendFeedback, null, null, readAttachment, "https://test@sentry.io/123", false,
-					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, 100, false, "0.1.0");
+					"1.0.0", "1", "production", 1.0, 1.0, traceLifecycle, propagateTraceparent, orgId, 100, false,
+					"0.1.0");
 		};
 
 		runTest("init()", () => {
@@ -424,6 +426,19 @@ try {
 			span.end();
 		});
 
+		runTest("spanGetTraceHeaders()", () => {
+			const span = bridge.startSpan("load-level", "");
+			const headers = bridge.spanGetTraceHeaders(span).split("\n");
+			assertEqual(headers.length, 2, "the default configuration should yield sentry-trace and baggage");
+			assertEqual(headers[0], `sentry-trace: ${span.spanContext().traceId}-${span.spanContext().spanId}-1`,
+					"sentry-trace should carry the span's own ids");
+			assert(headers[1].startsWith(`baggage: sentry-environment=production,`),
+					`baggage should carry the dynamic sampling context, got "${headers[1]}"`);
+			assert(headers[1].includes(`sentry-trace_id=${span.spanContext().traceId}`),
+					"baggage should stay on the span's trace");
+			span.end();
+		});
+
 		runTest("scopeSetSpan()", () => {
 			const scope = bridge.createScope();
 			const span = bridge.startSpan("load-level", "");
@@ -561,6 +576,18 @@ try {
 
 		runTest("removeAttribute()", () => {
 			bridge.removeAttribute("test-attr");
+		});
+
+		runTest("spanGetTraceHeaders() with traceparent enabled", () => {
+			bridge.close(2000);
+			initBridge(bridge.TraceLifecycle.Stream, true, "42");
+			const span = bridge.startSpan("load-level", "");
+			const headers = bridge.spanGetTraceHeaders(span).split("\n");
+			assertEqual(headers.length, 3, "propagateTraceparent should add a third header");
+			assertEqual(headers[2], `traceparent: 00-${span.spanContext().traceId}-${span.spanContext().spanId}-01`,
+					"traceparent should follow the W3C format");
+			assert(headers[1].includes("sentry-org_id=42"), "orgId should reach the baggage header");
+			span.end();
 		});
 
 		runTest("static trace lifecycle", () => {

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -15,15 +15,45 @@
 #include "sentry/processing/process_log.h"
 #include "sentry/processing/process_metric.h"
 #include "sentry/sentry_sdk.h"
+#include "sentry/util/json_writer.h"
 
 #include "gen/sdk_version.gen.h"
 
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 
 #include <emscripten.h>
 
 namespace sentry::javascript {
+
+namespace {
+
+String _serialize_trace_propagation_targets(const Array &p_targets) {
+	util::JSONWriter writer;
+	writer.begin_array();
+	for (const Variant &target : p_targets) {
+		if (target.get_type() == Variant::STRING) {
+			writer.begin_object();
+			writer.kv_string("pattern", target);
+			writer.kv_bool("is_regex", false);
+			writer.end_object();
+		} else {
+			ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: Ignoring an invalid trace propagation target.");
+			Object *object = target;
+			RegEx *regex = Object::cast_to<RegEx>(object);
+			ERR_CONTINUE_MSG(regex == nullptr || !regex->is_valid(), "Sentry: Ignoring an invalid trace propagation target.");
+			writer.begin_object();
+			writer.kv_string("pattern", regex->get_pattern());
+			writer.kv_bool("is_regex", true);
+			writer.end_object();
+		}
+	}
+	writer.end_array();
+	return writer.get_string();
+}
+
+} // unnamed namespace
 
 // *** WASM callbacks
 
@@ -367,7 +397,7 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_sample_rate(),
 			SENTRY_OPTIONS()->get_traces_sample_rate(),
 			(int)SENTRY_OPTIONS()->get_trace_lifecycle(),
-			JSON::stringify(SENTRY_OPTIONS()->get_trace_propagation_targets()).utf8(),
+			_serialize_trace_propagation_targets(SENTRY_OPTIONS()->get_trace_propagation_targets()).utf8(),
 			SENTRY_OPTIONS()->is_propagate_traceparent_enabled(),
 			SENTRY_OPTIONS()->get_org_id().utf8(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -367,6 +367,8 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_sample_rate(),
 			SENTRY_OPTIONS()->get_traces_sample_rate(),
 			(int)SENTRY_OPTIONS()->get_trace_lifecycle(),
+			SENTRY_OPTIONS()->is_propagate_traceparent_enabled(),
+			SENTRY_OPTIONS()->get_org_id().utf8(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),
 			SENTRY_OPTIONS()->is_send_default_pii_enabled(),
 			SENTRY_GODOT_SDK_VERSION);

--- a/src/sentry/javascript/javascript_sdk.cpp
+++ b/src/sentry/javascript/javascript_sdk.cpp
@@ -367,6 +367,7 @@ void JavaScriptSDK::init() {
 			SENTRY_OPTIONS()->get_sample_rate(),
 			SENTRY_OPTIONS()->get_traces_sample_rate(),
 			(int)SENTRY_OPTIONS()->get_trace_lifecycle(),
+			JSON::stringify(SENTRY_OPTIONS()->get_trace_propagation_targets()).utf8(),
 			SENTRY_OPTIONS()->is_propagate_traceparent_enabled(),
 			SENTRY_OPTIONS()->get_org_id().utf8(),
 			SENTRY_OPTIONS()->get_max_breadcrumbs(),

--- a/src/sentry/javascript/javascript_span.cpp
+++ b/src/sentry/javascript/javascript_span.cpp
@@ -47,6 +47,10 @@ void JavaScriptSpan::end() {
 	js_obj->call("end");
 }
 
+PackedStringArray JavaScriptSpan::get_trace_headers() {
+	return js_bridge()->call("spanGetTraceHeaders", js_obj).as_string().split("\n", false);
+}
+
 JavaScriptSpan::JavaScriptSpan(const JSObjectPtr &p_js_span_object) :
 		js_obj(p_js_span_object) {
 }

--- a/src/sentry/javascript/javascript_span.h
+++ b/src/sentry/javascript/javascript_span.h
@@ -26,6 +26,8 @@ public:
 	virtual void set_attribute(const String &p_key, const Variant &p_value) override;
 	virtual void set_status(SpanStatus p_status) override;
 	virtual void end() override;
+
+	virtual PackedStringArray get_trace_headers() override;
 };
 
 } //namespace sentry::javascript

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -417,6 +417,10 @@ void NativeSDK::init() {
 	sentry_options_set_environment(options, SENTRY_OPTIONS()->get_environment().utf8());
 	sentry_options_set_sample_rate(options, SENTRY_OPTIONS()->get_sample_rate());
 	sentry_options_set_traces_sample_rate(options, SENTRY_OPTIONS()->get_traces_sample_rate());
+	sentry_options_set_propagate_traceparent(options, SENTRY_OPTIONS()->is_propagate_traceparent_enabled());
+	if (!SENTRY_OPTIONS()->get_org_id().is_empty()) {
+		sentry_options_set_org_id(options, SENTRY_OPTIONS()->get_org_id().utf8());
+	}
 	sentry_options_set_max_breadcrumbs(options, SENTRY_OPTIONS()->get_max_breadcrumbs());
 	sentry_options_set_shutdown_timeout(options, SENTRY_OPTIONS()->get_shutdown_timeout_ms());
 	sentry_options_set_sdk_name(options, "sentry.native.godot");

--- a/src/sentry/native/native_span.cpp
+++ b/src/sentry/native/native_span.cpp
@@ -12,6 +12,10 @@ inline CharString _get_op(const Dictionary &p_attributes) {
 	return String(p_attributes.get(OP_KEY, String())).utf8();
 }
 
+void _append_header_line(const char *p_key, const char *p_value, void *p_userdata) {
+	static_cast<PackedStringArray *>(p_userdata)->append(String::utf8(p_key) + ": " + String::utf8(p_value));
+}
+
 } // unnamed namespace
 
 namespace sentry::native {
@@ -60,6 +64,16 @@ void NativeSpan::end() {
 		sentry_span_finish(_span);
 		_span = nullptr;
 	}
+}
+
+PackedStringArray NativeSpan::get_trace_headers() {
+	PackedStringArray headers;
+	if (_transaction) {
+		sentry_transaction_iter_headers(_transaction, _append_header_line, &headers);
+	} else {
+		sentry_span_iter_headers(_span, _append_header_line, &headers);
+	}
+	return headers;
 }
 
 void NativeSpan::bind_to_scope(sentry_scope_t *p_scope) {

--- a/src/sentry/native/native_span.h
+++ b/src/sentry/native/native_span.h
@@ -28,6 +28,8 @@ public:
 
 	virtual void end() override;
 
+	virtual PackedStringArray get_trace_headers() override;
+
 	void bind_to_scope(sentry_scope_t *p_scope);
 
 	virtual ~NativeSpan() override;

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -6,6 +6,7 @@
 
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 
 namespace {
 
@@ -129,7 +130,7 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate, false);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/traces_sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->traces_sample_rate, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), p_options->trace_lifecycle, false);
-	_define_setting("sentry/options/trace_propagation_targets", p_options->trace_propagation_targets, false);
+	_define_setting("sentry/options/trace_propagation_targets", PackedStringArray(p_options->trace_propagation_targets), false);
 	_define_setting("sentry/options/propagate_traceparent", p_options->propagate_traceparent, false);
 	_define_setting("sentry/options/org_id", p_options->org_id, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
@@ -223,7 +224,8 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/sample_rate", p_options->sample_rate);
 	p_options->traces_sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/traces_sample_rate", p_options->traces_sample_rate);
 	p_options->trace_lifecycle = (SentryOptions::TraceLifecycle)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/trace_lifecycle", p_options->trace_lifecycle);
-	p_options->trace_propagation_targets = ProjectSettings::get_singleton()->get_setting("sentry/options/trace_propagation_targets", p_options->trace_propagation_targets);
+	const PackedStringArray trace_propagation_targets = ProjectSettings::get_singleton()->get_setting("sentry/options/trace_propagation_targets", PackedStringArray(p_options->trace_propagation_targets));
+	p_options->set_trace_propagation_targets(Array(trace_propagation_targets));
 	p_options->propagate_traceparent = ProjectSettings::get_singleton()->get_setting("sentry/options/propagate_traceparent", p_options->propagate_traceparent);
 	p_options->org_id = ProjectSettings::get_singleton()->get_setting("sentry/options/org_id", p_options->org_id);
 	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/options/max_breadcrumbs", p_options->max_breadcrumbs);
@@ -400,6 +402,22 @@ void SentryOptions::release_callables() {
 	before_capture_screenshot = Callable();
 }
 
+void SentryOptions::set_trace_propagation_targets(const Array &p_targets) {
+	for (const Variant &target : p_targets) {
+		if (target.get_type() == Variant::STRING) {
+			continue;
+		}
+
+		ERR_FAIL_COND_MSG(target.get_type() != Variant::OBJECT, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+		Object *object = target;
+		RegEx *regex = Object::cast_to<RegEx>(object);
+		ERR_FAIL_NULL_MSG(regex, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+		ERR_FAIL_COND_MSG(!regex->is_valid(), "Sentry: trace_propagation_targets entries must contain valid regular expressions.");
+	}
+
+	trace_propagation_targets = p_targets.duplicate();
+}
+
 void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "dsn"), set_dsn, get_dsn);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "release"), set_release, get_release);
@@ -410,7 +428,7 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "traces_sample_rate"), set_traces_sample_rate, get_traces_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), set_trace_lifecycle, get_trace_lifecycle);
-	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::PACKED_STRING_ARRAY, "trace_propagation_targets"), set_trace_propagation_targets, get_trace_propagation_targets);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::ARRAY, "trace_propagation_targets"), set_trace_propagation_targets, get_trace_propagation_targets);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "propagate_traceparent"), set_propagate_traceparent, is_propagate_traceparent_enabled);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "org_id"), set_org_id, get_org_id);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_breadcrumbs"), set_max_breadcrumbs, get_max_breadcrumbs);

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -406,16 +406,18 @@ void SentryOptions::set_trace_propagation_targets(const Array &p_targets) {
 	Array valid_targets;
 	for (const Variant &target : p_targets) {
 		if (target.get_type() == Variant::STRING) {
+			const String text = target;
+			if (!text.is_empty()) {
+				valid_targets.append(target);
+			}
+		} else {
+			ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+			Object *object = target;
+			RegEx *regex = Object::cast_to<RegEx>(object);
+			ERR_CONTINUE_MSG(regex == nullptr, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+			ERR_CONTINUE_MSG(!regex->is_valid(), "Sentry: trace_propagation_targets entries must contain valid regular expressions.");
 			valid_targets.append(target);
-			continue;
 		}
-
-		ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
-		Object *object = target;
-		RegEx *regex = Object::cast_to<RegEx>(object);
-		ERR_CONTINUE_MSG(regex == nullptr, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
-		ERR_CONTINUE_MSG(!regex->is_valid(), "Sentry: trace_propagation_targets entries must contain valid regular expressions.");
-		valid_targets.append(target);
 	}
 
 	trace_propagation_targets = valid_targets;

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -403,19 +403,22 @@ void SentryOptions::release_callables() {
 }
 
 void SentryOptions::set_trace_propagation_targets(const Array &p_targets) {
+	Array valid_targets;
 	for (const Variant &target : p_targets) {
 		if (target.get_type() == Variant::STRING) {
+			valid_targets.append(target);
 			continue;
 		}
 
-		ERR_FAIL_COND_MSG(target.get_type() != Variant::OBJECT, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+		ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
 		Object *object = target;
 		RegEx *regex = Object::cast_to<RegEx>(object);
-		ERR_FAIL_NULL_MSG(regex, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
-		ERR_FAIL_COND_MSG(!regex->is_valid(), "Sentry: trace_propagation_targets entries must contain valid regular expressions.");
+		ERR_CONTINUE_MSG(regex == nullptr, "Sentry: trace_propagation_targets entries must be String or RegEx values.");
+		ERR_CONTINUE_MSG(!regex->is_valid(), "Sentry: trace_propagation_targets entries must contain valid regular expressions.");
+		valid_targets.append(target);
 	}
 
-	trace_propagation_targets = p_targets.duplicate();
+	trace_propagation_targets = valid_targets;
 }
 
 void SentryOptions::_bind_methods() {

--- a/src/sentry/sentry_options.cpp
+++ b/src/sentry/sentry_options.cpp
@@ -129,6 +129,9 @@ void SentryOptions::_define_project_settings(const Ref<SentryOptions> &p_options
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->sample_rate, false);
 	_define_setting(PropertyInfo(Variant::FLOAT, "sentry/options/traces_sample_rate", PROPERTY_HINT_RANGE, "0.0,1.0"), p_options->traces_sample_rate, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), p_options->trace_lifecycle, false);
+	_define_setting("sentry/options/trace_propagation_targets", p_options->trace_propagation_targets, false);
+	_define_setting("sentry/options/propagate_traceparent", p_options->propagate_traceparent, false);
+	_define_setting("sentry/options/org_id", p_options->org_id, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/max_breadcrumbs", PROPERTY_HINT_RANGE, "0, 500"), p_options->max_breadcrumbs, false);
 	_define_setting(PropertyInfo(Variant::INT, "sentry/options/shutdown_timeout_ms", PROPERTY_HINT_RANGE, "0,30000"), p_options->shutdown_timeout_ms, false);
 	_define_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -220,6 +223,9 @@ void SentryOptions::_load_project_settings(const Ref<SentryOptions> &p_options) 
 	p_options->sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/sample_rate", p_options->sample_rate);
 	p_options->traces_sample_rate = ProjectSettings::get_singleton()->get_setting("sentry/options/traces_sample_rate", p_options->traces_sample_rate);
 	p_options->trace_lifecycle = (SentryOptions::TraceLifecycle)(int)ProjectSettings::get_singleton()->get_setting("sentry/options/trace_lifecycle", p_options->trace_lifecycle);
+	p_options->trace_propagation_targets = ProjectSettings::get_singleton()->get_setting("sentry/options/trace_propagation_targets", p_options->trace_propagation_targets);
+	p_options->propagate_traceparent = ProjectSettings::get_singleton()->get_setting("sentry/options/propagate_traceparent", p_options->propagate_traceparent);
+	p_options->org_id = ProjectSettings::get_singleton()->get_setting("sentry/options/org_id", p_options->org_id);
 	p_options->max_breadcrumbs = ProjectSettings::get_singleton()->get_setting("sentry/options/max_breadcrumbs", p_options->max_breadcrumbs);
 	p_options->shutdown_timeout_ms = ProjectSettings::get_singleton()->get_setting("sentry/options/shutdown_timeout_ms", p_options->shutdown_timeout_ms);
 	p_options->send_default_pii = ProjectSettings::get_singleton()->get_setting("sentry/options/send_default_pii", p_options->send_default_pii);
@@ -404,6 +410,9 @@ void SentryOptions::_bind_methods() {
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "sample_rate"), set_sample_rate, get_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::FLOAT, "traces_sample_rate"), set_traces_sample_rate, get_traces_sample_rate);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "trace_lifecycle", PROPERTY_HINT_ENUM, "Static,Stream"), set_trace_lifecycle, get_trace_lifecycle);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::PACKED_STRING_ARRAY, "trace_propagation_targets"), set_trace_propagation_targets, get_trace_propagation_targets);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "propagate_traceparent"), set_propagate_traceparent, is_propagate_traceparent_enabled);
+	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::STRING, "org_id"), set_org_id, get_org_id);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "max_breadcrumbs"), set_max_breadcrumbs, get_max_breadcrumbs);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::INT, "shutdown_timeout_ms", PROPERTY_HINT_RANGE, "0,30000"), set_shutdown_timeout_ms, get_shutdown_timeout_ms);
 	BIND_PROPERTY(SentryOptions, PropertyInfo(Variant::BOOL, "send_default_pii"), set_send_default_pii, is_send_default_pii_enabled);

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -120,7 +120,7 @@ private:
 	double sample_rate = 1.0;
 	double traces_sample_rate = 0.0;
 	TraceLifecycle trace_lifecycle = TRACE_LIFECYCLE_STATIC;
-	PackedStringArray trace_propagation_targets = { ".*" };
+	Array trace_propagation_targets = { ".*" };
 	bool propagate_traceparent = false;
 	String org_id = "";
 	int max_breadcrumbs = 100;
@@ -198,8 +198,8 @@ public:
 	_FORCE_INLINE_ TraceLifecycle get_trace_lifecycle() const { return trace_lifecycle; }
 	_FORCE_INLINE_ void set_trace_lifecycle(TraceLifecycle p_trace_lifecycle) { trace_lifecycle = p_trace_lifecycle; }
 
-	_FORCE_INLINE_ PackedStringArray get_trace_propagation_targets() const { return trace_propagation_targets; }
-	_FORCE_INLINE_ void set_trace_propagation_targets(const PackedStringArray &p_targets) { trace_propagation_targets = p_targets; }
+	_FORCE_INLINE_ Array get_trace_propagation_targets() const { return trace_propagation_targets; }
+	void set_trace_propagation_targets(const Array &p_targets);
 
 	_FORCE_INLINE_ bool is_propagate_traceparent_enabled() const { return propagate_traceparent; }
 	_FORCE_INLINE_ void set_propagate_traceparent(bool p_enabled) { propagate_traceparent = p_enabled; }

--- a/src/sentry/sentry_options.h
+++ b/src/sentry/sentry_options.h
@@ -120,6 +120,9 @@ private:
 	double sample_rate = 1.0;
 	double traces_sample_rate = 0.0;
 	TraceLifecycle trace_lifecycle = TRACE_LIFECYCLE_STATIC;
+	PackedStringArray trace_propagation_targets = { ".*" };
+	bool propagate_traceparent = false;
+	String org_id = "";
 	int max_breadcrumbs = 100;
 	int shutdown_timeout_ms = 2000;
 	bool send_default_pii = false;
@@ -194,6 +197,15 @@ public:
 
 	_FORCE_INLINE_ TraceLifecycle get_trace_lifecycle() const { return trace_lifecycle; }
 	_FORCE_INLINE_ void set_trace_lifecycle(TraceLifecycle p_trace_lifecycle) { trace_lifecycle = p_trace_lifecycle; }
+
+	_FORCE_INLINE_ PackedStringArray get_trace_propagation_targets() const { return trace_propagation_targets; }
+	_FORCE_INLINE_ void set_trace_propagation_targets(const PackedStringArray &p_targets) { trace_propagation_targets = p_targets; }
+
+	_FORCE_INLINE_ bool is_propagate_traceparent_enabled() const { return propagate_traceparent; }
+	_FORCE_INLINE_ void set_propagate_traceparent(bool p_enabled) { propagate_traceparent = p_enabled; }
+
+	_FORCE_INLINE_ String get_org_id() const { return org_id; }
+	_FORCE_INLINE_ void set_org_id(const String &p_org_id) { org_id = p_org_id; }
 
 	_FORCE_INLINE_ int get_max_breadcrumbs() const { return max_breadcrumbs; }
 	_FORCE_INLINE_ void set_max_breadcrumbs(int p_max_breadcrumbs) { max_breadcrumbs = p_max_breadcrumbs; }

--- a/src/sentry/sentry_span.cpp
+++ b/src/sentry/sentry_span.cpp
@@ -14,6 +14,17 @@
 
 namespace {
 
+bool _is_propagation_target(const String &p_url) {
+	const String url = p_url.to_lower();
+	const PackedStringArray targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
+	for (const String &target : targets) {
+		if (target == ".*" || url.contains(target.to_lower())) {
+			return true;
+		}
+	}
+	return false;
+}
+
 Ref<sentry::SentrySpan> _unassigned_sentinel;
 
 void _release_unassigned_sentinel() {
@@ -67,6 +78,15 @@ void SentrySpan::set_status(SpanStatus p_status) {
 	_impl->set_status(p_status);
 }
 
+PackedStringArray SentrySpan::get_trace_headers(const String &p_url) {
+	ERR_SENTRY_THREAD_GUARD_V(PackedStringArray(), WRONG_THREAD_MSG);
+	ERR_FAIL_COND_V_MSG(_ended, PackedStringArray(), "Sentry: Can't read trace headers from a span that has ended.");
+	if (!p_url.is_empty() && !_is_propagation_target(p_url)) {
+		return PackedStringArray();
+	}
+	return _impl->get_trace_headers();
+}
+
 void SentrySpan::end() {
 	ERR_SENTRY_THREAD_GUARD(WRONG_THREAD_MSG);
 	if (_ended) {
@@ -117,6 +137,7 @@ void SentrySpan::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_attribute", "key", "value"), &SentrySpan::set_attribute);
 	ClassDB::bind_method(D_METHOD("set_attributes", "attributes"), &SentrySpan::set_attributes);
 	ClassDB::bind_method(D_METHOD("set_status", "status"), &SentrySpan::set_status);
+	ClassDB::bind_method(D_METHOD("get_trace_headers", "url"), &SentrySpan::get_trace_headers, DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("end"), &SentrySpan::end);
 
 	BIND_ENUM_CONSTANT(SPAN_STATUS_OK);

--- a/src/sentry/sentry_span.cpp
+++ b/src/sentry/sentry_span.cpp
@@ -4,6 +4,8 @@
 #include "sentry/engine_lifecycle/engine_lifecycle.h"
 #include "sentry_sdk.h" // Needed for VariantCaster<SentrySDK::Level>
 
+#include <godot_cpp/classes/reg_ex.hpp>
+#include <godot_cpp/classes/reg_ex_match.hpp>
 #include <godot_cpp/variant/callable_method_pointer.hpp>
 
 #define WRONG_THREAD_MSG \
@@ -16,10 +18,21 @@ namespace {
 
 bool _is_propagation_target(const String &p_url) {
 	const String url = p_url.to_lower();
-	const PackedStringArray targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
-	for (const String &target : targets) {
-		if (target == ".*" || url.contains(target.to_lower())) {
-			return true;
+	const Array targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
+	for (const Variant &target : targets) {
+		if (target.get_type() == Variant::STRING) {
+			const String text = target;
+			if (text == ".*" || url.contains(text.to_lower())) {
+				return true;
+			}
+		} else {
+			ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: Ignoring an invalid trace propagation target.");
+			Object *object = target;
+			RegEx *regex = Object::cast_to<RegEx>(object);
+			ERR_CONTINUE_MSG(regex == nullptr || !regex->is_valid(), "Sentry: Ignoring an invalid trace propagation target.");
+			if (regex->search(p_url).is_valid()) {
+				return true;
+			}
 		}
 	}
 	return false;

--- a/src/sentry/sentry_span.h
+++ b/src/sentry/sentry_span.h
@@ -51,6 +51,8 @@ public:
 
 	void set_status(SpanStatus p_status);
 
+	PackedStringArray get_trace_headers(const String &p_url);
+
 	void end();
 
 	// *** Not exposed in the public API

--- a/src/sentry/sentry_span_impl.h
+++ b/src/sentry/sentry_span_impl.h
@@ -23,6 +23,8 @@ public:
 	virtual void set_status(SpanStatus p_status) = 0;
 	virtual void end() = 0;
 
+	virtual PackedStringArray get_trace_headers() = 0;
+
 	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) = 0;
 
 	virtual ~SentrySpanImpl() = default;

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -98,6 +98,8 @@ TEST_SUITE("[.NET] Options interop") {
 			const HashSet<String> not_crossed = {
 				// Only affects the JavaScript SDK on Web.
 				"trace_lifecycle",
+				// Trace propagation options, not mirrored to the managed layer yet (follow-up needed).
+				"trace_propagation_targets", "propagate_traceparent", "org_id",
 				// Deprecated no-ops.
 				"enable_logs", "enable_metrics",
 				// Deprecated aliases for the properties above.


### PR DESCRIPTION
Adds `SentrySpan.get_trace_headers()` so outgoing requests can continue the active trace in downstream services. Also, adds `SentryOptions.trace_propagation_targets` for URL filtering, `SentryOptions.propagate_traceparent` for optional W3C `traceparent` support, and `SentryOptions.org_id` for overriding the organization ID, as described by the [Trace Propagation / Strict trace continuation](https://develop.sentry.dev/sdk/foundations/trace-propagation/) docs. Supported options are forwarded to Native, Android, Cocoa, and Web; .NET synchronization is deferred to a follow-up.

- Refs #907
- Refs #670

**Usage example:**

```gdscript
var span := SentrySDK.start_span("fetch_scores")
var request := HTTPRequest.new()
add_child(request)
request.request(url, span.get_trace_headers(url))

# On HTTP request completed
span.end()
```
