### PR TITLE
ref(apple): Simplify empty collection handling

### DIFF
--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -211,7 +211,7 @@ void CocoaEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 	NSDictionary *existing_context = [mut_contexts objectForKey:context_name];
 	if (existing_context) {
 		// If context exists, update it with new values.
-		NSMutableDictionary *mut_exisiting_context = [existing_context mutableCopy] ?: [NSMutableDictionary dictionary];
+		NSMutableDictionary *mut_exisiting_context = [existing_context mutableCopy];
 		const Array &updated_keys = p_value.keys();
 		for (int i = 0; i < updated_keys.size(); i++) {
 			const Variant &key = updated_keys[i];
@@ -229,7 +229,7 @@ void CocoaEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 void CocoaEvent::add_exception(const Exception &p_exception) {
 	ERR_FAIL_NULL(cocoa_event);
 
-	NSMutableArray *mut_frames = [NSMutableArray arrayWithCapacity:p_exception.frames.size()];
+	NSMutableArray *mut_frames = p_exception.frames.is_empty() ? nil : [NSMutableArray arrayWithCapacity:p_exception.frames.size()];
 	for (const StackFrame &frame : p_exception.frames) {
 		SentryObjCFrame *cocoa_frame = [[SentryObjCFrame alloc] init];
 		cocoa_frame.fileName = string_to_objc(frame.filename);
@@ -257,8 +257,8 @@ void CocoaEvent::add_exception(const Exception &p_exception) {
 		[mut_frames addObject:cocoa_frame];
 	}
 
-	SentryObjCStacktrace *stack_trace = [[SentryObjCStacktrace alloc] initWithFrames:mut_frames
-																		   registers:[NSDictionary dictionary]];
+	SentryObjCStacktrace *stack_trace = [[SentryObjCStacktrace alloc] initWithFrames:mut_frames ?: @[]
+																		   registers:@{}];
 
 	uint64_t thread_id = godot::OS::get_singleton()->get_thread_caller_id();
 	bool is_main = godot::OS::get_singleton()->get_main_thread_id() == thread_id;

--- a/src/sentry/cocoa/cocoa_event.mm
+++ b/src/sentry/cocoa/cocoa_event.mm
@@ -229,35 +229,39 @@ void CocoaEvent::merge_context(const String &p_key, const Dictionary &p_value) {
 void CocoaEvent::add_exception(const Exception &p_exception) {
 	ERR_FAIL_NULL(cocoa_event);
 
-	NSMutableArray *mut_frames = p_exception.frames.is_empty() ? nil : [NSMutableArray arrayWithCapacity:p_exception.frames.size()];
-	for (const StackFrame &frame : p_exception.frames) {
-		SentryObjCFrame *cocoa_frame = [[SentryObjCFrame alloc] init];
-		cocoa_frame.fileName = string_to_objc(frame.filename);
-		cocoa_frame.function = string_to_objc(frame.function);
-		cocoa_frame.lineNumber = int_to_objc(frame.lineno);
-		cocoa_frame.inApp = bool_to_objc(frame.in_app);
-		cocoa_frame.platform = string_to_objc(frame.platform);
+	NSArray *frames = @[];
+	if (!p_exception.frames.is_empty()) {
+		NSMutableArray *mut_frames = [NSMutableArray arrayWithCapacity:p_exception.frames.size()];
+		for (const StackFrame &frame : p_exception.frames) {
+			SentryObjCFrame *cocoa_frame = [[SentryObjCFrame alloc] init];
+			cocoa_frame.fileName = string_to_objc(frame.filename);
+			cocoa_frame.function = string_to_objc(frame.function);
+			cocoa_frame.lineNumber = int_to_objc(frame.lineno);
+			cocoa_frame.inApp = bool_to_objc(frame.in_app);
+			cocoa_frame.platform = string_to_objc(frame.platform);
 
-		if (!frame.context_line.is_empty()) {
-			cocoa_frame.contextLine = string_to_objc(frame.context_line);
-			cocoa_frame.preContext = string_array_to_objc(frame.pre_context);
-			cocoa_frame.postContext = string_array_to_objc(frame.post_context);
-		}
-
-		if (!frame.vars.is_empty()) {
-			NSMutableDictionary *objc_vars = [NSMutableDictionary dictionaryWithCapacity:frame.vars.size()];
-			for (const auto &var : frame.vars) {
-				NSString *key = string_to_objc(var.first);
-				id value = variant_to_objc(var.second);
-				objc_vars[key] = value;
+			if (!frame.context_line.is_empty()) {
+				cocoa_frame.contextLine = string_to_objc(frame.context_line);
+				cocoa_frame.preContext = string_array_to_objc(frame.pre_context);
+				cocoa_frame.postContext = string_array_to_objc(frame.post_context);
 			}
-			cocoa_frame.vars = objc_vars;
-		}
 
-		[mut_frames addObject:cocoa_frame];
+			if (!frame.vars.is_empty()) {
+				NSMutableDictionary *objc_vars = [NSMutableDictionary dictionaryWithCapacity:frame.vars.size()];
+				for (const auto &var : frame.vars) {
+					NSString *key = string_to_objc(var.first);
+					id value = variant_to_objc(var.second);
+					objc_vars[key] = value;
+				}
+				cocoa_frame.vars = objc_vars;
+			}
+
+			[mut_frames addObject:cocoa_frame];
+		}
+		frames = mut_frames;
 	}
 
-	SentryObjCStacktrace *stack_trace = [[SentryObjCStacktrace alloc] initWithFrames:mut_frames ?: @[]
+	SentryObjCStacktrace *stack_trace = [[SentryObjCStacktrace alloc] initWithFrames:frames
 																		   registers:@{}];
 
 	uint64_t thread_id = godot::OS::get_singleton()->get_thread_caller_id();

--- a/src/sentry/cocoa/cocoa_log.mm
+++ b/src/sentry/cocoa/cocoa_log.mm
@@ -72,7 +72,7 @@ Variant CocoaLog::get_attribute(const String &p_name) const {
 }
 
 void CocoaLog::set_attribute(const String &p_name, const Variant &p_value) {
-	NSMutableDictionary *mut_attributes = [cocoa_log.attributes mutableCopy] ?: [NSMutableDictionary dictionary];
+	NSMutableDictionary *mut_attributes = [cocoa_log.attributes mutableCopy];
 	[mut_attributes setObject:variant_to_attribute(p_value) forKey:string_to_objc(p_name)];
 	cocoa_log.attributes = mut_attributes;
 }
@@ -82,7 +82,7 @@ void CocoaLog::add_attributes(const Dictionary &p_attributes) {
 		return;
 	}
 
-	NSMutableDictionary *mut_attributes = [cocoa_log.attributes mutableCopy] ?: [NSMutableDictionary dictionary];
+	NSMutableDictionary *mut_attributes = [cocoa_log.attributes mutableCopy];
 	const Array &keys = p_attributes.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		const Variant &key = keys[i];
@@ -95,7 +95,7 @@ void CocoaLog::add_attributes(const Dictionary &p_attributes) {
 void CocoaLog::remove_attribute(const String &p_name) {
 	NSMutableDictionary *mut_attributes = [cocoa_log.attributes mutableCopy];
 	[mut_attributes removeObjectForKey:string_to_objc(p_name)];
-	cocoa_log.attributes = mut_attributes.count > 0 ? mut_attributes : nil;
+	cocoa_log.attributes = mut_attributes;
 }
 
 CocoaLog::CocoaLog() :

--- a/src/sentry/cocoa/cocoa_metric.mm
+++ b/src/sentry/cocoa/cocoa_metric.mm
@@ -100,7 +100,7 @@ Variant CocoaMetric::get_attribute(const String &p_name) const {
 void CocoaMetric::set_attribute(const String &p_name, const Variant &p_value) {
 	ERR_FAIL_NULL(cocoa_metric);
 
-	NSMutableDictionary *mut_attributes = [cocoa_metric.attributes mutableCopy] ?: [NSMutableDictionary dictionary];
+	NSMutableDictionary *mut_attributes = [cocoa_metric.attributes mutableCopy];
 	[mut_attributes setObject:variant_to_attribute_content(p_value) forKey:string_to_objc(p_name)];
 	cocoa_metric.attributes = mut_attributes;
 }
@@ -112,7 +112,7 @@ void CocoaMetric::add_attributes(const Dictionary &p_attributes) {
 		return;
 	}
 
-	NSMutableDictionary *mut_attributes = [cocoa_metric.attributes mutableCopy] ?: [NSMutableDictionary dictionary];
+	NSMutableDictionary *mut_attributes = [cocoa_metric.attributes mutableCopy];
 	const Array &keys = p_attributes.keys();
 	for (int i = 0; i < keys.size(); i++) {
 		const Variant &key = keys[i];
@@ -127,7 +127,7 @@ void CocoaMetric::remove_attribute(const String &p_name) {
 
 	NSMutableDictionary *mut_attributes = [cocoa_metric.attributes mutableCopy];
 	[mut_attributes removeObjectForKey:string_to_objc(p_name)];
-	cocoa_metric.attributes = mut_attributes.count > 0 ? mut_attributes : nil;
+	cocoa_metric.attributes = mut_attributes;
 }
 
 CocoaMetric::CocoaMetric() :

--- a/src/sentry/cocoa/cocoa_sdk.mm
+++ b/src/sentry/cocoa/cocoa_sdk.mm
@@ -50,6 +50,10 @@ NSDictionary<NSString *, SentryObjCAttributeContent *> *_metric_attributes_to_ob
 }
 
 NSArray *_trace_propagation_targets_to_objc(const Array &p_targets) {
+	if (p_targets.is_empty()) {
+		return @[];
+	}
+
 	NSMutableArray *targets = [NSMutableArray arrayWithCapacity:p_targets.size()];
 	for (const Variant &target : p_targets) {
 		if (target.get_type() == Variant::STRING && (String)target != ".*") {

--- a/src/sentry/cocoa/cocoa_util.mm
+++ b/src/sentry/cocoa/cocoa_util.mm
@@ -98,6 +98,9 @@ NSObject *variant_to_objc(const godot::Variant &p_value, int p_depth) {
 			}
 
 			Dictionary dict = p_value;
+			if (dict.is_empty()) {
+				return @{};
+			}
 			NSMutableDictionary *objc_dict = [[NSMutableDictionary alloc] init];
 
 			const Array &keys = dict.keys();
@@ -126,16 +129,20 @@ NSObject *variant_to_objc(const godot::Variant &p_value, int p_depth) {
 				return [NSString stringWithUTF8String:"[...]"];
 			}
 
-			NSMutableArray *objc_array = [[NSMutableArray alloc] init];
 			bool oob = false;
 			bool valid = true;
 			int i = 0;
+			Variant item = p_value.get_indexed(i++, valid, oob);
+			if (oob) {
+				return @[];
+			}
+			NSMutableArray *objc_array = [[NSMutableArray alloc] init];
 
 			do {
-				Variant item = p_value.get_indexed(i++, valid, oob);
 				if (valid) {
 					[objc_array addObject:variant_to_objc(item, p_depth + 1)];
 				}
+				item = p_value.get_indexed(i++, valid, oob);
 			} while (!oob);
 
 			return objc_array;
@@ -195,6 +202,10 @@ NSDictionary *dictionary_to_objc(const godot::Dictionary &p_dictionary) {
 }
 
 NSArray<NSString *> *string_array_to_objc(const godot::PackedStringArray &p_array) {
+	if (p_array.is_empty()) {
+		return @[];
+	}
+
 	NSMutableArray<NSString *> *objc_array = [NSMutableArray arrayWithCapacity:p_array.size()];
 	for (int i = 0; i < p_array.size(); i++) {
 		[objc_array addObject:string_to_objc(p_array[i])];


### PR DESCRIPTION
Use empty collection literals to avoid unnecessary allocations in the Cocoa backend and remove redundant fallbacks. Keep log and metric attributes nonnull when their last entry is removed.

- Depends on #920
