### PR TITLE
feat(dotnet): Sync trace propagation options

### DIFF
--- a/project/test/dotnet/DotnetTestHarness.cs
+++ b/project/test/dotnet/DotnetTestHarness.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using Godot;
 using Sentry;
 using Sentry.Godot;
@@ -51,6 +53,25 @@ public partial class DotnetTestHarness : RefCounted
 
     private readonly Godot.Collections.Dictionary _receivedOptions = [];
     public Godot.Collections.Dictionary GetReceivedOptions() => _receivedOptions;
+
+    public string[] GetCurrentTracePropagationTargets()
+    {
+        var optionsProperty = typeof(SentrySdk).GetProperty("CurrentOptions", BindingFlags.NonPublic | BindingFlags.Static);
+        if (optionsProperty?.GetValue(null) is not SentryGodotOptions options)
+        {
+            return [];
+        }
+
+        var regexField = typeof(StringOrRegex).GetField("_regex", BindingFlags.NonPublic | BindingFlags.Instance);
+        var targets = new string[options.TracePropagationTargets.Count];
+        for (int i = 0; i < targets.Length; i++)
+        {
+            var target = options.TracePropagationTargets[i];
+            string type = regexField?.GetValue(target) is Regex ? "regex" : "string";
+            targets[i] = $"{type}:{target}";
+        }
+        return targets;
+    }
 
     /// <summary>
     /// Records every option the native layer handed over, then writes a different value to each one.

--- a/project/test/dotnet/DotnetTestHarness.cs
+++ b/project/test/dotnet/DotnetTestHarness.cs
@@ -72,6 +72,14 @@ public partial class DotnetTestHarness : RefCounted
             _receivedOptions["diagnostic_level"] = (int)options.DiagnosticLevel;
             _receivedOptions["sample_rate"] = options.SampleRate ?? -1.0f;
             _receivedOptions["traces_sample_rate"] = options.TracesSampleRate ?? -1.0;
+            var tracePropagationTargets = new string[options.TracePropagationTargets.Count];
+            for (int i = 0; i < tracePropagationTargets.Length; i++)
+            {
+                tracePropagationTargets[i] = options.TracePropagationTargets[i].ToString();
+            }
+            _receivedOptions["trace_propagation_targets"] = tracePropagationTargets;
+            _receivedOptions["propagate_traceparent"] = options.PropagateTraceparent;
+            _receivedOptions["org_id"] = options.OrgId;
             _receivedOptions["max_breadcrumbs"] = options.MaxBreadcrumbs;
             _receivedOptions["shutdown_timeout_ms"] = (int)options.ShutdownTimeout.TotalMilliseconds;
             _receivedOptions["send_default_pii"] = options.SendDefaultPii;
@@ -105,6 +113,11 @@ public partial class DotnetTestHarness : RefCounted
             options.DiagnosticLevel = SentryLevel.Error;
             options.SampleRate = 0.75f;
             options.TracesSampleRate = 0.8;
+            options.TracePropagationTargets.Clear();
+            options.TracePropagationTargets.Add("ccc");
+            options.TracePropagationTargets.Add("ddd");
+            options.PropagateTraceparent = false;
+            options.OrgId = "222";
             options.MaxBreadcrumbs = 22;
             options.ShutdownTimeout = TimeSpan.FromMilliseconds(2200);
             options.SendDefaultPii = false;

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -53,6 +53,34 @@ CSHARP_EXPORT void csharp_interop_string_free(void *p_handle) {
 	}
 }
 
+// Generic array handle for returning native-allocated arrays across the interop boundary.
+// C# casts "ptr" to the concrete element type and must free it via csharp_interop_free_array().
+struct NativeArray {
+	void *ptr;
+	int32_t count;
+};
+
+CSHARP_EXPORT void csharp_interop_free_array(void *p_array) {
+	if (p_array) {
+		// Equivalent to memdelete_arr() for trivially-destructible types.
+		// memdelete_arr() can't be used directly here because the call site only has a void*.
+		Memory::free_static(p_array, true);
+	}
+}
+
+static NativeArray _make_string_array(const PackedStringArray &p_strings) {
+	NativeArray result = {};
+	result.count = p_strings.size();
+	if (result.count > 0) {
+		GodotStringHandle *items = memnew_arr(GodotStringHandle, result.count);
+		for (int32_t i = 0; i < result.count; i++) {
+			items[i] = _make_handle(p_strings[i]);
+		}
+		result.ptr = items;
+	}
+	return result;
+}
+
 // Managed-owned string map for passing Dictionary<string, string> across P/Invoke.
 // C# builds and pins this; native reads it synchronously during the call.
 // Buffer layout: key1+val1+key2+val2... concatenated as UTF-16.
