### PR TITLE
feat: Add SentrySDK.set_tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Features
 
+- Add `SentrySDK.set_tags()` to efficiently update multiple tags at once ([#929](https://github.com/getsentry/sentry-godot/pull/929))
 - Add current scope support to the GDScript API to enrich the telemetry captured within a specific part of the code ([#834](https://github.com/getsentry/sentry-godot/pull/834), [#835](https://github.com/getsentry/sentry-godot/pull/835), [#836](https://github.com/getsentry/sentry-godot/pull/836), [#920](https://github.com/getsentry/sentry-godot/pull/920))
   - `SentrySDK.with_scope()` runs a callable with a forked scope, `SentrySDK.get_current_scope()` returns the scope active on the calling thread, and the new `SentryScope` class carries tags, contexts, user, level, fingerprint, breadcrumbs, and attributes on top of the data set globally
   - Add `SentryScope.add_attachment()` to send a file or a block of bytes with the events captured within a scope instead of with every event ([#856](https://github.com/getsentry/sentry-godot/pull/856))

--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -191,6 +191,15 @@
 				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/tags/]Tags documentation[/url].
 			</description>
 		</method>
+		<method name="set_tags">
+			<return type="void" />
+			<param index="0" name="tags" type="Dictionary" />
+			<description>
+				Assigns multiple tags from the specified [param tags] dictionary. Tag keys and values must be strings. Existing tags with matching keys are overwritten, while other tags remain unchanged.
+				On Windows and Linux, this is more efficient than calling [method set_tag] repeatedly. Other platforms receive no batching performance benefit.
+				To learn more, visit [url=https://docs.sentry.io/platforms/godot/enriching-events/tags/]Tags documentation[/url].
+			</description>
+		</method>
 		<method name="set_user">
 			<return type="void" />
 			<param index="0" name="user" type="SentryUser" />

--- a/project/test/suites/test_sdk.gd
+++ b/project/test/suites/test_sdk.gd
@@ -34,6 +34,28 @@ func test_set_tag() -> void:
 	await assert_signal(monitor).is_emitted("callback_processed")
 
 
+## SentrySDK.set_tags() should assign multiple tags to the event object.
+func test_set_tags() -> void:
+	SentrySDK._set_before_send(
+		func(ev: SentryEvent):
+			assert_str(ev.get_tag("custom-tag")).is_equal("updated-value")
+			assert_str(ev.get_tag("preserved-tag")).is_equal("preserved-value")
+			assert_str(ev.get_tag("utf8-test")).is_equal("Hello 世界! 👋")
+			callback_processed.emit()
+			return null)
+
+	SentrySDK.set_tag("custom-tag", "initial-value")
+	SentrySDK.set_tag("preserved-tag", "preserved-value")
+	SentrySDK.set_tags({
+		"custom-tag": "updated-value",
+		"utf8-test": "Hello 世界! 👋",
+	})
+
+	var monitor := monitor_signals(self, false)
+	SentrySDK.capture_message("test-tags")
+	await assert_signal(monitor).is_emitted("callback_processed")
+
+
 ## SentrySDK.remove_tag() should remove a tag from the event object.
 func test_remove_tag() -> void:
 	SentrySDK._set_before_send(

--- a/src/sentry/internal_sdk.h
+++ b/src/sentry/internal_sdk.h
@@ -24,6 +24,11 @@ public:
 	virtual void remove_context(const String &p_key) = 0;
 
 	virtual void set_tag(const String &p_key, const String &p_value) = 0;
+	virtual void set_tags(const Dictionary &p_tags) {
+		for (const Variant &key : p_tags.keys()) {
+			set_tag((String)key, (String)p_tags[key]);
+		}
+	}
 	virtual void remove_tag(const String &p_key) = 0;
 
 	virtual void set_user(const Ref<SentryUser> &p_user) = 0;

--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -208,6 +208,10 @@ void NativeSDK::set_tag(const String &p_key, const String &p_value) {
 	sentry_set_tag(p_key.utf8(), p_value.utf8());
 }
 
+void NativeSDK::set_tags(const Dictionary &p_tags) {
+	sentry_set_tags(sentry::native::variant_to_sentry_value(p_tags));
+}
+
 void NativeSDK::remove_tag(const String &p_key) {
 	ERR_FAIL_COND(p_key.is_empty());
 	sentry_remove_tag(p_key.utf8());

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -20,6 +20,7 @@ public:
 	virtual void remove_context(const String &p_key) override;
 
 	virtual void set_tag(const String &p_key, const String &p_value) override;
+	virtual void set_tags(const Dictionary &p_tags) override;
 	virtual void remove_tag(const String &p_key) override;
 
 	virtual void set_user(const Ref<SentryUser> &p_user) override;

--- a/src/sentry/sentry_sdk.cpp
+++ b/src/sentry/sentry_sdk.cpp
@@ -399,6 +399,30 @@ void SentrySDK::set_tag(const String &p_key, const String &p_value) {
 	}
 }
 
+void SentrySDK::set_tags(const Dictionary &p_tags) {
+	Dictionary tags;
+	for (const Variant &key : p_tags.keys()) {
+		const Variant &value = p_tags[key];
+		ERR_CONTINUE_MSG(key.get_type() != Variant::STRING, "Sentry: Tag keys must be strings.");
+		ERR_CONTINUE_MSG(value.get_type() != Variant::STRING, "Sentry: Tag values must be strings.");
+
+		const String tag_key = key;
+		ERR_CONTINUE_MSG(tag_key.is_empty(), "Sentry: Can't set tag with an empty key.");
+		tags[tag_key] = value;
+	}
+
+	if (tags.is_empty()) {
+		return;
+	}
+
+	internal_sdk->set_tags(tags);
+	for (const Variant &key : tags.keys()) {
+		for (const Ref<SentryScopeObserver> &observer : SENTRY_OPTIONS()->get_scope_observers()) {
+			observer->set_tag((String)key, (String)tags[key]);
+		}
+	}
+}
+
 void SentrySDK::remove_tag(const String &p_key) {
 	ERR_FAIL_COND_MSG(p_key.is_empty(), "Sentry: Can't remove tag with an empty key.");
 	internal_sdk->remove_tag(p_key);
@@ -658,6 +682,7 @@ void SentrySDK::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_last_event_id"), &SentrySDK::get_last_event_id);
 	ClassDB::bind_method(D_METHOD("set_context", "key", "value"), &SentrySDK::set_context);
 	ClassDB::bind_method(D_METHOD("set_tag", "key", "value"), &SentrySDK::set_tag);
+	ClassDB::bind_method(D_METHOD("set_tags", "tags"), &SentrySDK::set_tags);
 	ClassDB::bind_method(D_METHOD("remove_tag", "key"), &SentrySDK::remove_tag);
 	ClassDB::bind_method(D_METHOD("set_user", "user"), &SentrySDK::set_user);
 	ClassDB::bind_method(D_METHOD("remove_user"), &SentrySDK::remove_user);

--- a/src/sentry/sentry_sdk.h
+++ b/src/sentry/sentry_sdk.h
@@ -104,6 +104,7 @@ public:
 	void set_context(const String &p_key, const Dictionary &p_value);
 
 	void set_tag(const String &p_key, const String &p_value);
+	void set_tags(const Dictionary &p_tags);
 	void remove_tag(const String &p_key);
 
 	void set_user(const Ref<SentryUser> &p_user);


### PR DESCRIPTION
## Summary

- add `SentrySDK.set_tags()` for updating multiple tags at once
- use sentry-native's batch API to avoid repeated native scope flushes
- document and test multi-tag updates and overwrites

Fixes #891

## Testing

- `python -m SCons target=editor debug_symbols=yes`
- `python -m pre_commit run --all-files`
- `Godot --headless --path project -- run-tests res://test/suites/test_sdk.gd`