### PR TITLE
feat(apple): Add GDScript span support on macOS and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,13 @@
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))
 - Add the `SentryOptions.before_send_feedback` callback to filter or enrich user feedback before it is sent ([#878](https://github.com/getsentry/sentry-godot/pull/878))
   - Not supported on macOS and iOS yet, where feedback is still sent but the callback never runs
-- Add Spans support to the GDScript API for measuring operations and grouping telemetry captured while they run ([#863](https://github.com/getsentry/sentry-godot/pull/863), [#875](https://github.com/getsentry/sentry-godot/pull/875), [#886](https://github.com/getsentry/sentry-godot/pull/886))
+- Add Spans support to the GDScript API for measuring operations and grouping telemetry captured while they run ([#863](https://github.com/getsentry/sentry-godot/pull/863), [#875](https://github.com/getsentry/sentry-godot/pull/875), [#886](https://github.com/getsentry/sentry-godot/pull/886), [#921](https://github.com/getsentry/sentry-godot/pull/921))
   - `SentrySDK.start_span()` starts a span and makes it active, and `SentrySDK.get_active_span()` returns the active span for the calling thread
   - `SentrySDK.with_span()` runs a callable with an active span and ends it on return ([#892](https://github.com/getsentry/sentry-godot/pull/892))
   - The new `SentrySpan` class carries attributes and status; call `SentrySpan.end()` to finish the operation
   - Events captured during an active span are associated with that operation
   - `SentryOptions.traces_sample_rate` controls the share of traces sent to Sentry. It defaults to `0.0`; set it above `0.0` to enable performance tracing and send spans
   - `SentryOptions.trace_lifecycle` selects whether traces are sent as transactions or individual spans; it currently only affects Web ([#895](https://github.com/getsentry/sentry-godot/pull/895))
-  - Not supported on macOS or iOS yet, where the SDK returns a no-op span with a warning
 - Add `SentrySDK.start_new_trace()` to start a trace unconnected to the current one, so the telemetry captured afterwards is grouped separately ([#909](https://github.com/getsentry/sentry-godot/pull/909))
 - Synchronize traces started in the native layer with the .NET layer, so telemetry captured from C# is associated with the same trace ([#910](https://github.com/getsentry/sentry-godot/pull/910))
 - Add distributed trace propagation from spans: `SentrySpan.get_trace_headers()` returns request headers for continuing a trace, with `SentryOptions.trace_propagation_targets`, `propagate_traceparent`, and `org_id` controlling where and how they are sent ([#915](https://github.com/getsentry/sentry-godot/pull/915))

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -2,12 +2,6 @@ extends SentryTestSuite
 ## Verifies trace header filtering and the W3C traceparent option.
 
 
-# TODO: drop the skip when Cocoa gains span support.
-func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
-		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
-	super()
-
-
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.traces_sample_rate = 1.0

--- a/project/test/isolated/test_trace_propagation_disabled.gd
+++ b/project/test/isolated/test_trace_propagation_disabled.gd
@@ -2,12 +2,6 @@ extends SentryTestSuite
 ## Verifies that an empty trace_propagation_targets list propagates to nothing.
 
 
-# TODO: drop the skip when Cocoa gains span support.
-func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
-		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
-	super()
-
-
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
 		options.traces_sample_rate = 0.0

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -2,12 +2,6 @@ extends SentryTestSuite
 ## Verifies events captured while a span is active are stamped with that span.
 
 
-# TODO: drop the skip when Cocoa gains span support.
-func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
-		_skip_reason = "Spans are not implemented on this platform yet.") -> void:
-	super()
-
-
 func after_test() -> void:
 	super()
 	SentrySDK.get_current_scope().clear()

--- a/src/sentry/cocoa/cocoa_includes.h
+++ b/src/sentry/cocoa/cocoa_includes.h
@@ -12,6 +12,7 @@
 
 // Allow headers to compile: In C++ context, the ObjC types are not available.
 using SentryObjCScope = void;
+using SentryObjCSpan = void;
 using SentryObjCEvent = void;
 using SentryObjCBreadcrumb = void;
 using SentryObjCLog = void;

--- a/src/sentry/cocoa/cocoa_scope.h
+++ b/src/sentry/cocoa/cocoa_scope.h
@@ -20,6 +20,7 @@ public:
 	virtual void set_level(sentry::Level p_level) override;
 	virtual void set_fingerprint(const PackedStringArray &p_fingerprint) override;
 	virtual void set_attribute(const String &p_name, const Variant &p_value) override;
+	virtual void set_span(SentrySpanImpl *p_span) override;
 	virtual void add_breadcrumb(const Ref<SentryBreadcrumb> &p_breadcrumb) override;
 	virtual void add_attachment(const Ref<SentryAttachment> &p_attachment) override;
 	virtual void clear() override;

--- a/src/sentry/cocoa/cocoa_scope.mm
+++ b/src/sentry/cocoa/cocoa_scope.mm
@@ -1,6 +1,7 @@
 #include "cocoa_scope.h"
 
 #include "cocoa_breadcrumb.h"
+#include "cocoa_span.h"
 #include "cocoa_util.h"
 
 namespace sentry::cocoa {
@@ -45,6 +46,11 @@ void CocoaScope::add_attachment(const Ref<SentryAttachment> &p_attachment) {
 
 void CocoaScope::clear() {
 	[_scope clear];
+}
+
+void CocoaScope::set_span(SentrySpanImpl *p_span) {
+	CocoaSpan *span = Castable::cast_to<CocoaSpan>(p_span);
+	_scope.span = span ? span->get_cocoa_span() : nil;
 }
 
 SentryScopeImpl *CocoaScope::clone() const {

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -6,6 +6,7 @@
 #include "cocoa_log.h"
 #include "cocoa_metric.h"
 #include "cocoa_scope.h"
+#include "cocoa_span.h"
 #include "cocoa_util.h"
 #include "gen/sdk_version.gen.h"
 #include "sentry/common_defs.h"
@@ -308,8 +309,7 @@ SentryScopeImpl *CocoaSDK::create_scope() {
 }
 
 SentrySpanImpl *CocoaSDK::create_span(const String &p_name, const Dictionary &p_attributes) {
-	WARN_PRINT_ONCE("Sentry: Spans are not implemented on this platform yet - nothing will be recorded.");
-	return SentrySpanImpl::create_noop();
+	return CocoaSpan::start_root(p_name, p_attributes);
 }
 
 void CocoaSDK::set_trace(const String &p_trace_id, const String &p_parent_span_id) {
@@ -333,6 +333,7 @@ void CocoaSDK::init() {
 		options.releaseName = string_to_objc(SENTRY_OPTIONS()->get_release());
 		options.environment = string_to_objc(SENTRY_OPTIONS()->get_environment());
 		options.sampleRate = double_to_objc(SENTRY_OPTIONS()->get_sample_rate());
+		options.tracesSampleRate = double_to_objc(SENTRY_OPTIONS()->get_traces_sample_rate());
 		options.maxBreadcrumbs = (NSUInteger)SENTRY_OPTIONS()->get_max_breadcrumbs();
 		options.sendDefaultPii = SENTRY_OPTIONS()->is_send_default_pii_enabled();
 		options.diagnosticLevel = sentry_level_to_objc(SENTRY_OPTIONS()->get_diagnostic_level());

--- a/src/sentry/cocoa/cocoa_span.h
+++ b/src/sentry/cocoa/cocoa_span.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "cocoa_includes.h"
+#include "sentry/sentry_span_impl.h"
+
+namespace sentry::cocoa {
+
+class CocoaSpan : public SentrySpanImpl {
+	SENTRY_CASTABLE(CocoaSpan, SentrySpanImpl);
+
+private:
+	SentryObjCSpan *_span;
+
+	void _apply_attributes(const Dictionary &p_attributes);
+
+public:
+	_FORCE_INLINE_ SentryObjCSpan *get_cocoa_span() const { return _span; }
+
+	static SentrySpanImpl *start_root(const String &p_name, const Dictionary &p_attributes);
+	virtual SentrySpanImpl *start_child(const String &p_name, const Dictionary &p_attributes) override;
+	virtual void set_attribute(const String &p_key, const Variant &p_value) override;
+	virtual void set_status(SpanStatus p_status) override;
+	virtual void end() override;
+	virtual PackedStringArray get_trace_headers() override;
+
+	CocoaSpan(SentryObjCSpan *p_span, const Dictionary &p_attributes);
+	virtual ~CocoaSpan() override;
+};
+
+} //namespace sentry::cocoa

--- a/src/sentry/cocoa/cocoa_span.mm
+++ b/src/sentry/cocoa/cocoa_span.mm
@@ -3,6 +3,16 @@
 #include "cocoa_util.h"
 #include "sentry/sentry_sdk.h"
 
+namespace {
+
+bool _is_noop(SentryObjCSpan *p_span) {
+	// Cocoa returns a no-op span with empty IDs when the owning transaction is gone or finished.
+	return [p_span.traceId.sentryIdString isEqualToString:SentryObjCId.empty.sentryIdString] ||
+			[p_span.spanId.sentrySpanIdString isEqualToString:SentryObjCSpanId.empty.sentrySpanIdString];
+}
+
+} // unnamed namespace
+
 namespace sentry::cocoa {
 
 SentrySpanImpl *CocoaSpan::start_root(const String &p_name, const Dictionary &p_attributes) {
@@ -23,12 +33,18 @@ SentrySpanImpl *CocoaSpan::start_root(const String &p_name, const Dictionary &p_
 			parentSampleRand:nil];
 	// Cocoa returns a span even for unsampled transactions; its headers still carry the trace context and sampling decision.
 	SentryObjCSpan *span = [SentryObjCSDK startTransactionWithContext:context bindToScope:NO];
+	if (_is_noop(span)) {
+		return SentrySpanImpl::create_noop();
+	}
 	return memnew(CocoaSpan(span, p_attributes));
 }
 
 SentrySpanImpl *CocoaSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
 	SentryObjCSpan *child = [_span startChildWithOperation:string_to_objc(p_attributes.get("sentry.op", String()))
 											   description:string_to_objc(p_name)];
+	if (_is_noop(child)) {
+		return SentrySpanImpl::create_noop();
+	}
 	return memnew(CocoaSpan(child, p_attributes));
 }
 

--- a/src/sentry/cocoa/cocoa_span.mm
+++ b/src/sentry/cocoa/cocoa_span.mm
@@ -21,6 +21,7 @@ SentrySpanImpl *CocoaSpan::start_root(const String &p_name, const Dictionary &p_
 			   parentSampled:SentryObjCSampleDecisionUndecided
 			parentSampleRate:nil
 			parentSampleRand:nil];
+	// Cocoa returns a span even for unsampled transactions; its headers still carry the trace context and sampling decision.
 	SentryObjCSpan *span = [SentryObjCSDK startTransactionWithContext:context bindToScope:NO];
 	return memnew(CocoaSpan(span, p_attributes));
 }

--- a/src/sentry/cocoa/cocoa_span.mm
+++ b/src/sentry/cocoa/cocoa_span.mm
@@ -1,0 +1,81 @@
+#include "cocoa_span.h"
+
+#include "cocoa_util.h"
+#include "sentry/sentry_sdk.h"
+
+namespace sentry::cocoa {
+
+SentrySpanImpl *CocoaSpan::start_root(const String &p_name, const Dictionary &p_attributes) {
+	if (!SentryObjCSDK.isEnabled) {
+		return SentrySpanImpl::create_noop();
+	}
+	const SentrySDK::TraceContext trace = SentrySDK::get_singleton()->get_trace_context();
+	SentryObjCTransactionContext *context = [[SentryObjCTransactionContext alloc]
+				initWithName:string_to_objc(p_name)
+				   operation:string_to_objc(p_attributes.get("sentry.op", String()))
+					 traceId:[[SentryObjCId alloc] initWithUUIDString:string_to_objc(trace.trace_id)]
+					  spanId:[[SentryObjCSpanId alloc] init]
+				parentSpanId:trace.parent_span_id.is_empty()
+					? nil
+					: [[SentryObjCSpanId alloc] initWithValue:string_to_objc(trace.parent_span_id)]
+			   parentSampled:SentryObjCSampleDecisionUndecided
+			parentSampleRate:nil
+			parentSampleRand:nil];
+	SentryObjCSpan *span = [SentryObjCSDK startTransactionWithContext:context bindToScope:NO];
+	return memnew(CocoaSpan(span, p_attributes));
+}
+
+SentrySpanImpl *CocoaSpan::start_child(const String &p_name, const Dictionary &p_attributes) {
+	SentryObjCSpan *child = [_span startChildWithOperation:string_to_objc(p_attributes.get("sentry.op", String()))
+											   description:string_to_objc(p_name)];
+	return memnew(CocoaSpan(child, p_attributes));
+}
+
+void CocoaSpan::set_attribute(const String &p_key, const Variant &p_value) {
+	[_span setDataValue:variant_to_scope_attribute(p_value) forKey:string_to_objc(p_key)];
+}
+
+void CocoaSpan::set_status(SpanStatus p_status) {
+	_span.status = p_status == SPAN_STATUS_OK ? SentryObjCSpanStatusOk : SentryObjCSpanStatusInternalError;
+}
+
+void CocoaSpan::end() {
+	[_span finishWithStatus:_span.status == SentryObjCSpanStatusUndefined ? SentryObjCSpanStatusOk : _span.status];
+}
+
+PackedStringArray CocoaSpan::get_trace_headers() {
+	PackedStringArray headers;
+	SentryObjCTraceHeader *trace = [_span toTraceHeader];
+	headers.append("sentry-trace: " + string_from_objc([trace value]));
+	NSString *baggage = [_span baggageHttpHeader];
+	if (baggage.length > 0) {
+		headers.append("baggage: " + string_from_objc(baggage));
+	}
+	if (SENTRY_OPTIONS()->is_propagate_traceparent_enabled()) {
+		headers.append(vformat("traceparent: 00-%s-%s-%s",
+				string_from_objc(trace.traceId.sentryIdString),
+				string_from_objc(trace.spanId.sentrySpanIdString),
+				trace.sampled == SentryObjCSampleDecisionYes ? "01" : "00"));
+	}
+	return headers;
+}
+
+void CocoaSpan::_apply_attributes(const Dictionary &p_attributes) {
+	const Array &keys = p_attributes.keys();
+	for (int i = 0; i < keys.size(); i++) {
+		const Variant &key = keys[i];
+		String name = key;
+		ERR_CONTINUE_MSG(name.is_empty(), "Sentry: Can't set attribute with an empty key.");
+		set_attribute(name, p_attributes[key]);
+	}
+}
+
+CocoaSpan::CocoaSpan(SentryObjCSpan *p_span, const Dictionary &p_attributes) :
+		_span(p_span) {
+	_apply_attributes(p_attributes);
+}
+
+CocoaSpan::~CocoaSpan() {
+}
+
+} //namespace sentry::cocoa


### PR DESCRIPTION
Add GDScript span support on macOS and iOS, including root and child spans, binding to current scopes, and trace-header propagation. Captured events, feedback, logs, and metrics correlate with the active span using the fixes in Cocoa SDK 9.28.0.

- Resolves #925
- Refs #861