@@ -80,6 +108,30 @@ static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map)
 		dict[key] = val;
 	}
 	return dict;
+}
+
+// Managed-owned string list for passing string arrays across P/Invoke.
+// C# builds and pins this; native reads it synchronously during the call.
+// Buffer layout: all strings concatenated as UTF-16, with one length per entry.
+struct ManagedStringList {
+	const char16_t *buffer;
+	const int32_t *lengths;
+	int32_t count;
+};
+
+static PackedStringArray _managed_string_list_to_packed_array(const ManagedStringList &list) {
+	PackedStringArray result;
+	if (list.count <= 0 || list.buffer == nullptr || list.lengths == nullptr) {
+		return result;
+	}
+	const char16_t *ptr = list.buffer;
+	result.resize(list.count);
+	for (int32_t i = 0; i < list.count; i++) {
+		const int32_t length = list.lengths[i];
+		result[i] = String::utf16(ptr, length);
+		ptr += length;
+	}
+	return result;
 }
 
 // Managed functions that are called from native layer.
@@ -164,22 +216,12 @@ struct NativeOptions {
 	uint8_t android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
 	uint8_t android_attach_anr_thread_dump;
-};
 
-// Generic array handle for returning native-allocated arrays across the interop boundary.
-// C# casts "ptr" to the concrete element type and must free it via csharp_interop_free_array().
-struct NativeArray {
-	void *ptr;
-	int32_t count;
+	// Trace propagation
+	GodotStringHandle org_id;
+	NativeArray trace_propagation_targets;
+	uint8_t propagate_traceparent;
 };
-
-CSHARP_EXPORT void csharp_interop_free_array(void *p_array) {
-	if (p_array) {
-		// Equivalent to memdelete_arr() for trivially-destructible types.
-		// memdelete_arr() can't be used directly here because the call site only has a void*.
-		Memory::free_static(p_array, true);
-	}
-}
 
 // Managed-owned options for passing C# options to native.
 // C# pins strings; native reads synchronously. No free needed.
@@ -224,6 +266,12 @@ struct ManagedOptions {
 	uint8_t android_enable_anr_detection;
 	int32_t android_anr_timeout_interval_ms;
 	uint8_t android_attach_anr_thread_dump;
+
+	// Trace propagation
+	const char16_t *org_id;
+	int32_t org_id_len;
+	ManagedStringList trace_propagation_targets;
+	uint8_t propagate_traceparent;
 };
 
 struct NativeTraceContext {
@@ -264,6 +312,9 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->get_android()->set_enable_anr_detection(data.android_enable_anr_detection);
 	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
 	options->get_android()->set_attach_anr_thread_dump(data.android_attach_anr_thread_dump);
+	options->set_org_id(String::utf16(data.org_id, data.org_id_len));
+	options->set_trace_propagation_targets(_managed_string_list_to_packed_array(data.trace_propagation_targets));
+	options->set_propagate_traceparent(data.propagate_traceparent);
 }
 
 void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &options) {
@@ -301,6 +352,9 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.android_enable_anr_detection = options->get_android()->get_enable_anr_detection();
 	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();
 	r_data.android_attach_anr_thread_dump = options->get_android()->get_attach_anr_thread_dump();
+	r_data.org_id = _make_handle(options->get_org_id());
+	r_data.trace_propagation_targets = _make_string_array(options->get_trace_propagation_targets());
+	r_data.propagate_traceparent = options->is_propagate_traceparent_enabled();
 }
 
 // *** Functions called from C#

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -19,6 +19,7 @@
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/core/type_info.hpp>
 
 #include <cstring>
