### PR TITLE
test(e2e): Use the default event polling timeout for crash tests

### DIFF
--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -239,7 +239,7 @@ Describe "Platform Integration Tests" {
                 # Retrieve the Sentry event associated with the crash ID,
                 # which will be tested in the following "It" blocks.
                 Write-GitHub "::group::Getting event content"
-                $script:runEvent = Get-SentryTestEvent -TagName "test.crash_id" -TagValue "$eventId" -TimeoutSeconds 120
+                $script:runEvent = Get-SentryTestEvent -TagName "test.crash_id" -TagValue "$eventId"
                 Write-GitHub "::endgroup::"
             }
         }


### PR DESCRIPTION
Allow crash integration tests to use the shared 300-second event polling timeout, matching other event tests and giving Sentry more time to make crash reports available.
