### PR TITLE
fix(android): Handle no-op spans

### DIFF
--- a/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
+++ b/android_lib/src/main/java/io/sentry/godotplugin/SentryAndroidGodotPlugin.kt
@@ -252,6 +252,10 @@ class SentryAndroidGodotPlugin(godot: Godot) : GodotPlugin(godot) {
     }
 
     private fun registerSpan(span: ISpan): Int {
+        if (span.isNoOp) {
+            return 0
+        }
+
         val spansMap = spansByHandle.get() ?: run {
             Log.e(TAG, "Internal Error -- spansByHandle is null")
             return 0

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -90,3 +90,30 @@ func test_traceparent_is_emitted_when_enabled() -> void:
 	assert_str(_header_value(headers, "traceparent")) \
 		.override_failure_message("traceparent should follow the W3C format and carry the span's own ids") \
 		.is_equal("00-%s-%s-01" % [trace.get("trace_id"), trace.get("span_id")])
+
+
+@warning_ignore("unused_parameter")
+func test_descendants_never_propagate_empty_ids(finish_root: bool, test_parameters := [
+		[true],
+		[false],
+]) -> void:
+	var root := SentrySDK.start_span("test.root", {}, null, false)
+	var child := SentrySDK.start_span("test.child", {}, root, false)
+	assert_array(child.get_trace_headers()).is_not_empty()
+	if finish_root:
+		root.end()
+	root = null
+
+	var grandchild := SentrySDK.start_span("test.grandchild", {}, child, false)
+	var descendant := SentrySDK.start_span("test.descendant", {}, grandchild, false)
+	for span: SentrySpan in [grandchild, descendant]:
+		var headers := span.get_trace_headers()
+		if headers.is_empty():
+			continue
+		var sentry_trace := _header_value(headers, "sentry-trace")
+		assert_str(sentry_trace).is_not_empty().not_contains("0000000000000000")
+		assert_str(_header_value(headers, "traceparent")) \
+			.is_equal("00-%s-01" % sentry_trace.trim_suffix("-1"))
+	descendant.end()
+	grandchild.end()
+	child.end()

--- a/project/test/isolated/test_trace_propagation_disabled.gd
+++ b/project/test/isolated/test_trace_propagation_disabled.gd
@@ -10,8 +10,9 @@ func before(_do_skip = OS.get_name() in ["macOS", "iOS"],
 
 func init_sdk() -> void:
 	SentrySDK.init(func(options: SentryOptions) -> void:
-		options.traces_sample_rate = 1.0
+		options.traces_sample_rate = 0.0
 		options.trace_propagation_targets = []
+		options.propagate_traceparent = true
 	)
 
 
@@ -33,3 +34,20 @@ func test_omitting_the_url_still_yields_headers() -> void:
 	assert_array(headers) \
 		.override_failure_message("reading headers without a URL should skip the allowlist check") \
 		.is_not_empty()
+
+
+func test_unsampled_spans_keep_trace_headers() -> void:
+	var root := SentrySDK.start_span("test.unsampled_root", {}, null, false)
+	var child := SentrySDK.start_span("test.unsampled_child", {}, root, false)
+	for span: SentrySpan in [root, child]:
+		var sentry_trace := ""
+		var traceparent := ""
+		for header: String in span.get_trace_headers():
+			if header.begins_with("sentry-trace: "):
+				sentry_trace = header.trim_prefix("sentry-trace: ")
+			elif header.begins_with("traceparent: "):
+				traceparent = header.trim_prefix("traceparent: ")
+		assert_str(sentry_trace).ends_with("-0").not_contains("0000000000000000")
+		assert_str(traceparent).is_equal("00-%s0" % sentry_trace)
+	child.end()
+	root.end()


### PR DESCRIPTION
Map Android SDK no-op spans to Godot’s no-op implementation, preventing all-zero trace headers. Shared regression tests cover root lifetime and preserve propagation for unsampled spans.

- Refs #921

#skip-changelog: bug not released