@@ -68,13 +69,26 @@ CSHARP_EXPORT void csharp_interop_free_array(void *p_array) {
 	}
 }
 
-static NativeArray _make_string_array(const PackedStringArray &p_strings) {
+// Must match layout of NativeTracePropagationTarget in NativeBridge.cs.
+struct NativeTracePropagationTarget {
+	GodotStringHandle pattern;
+	uint8_t is_regex;
+};
+
+static NativeArray _make_trace_propagation_targets(const Array &p_targets) {
 	NativeArray result = {};
-	result.count = p_strings.size();
-	if (result.count > 0) {
-		GodotStringHandle *items = memnew_arr(GodotStringHandle, result.count);
-		for (int32_t i = 0; i < result.count; i++) {
-			items[i] = _make_handle(p_strings[i]);
+	if (!p_targets.is_empty()) {
+		NativeTracePropagationTarget *items = memnew_arr(NativeTracePropagationTarget, p_targets.size());
+		for (const Variant &target : p_targets) {
+			if (target.get_type() == Variant::STRING) {
+				items[result.count++] = { _make_handle(target), false };
+			} else {
+				ERR_CONTINUE_MSG(target.get_type() != Variant::OBJECT, "Sentry: Ignoring an invalid trace propagation target.");
+				Object *object = target;
+				RegEx *regex = Object::cast_to<RegEx>(object);
+				ERR_CONTINUE_MSG(regex == nullptr || !regex->is_valid(), "Sentry: Ignoring an invalid trace propagation target.");
+				items[result.count++] = { _make_handle(regex->get_pattern()), true };
+			}
 		}
 		result.ptr = items;
 	}
@@ -353,7 +367,7 @@ void _populate_options_data(NativeOptions &r_data, const Ref<SentryOptions> &opt
 	r_data.android_anr_timeout_interval_ms = options->get_android()->get_anr_timeout_interval_ms();
 	r_data.android_attach_anr_thread_dump = options->get_android()->get_attach_anr_thread_dump();
 	r_data.org_id = _make_handle(options->get_org_id());
-	r_data.trace_propagation_targets = _make_string_array(options->get_trace_propagation_targets());
+	r_data.trace_propagation_targets = _make_trace_propagation_targets(options->get_trace_propagation_targets());
 	r_data.propagate_traceparent = options->is_propagate_traceparent_enabled();
 }
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -52,6 +52,29 @@ internal static partial class NativeBridge
         public IntPtr Ptr;
         public int Count;
 
+        public unsafe string[] TakeStrings()
+        {
+            try
+            {
+                if (Ptr == IntPtr.Zero)
+                {
+                    return [];
+                }
+
+                var result = new string[Count];
+                var strings = (GodotStringHandle*)Ptr;
+                for (int i = 0; i < Count; i++)
+                {
+                    result[i] = strings[i].TakeString() ?? "";
+                }
+                return result;
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+
         public void Dispose()
         {
             if (Ptr != IntPtr.Zero)
@@ -136,6 +159,9 @@ internal static partial class NativeBridge
         public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
         public byte android_attach_anr_thread_dump;
+        public GodotStringHandle org_id;
+        public NativeArray trace_propagation_targets;
+        public byte propagate_traceparent;
     }
 
     // Must match layout of ManagedOptions in csharp_interop.cpp.
@@ -174,6 +200,10 @@ internal static partial class NativeBridge
         public byte android_enable_anr_detection;
         public int android_anr_timeout_interval_ms;
         public byte android_attach_anr_thread_dump;
+        public char* org_id;
+        public int org_id_len;
+        public ManagedStringList trace_propagation_targets;
+        public byte propagate_traceparent;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -193,6 +223,17 @@ internal static partial class NativeBridge
         public char* Buffer;
         public int* Lengths;
         public int PairCount;
+    }
+
+    // Managed-owned string list for passing string arrays across P/Invoke.
+    // Buffer layout: all strings concatenated as UTF-16, with one length per entry.
+    // Must match layout of ManagedStringList in csharp_interop.cpp.
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct ManagedStringList
+    {
+        public char* Buffer;
+        public int* Lengths;
+        public int Count;
     }
 
     private delegate void ManagedStringMapAction(ManagedStringMap map);
@@ -249,6 +290,28 @@ internal static partial class NativeBridge
             };
             nativeFunc(map);
         }
+    }
+
+    private static (char[] Buffer, int[] Lengths) MarshallStringList<T>(IList<T> values)
+    {
+        int totalChars = 0;
+        for (int i = 0; i < values.Count; i++)
+        {
+            totalChars += values[i]?.ToString()?.Length ?? 0;
+        }
+
+        var lengths = new int[values.Count];
+        var buffer = new char[Math.Max(totalChars, 1)];
+
+        int position = 0;
+        for (int i = 0; i < values.Count; i++)
+        {
+            string value = values[i]?.ToString() ?? "";
+            lengths[i] = value.Length;
+            value.CopyTo(0, buffer, position, value.Length);
+            position += value.Length;
+        }
+        return (buffer, lengths);
     }
 
     // Must match ManagedFunctions struct in csharp_interop.cpp
@@ -554,6 +617,13 @@ internal static partial class NativeBridge
         opts.Android.EnableAnrDetection = data.android_enable_anr_detection != 0;
         opts.Android.AnrTimeoutInterval = TimeSpan.FromMilliseconds(data.android_anr_timeout_interval_ms);
         opts.Android.AttachAnrThreadDump = data.android_attach_anr_thread_dump != 0;
+        opts.OrgId = data.org_id.TakeString();
+        opts.TracePropagationTargets.Clear();
+        foreach (string target in data.trace_propagation_targets.TakeStrings())
+        {
+            opts.TracePropagationTargets.Add(target);
+        }
+        opts.PropagateTraceparent = data.propagate_traceparent != 0;
     }
 
     public static void ApplyNativeOptions(SentryGodotOptions opts)
@@ -807,11 +877,17 @@ internal static partial class NativeBridge
         var release = opts.Release ?? "";
         var dist = opts.Distribution ?? "";
         var env = opts.Environment ?? "";
+        var orgId = opts.OrgId ?? "";
+        var (tracePropagationTargetsBuffer, tracePropagationTargetsLengths) =
+                MarshallStringList(opts.TracePropagationTargets);
 
         fixed (char* dsnPtr = dsn)
         fixed (char* relPtr = release)
         fixed (char* distPtr = dist)
         fixed (char* envPtr = env)
+        fixed (char* orgIdPtr = orgId)
+        fixed (char* tracePropagationTargetsPtr = tracePropagationTargetsBuffer)
+        fixed (int* tracePropagationTargetLengthsPtr = tracePropagationTargetsLengths)
         {
             var managed = new ManagedOptions
             {
@@ -853,6 +929,15 @@ internal static partial class NativeBridge
                 android_enable_anr_detection = (byte)(opts.Android.EnableAnrDetection ? 1 : 0),
                 android_anr_timeout_interval_ms = (int)opts.Android.AnrTimeoutInterval.TotalMilliseconds,
                 android_attach_anr_thread_dump = (byte)(opts.Android.AttachAnrThreadDump ? 1 : 0),
+                org_id = orgIdPtr,
+                org_id_len = orgId.Length,
+                trace_propagation_targets = new ManagedStringList
+                {
+                    Buffer = tracePropagationTargetsPtr,
+                    Lengths = tracePropagationTargetLengthsPtr,
+                    Count = tracePropagationTargetsLengths.Length,
+                },
+                propagate_traceparent = (byte)(opts.PropagateTraceparent ? 1 : 0),
             };
             csharp_interop_sdk_init(managed);
         }

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Sentry.Godot.Internal;
 using Sentry.Protocol;
 
@@ -52,29 +53,6 @@ internal static partial class NativeBridge
         public IntPtr Ptr;
         public int Count;
 
-        public unsafe string[] TakeStrings()
-        {
-            try
-            {
-                if (Ptr == IntPtr.Zero)
-                {
-                    return [];
-                }
-
-                var result = new string[Count];
-                var strings = (GodotStringHandle*)Ptr;
-                for (int i = 0; i < Count; i++)
-                {
-                    result[i] = strings[i].TakeString() ?? "";
-                }
-                return result;
-            }
-            finally
-            {
-                Dispose();
-            }
-        }
-
         public void Dispose()
         {
             if (Ptr != IntPtr.Zero)
@@ -82,6 +60,58 @@ internal static partial class NativeBridge
                 csharp_interop_free_array(Ptr);
                 Ptr = IntPtr.Zero;
             }
+        }
+    }
+
+    // Must match layout of NativeTracePropagationTarget in csharp_interop.cpp.
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeTracePropagationTarget
+    {
+        public GodotStringHandle Pattern;
+        public byte IsRegex;
+    }
+
+    private static unsafe StringOrRegex[] TakeTracePropagationTargets(NativeArray array)
+    {
+        try
+        {
+            if (array.Ptr == IntPtr.Zero)
+            {
+                return [];
+            }
+
+            var patterns = new string[array.Count];
+            var regexFlags = new bool[array.Count];
+            var targets = (NativeTracePropagationTarget*)array.Ptr;
+            for (int i = 0; i < array.Count; i++)
+            {
+                patterns[i] = targets[i].Pattern.TakeString() ?? "";
+                regexFlags[i] = targets[i].IsRegex != 0;
+            }
+
+            var result = new List<StringOrRegex>(array.Count);
+            for (int i = 0; i < array.Count; i++)
+            {
+                if (!regexFlags[i])
+                {
+                    result.Add(patterns[i]);
+                    continue;
+                }
+
+                try
+                {
+                    result.Add(new Regex(patterns[i]));
+                }
+                catch (ArgumentException)
+                {
+                    GodotLog.Warn($"Sentry: Ignoring trace propagation target '{patterns[i]}' because it is not a valid .NET regular expression.");
+                }
+            }
+            return result.ToArray();
+        }
+        finally
+        {
+            array.Dispose();
         }
     }
 
@@ -619,7 +649,7 @@ internal static partial class NativeBridge
         opts.Android.AttachAnrThreadDump = data.android_attach_anr_thread_dump != 0;
         opts.OrgId = data.org_id.TakeString();
         opts.TracePropagationTargets.Clear();
-        foreach (string target in data.trace_propagation_targets.TakeStrings())
+        foreach (StringOrRegex target in TakeTracePropagationTargets(data.trace_propagation_targets))
         {
             opts.TracePropagationTargets.Add(target);
         }
@@ -878,6 +908,8 @@ internal static partial class NativeBridge
         var dist = opts.Distribution ?? "";
         var env = opts.Environment ?? "";
         var orgId = opts.OrgId ?? "";
+        // LIMITATION: sentry-dotnet does not expose whether StringOrRegex contains a regex,
+        // so managed targets cross as literals.
         var (tracePropagationTargetsBuffer, tracePropagationTargetsLengths) =
                 MarshallStringList(opts.TracePropagationTargets);
 

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -52,6 +52,7 @@ TEST_SUITE("[.NET] Options interop") {
 		// in DotnetTestHarness.cs, keyed by the last segment of the property path.
 		// The two value columns must differ from each other, and "from native" must differ from the
 		// option's C# default, or the managed side reports a value that never crossed and the row passes.
+		using Strings = PackedStringArray;
 		const LocalVector<OptionCase> cases = {
 			// clang-format off
 			// project setting                                                 property                                        from native                     from managed
@@ -63,6 +64,9 @@ TEST_SUITE("[.NET] Options interop") {
 			{ "sentry/options/diagnostic_level",                               "diagnostic_level",                             LEVEL_WARNING,                  LEVEL_ERROR },
 			{ "sentry/options/sample_rate",                                    "sample_rate",                                  0.5,                            0.75 },
 			{ "sentry/options/traces_sample_rate",                             "traces_sample_rate",                           0.6,                            0.8 },
+			{ "sentry/options/trace_propagation_targets",                      "trace_propagation_targets",                    Strings({ "aaa", "bbb" }),      Strings({ "ccc", "ddd" }) },
+			{ "sentry/options/propagate_traceparent",                          "propagate_traceparent",                        true,                           false },
+			{ "sentry/options/org_id",                                         "org_id",                                       "111",                          "222" },
 			{ "sentry/options/max_breadcrumbs",                                "max_breadcrumbs",                              11,                             22 },
 			{ "sentry/options/shutdown_timeout_ms",                            "shutdown_timeout_ms",                          1100,                           2200 },
 			{ "sentry/options/send_default_pii",                               "send_default_pii",                             true,                           false },
@@ -98,8 +102,6 @@ TEST_SUITE("[.NET] Options interop") {
 			const HashSet<String> not_crossed = {
 				// Only affects the JavaScript SDK on Web.
 				"trace_lifecycle",
-				// Trace propagation options, not mirrored to the managed layer yet (follow-up needed).
-				"trace_propagation_targets", "propagate_traceparent", "org_id",
 				// Deprecated no-ops.
 				"enable_logs", "enable_metrics",
 				// Deprecated aliases for the properties above.

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -11,8 +11,10 @@
 
 #include <godot_cpp/classes/class_db_singleton.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
+#include <godot_cpp/variant/callable_method_pointer.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
 
 #include <string>
@@ -44,6 +46,13 @@ String option_name(const OptionCase &p_option) {
 	return path.substr(path.rfind(":") + 1);
 }
 
+void _configure_regex_trace_propagation_target(const Ref<SentryOptions> &p_options) {
+	Ref<RegEx> regex;
+	regex.instantiate();
+	REQUIRE(regex->compile("api\\.example\\.com") == OK);
+	p_options->set_trace_propagation_targets(Array({ "literal.example.com", regex }));
+}
+
 } // unnamed namespace
 
 TEST_SUITE("[.NET] Options interop") {
@@ -64,7 +73,7 @@ TEST_SUITE("[.NET] Options interop") {
 			{ "sentry/options/diagnostic_level",                               "diagnostic_level",                             LEVEL_WARNING,                  LEVEL_ERROR },
 			{ "sentry/options/sample_rate",                                    "sample_rate",                                  0.5,                            0.75 },
 			{ "sentry/options/traces_sample_rate",                             "traces_sample_rate",                           0.6,                            0.8 },
-			{ "sentry/options/trace_propagation_targets",                      "trace_propagation_targets",                    Strings({ "aaa", "bbb" }),      Strings({ "ccc", "ddd" }) },
+			{ "sentry/options/trace_propagation_targets",                      "trace_propagation_targets",                    Strings({ "aaa", "bbb" }),      Array({ "ccc", "ddd" }) },
 			{ "sentry/options/propagate_traceparent",                          "propagate_traceparent",                        true,                           false },
 			{ "sentry/options/org_id",                                         "org_id",                                       "111",                          "222" },
 			{ "sentry/options/max_breadcrumbs",                                "max_breadcrumbs",                              11,                             22 },
@@ -157,6 +166,20 @@ TEST_SUITE("[.NET] Options interop") {
 			for (const OptionCase &option : cases) {
 				ProjectSettings::get_singleton()->set_setting(option.setting, saved[option.setting]);
 			}
+		}
+
+		SUBCASE("Native regex propagation targets remain regexes in .NET") {
+			if (!sentry::dotnet::godot_supports_dotnet()) {
+				MESSAGE("Skipping: managed runtime unavailable (non-mono Godot build).");
+				return;
+			}
+
+			Object *harness = sentry::tests::get_dotnet_harness();
+			REQUIRE(harness != nullptr);
+			SentrySDK::get_singleton()->init(callable_mp_static(&_configure_regex_trace_propagation_target));
+			const PackedStringArray targets = harness->call("GetCurrentTracePropagationTargets");
+			CHECK(targets == PackedStringArray({ "string:literal.example.com", "regex:api\\.example\\.com" }));
+			SentrySDK::get_singleton()->close();
 		}
 	}
 }


### PR DESCRIPTION
Synchronizes `trace_propagation_targets`, `propagate_traceparent`, and `org_id` in both directions across the .NET interop boundary so both layers use the same trace propagation configuration. The parent PR carries the changelog entry. #skip-changelog

- Depends on #915
- Refs https://github.com/getsentry/sentry-dotnet/pull/5543
