### PR TITLE
fix(tracing): Retain span ancestors and reject children after end

### DIFF
--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -227,9 +227,10 @@
 				span.set_status(SentrySpan.SPAN_STATUS_OK)
 				span.end()
 				[/codeblock]
-				When [param parent_span] is omitted, the new span becomes a child of [method SentrySDK.get_active_span] if one exists; otherwise, it starts a new root span. Pass [code]null[/code] to force a new root span, or pass a [SentrySpan] to create a child of that span even when another span is active. If [param parent_span] has ended, the SDK prints an error and returns a no-op span.
+				When [param parent_span] is omitted, the new span becomes a child of [method SentrySDK.get_active_span] if one exists; otherwise, it starts a new root span. Pass [code]null[/code] to force a new root span, or pass a [SentrySpan] to create a child of that span even when another span is active. If the chosen parent or any of its ancestors has ended, the SDK prints an error and returns a no-op span.
 				The [param attributes] dictionary is added to the span when it starts. The special [code]sentry.op[/code] attribute sets the operation the span is grouped under in Sentry. The SDK skips an entry with an empty key and prints an error.
 				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code]. The API works either way: telemetry captured during an active span carries its trace context even when the span is not sent.
+				[b]Note:[/b] The child span keeps its parent and ancestors alive until it is freed.
 				[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 			</description>

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -18,6 +18,7 @@
 		Each unended active span also leaves a scope fork on the calling thread; the SDK warns if the scope stack grows unusually deep. [method SentrySDK.with_span] ends its span automatically.
 		Set [code]sentry.op[/code] to categorize the work the span measures, such as [code]asset.load[/code] or [code]db.query[/code]. Sentry groups and filters spans by operation. Pass it in the [code]attributes[/code] dictionary of [method SentrySDK.start_span], since some platforms fix the operation when the span starts.
 		[b]Note:[/b] Spans are thread-local. Call span methods only from the thread that created the span.
+		[b]Note:[/b] A child span keeps its parent and ancestors alive until it is freed.
 		[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.
 		To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 	</description>
@@ -28,7 +29,7 @@
 			<return type="void" />
 			<description>
 				Finishes the span and records its duration. If the span is active, the SDK removes its scope fork and restores the previous active span, if any. Calling [method end] again has no effect.
-				Set attributes and status before calling [method end]. After the span ends, [method set_attribute], [method set_attributes], and [method set_status] print an error and do nothing. The SDK also rejects the ended span as [code]parent_span[/code] in [method SentrySDK.start_span].
+				Set attributes and status before calling [method end]. After the span ends, [method set_attribute], [method set_attributes], and [method set_status] print an error and do nothing. Calling [method SentrySDK.start_span] with the ended span or any of its descendants as the parent prints an error and returns a no-op span.
 				[b]Note:[/b] End every child span before its root span. If the root ends first, the SDK may drop an unfinished child, give it the root's end time, or send it after the child ends, depending on the platform.
 			</description>
 		</method>

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -86,16 +86,10 @@ func test_traceparent_is_emitted_when_enabled() -> void:
 		.is_equal("00-%s-%s-01" % [trace.get("trace_id"), trace.get("span_id")])
 
 
-@warning_ignore("unused_parameter")
-func test_descendants_never_propagate_empty_ids(finish_root: bool, test_parameters := [
-		[true],
-		[false],
-]) -> void:
+func test_descendants_never_propagate_empty_ids() -> void:
 	var root := SentrySDK.start_span("test.root", {}, null, false)
 	var child := SentrySDK.start_span("test.child", {}, root, false)
 	assert_array(child.get_trace_headers()).is_not_empty()
-	if finish_root:
-		root.end()
 	root = null
 
 	var grandchild := SentrySDK.start_span("test.grandchild", {}, child, false)

--- a/project/test/isolated/test_trace_propagation.gd
+++ b/project/test/isolated/test_trace_propagation.gd
@@ -111,3 +111,17 @@ func test_descendants_never_propagate_empty_ids(finish_root: bool, test_paramete
 	descendant.end()
 	grandchild.end()
 	child.end()
+
+
+func test_existing_span_headers_survive_ancestor_end() -> void:
+	var root := SentrySDK.start_span("test.finished_root", {}, null, false)
+	var child := SentrySDK.start_span("test.surviving_child", {}, root, false)
+	var before := _header_value(child.get_trace_headers(), "sentry-trace")
+	assert_str(before).is_not_empty()
+	root.end()
+
+	var headers := child.get_trace_headers()
+	assert_str(_header_value(headers, "sentry-trace")).is_equal(before)
+	assert_str(_header_value(headers, "traceparent")) \
+		.is_equal("00-%s-01" % before.trim_suffix("-1"))
+	child.end()

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -470,6 +470,34 @@ func test_inactive_span_lifecycle() -> void:
 
 
 @warning_ignore("unused_parameter")
+func test_active_span_lifecycle(clone_scope: bool, test_parameters := [
+		[false],
+		[true],
+]) -> void:
+	var root := SentrySDK.start_span("test.active_root")
+	var child := SentrySDK.start_span("test.active_child")
+	var root_ref: WeakRef = weakref(root)
+	var child_ref: WeakRef = weakref(child)
+	var scope_copy: SentryScope
+	if clone_scope:
+		scope_copy = SentrySDK.with_scope(func(scope: SentryScope) -> SentryScope:
+			return scope
+			)
+	child.end()
+	root.end()
+	root = null
+	assert_bool(root_ref.get_ref() != null).is_true()
+	child = null
+	assert_object(SentrySDK.get_active_span()).is_null()
+	if clone_scope:
+		assert_bool(child_ref.get_ref() != null).is_true()
+		assert_bool(root_ref.get_ref() != null).is_true()
+		scope_copy.clear()
+	assert_bool(child_ref.get_ref() == null).is_true()
+	assert_bool(root_ref.get_ref() == null).is_true()
+
+
+@warning_ignore("unused_parameter")
 func test_ended_ancestor_refuses_a_child(ended_depth: int, inherited_parent: bool, test_parameters := [
 		[0, false],
 		[1, false],
@@ -515,31 +543,3 @@ func test_ended_previous_span_is_not_a_tracing_ancestor() -> void:
 	child.end()
 	root.end()
 	assert_object(SentrySDK.get_active_span()).is_null()
-
-
-@warning_ignore("unused_parameter")
-func test_active_span_parent_links_are_released(clone_scope: bool, test_parameters := [
-		[false],
-		[true],
-]) -> void:
-	var root := SentrySDK.start_span("test.active_root")
-	var child := SentrySDK.start_span("test.active_child")
-	var root_ref: WeakRef = weakref(root)
-	var child_ref: WeakRef = weakref(child)
-	var scope_copy: SentryScope
-	if clone_scope:
-		scope_copy = SentrySDK.with_scope(func(scope: SentryScope) -> SentryScope:
-			return scope
-			)
-	child.end()
-	root.end()
-	root = null
-	assert_bool(root_ref.get_ref() != null).is_true()
-	child = null
-	assert_object(SentrySDK.get_active_span()).is_null()
-	if clone_scope:
-		assert_bool(child_ref.get_ref() != null).is_true()
-		assert_bool(root_ref.get_ref() != null).is_true()
-		scope_copy.clear()
-	assert_bool(child_ref.get_ref() == null).is_true()
-	assert_bool(root_ref.get_ref() == null).is_true()

--- a/project/test/suites/test_span.gd
+++ b/project/test/suites/test_span.gd
@@ -441,3 +441,105 @@ func test_ended_span_yields_no_trace_headers() -> void:
 	assert_array(span.get_trace_headers()) \
 		.override_failure_message("an ended span has nothing left to propagate") \
 		.is_empty()
+
+
+func test_inactive_span_lifecycle() -> void:
+	var root := SentrySDK.start_span("test.retained_root", {}, null, false)
+	var child := SentrySDK.start_span("test.retained_child", {}, root, false)
+	var grandchild := SentrySDK.start_span("test.retained_grandchild", {}, child, false)
+	var root_ref: WeakRef = weakref(root)
+	var child_ref: WeakRef = weakref(child)
+	var trace_id := _header_value(root.get_trace_headers(), "sentry-trace").get_slice("-", 0)
+	root = null
+	child = null
+
+	assert_bool(root_ref.get_ref() != null).is_true()
+	assert_bool(child_ref.get_ref() != null).is_true()
+	var descendant := SentrySDK.start_span("test.retained_descendant", {}, grandchild, false)
+	assert_str(_header_value(descendant.get_trace_headers(), "sentry-trace")).starts_with(trace_id + "-")
+	descendant.end()
+	grandchild.end()
+	if child_ref.get_ref() != null:
+		child_ref.get_ref().end()
+	if root_ref.get_ref() != null:
+		root_ref.get_ref().end()
+	descendant = null
+	grandchild = null
+	assert_bool(child_ref.get_ref() == null).is_true()
+	assert_bool(root_ref.get_ref() == null).is_true()
+
+
+@warning_ignore("unused_parameter")
+func test_ended_ancestor_refuses_a_child(ended_depth: int, inherited_parent: bool, test_parameters := [
+		[0, false],
+		[1, false],
+		[2, false],
+		[0, true],
+		[1, true],
+]) -> void:
+	var root := SentrySDK.start_span("test.ancestor_root", {}, null, false)
+	var middle := SentrySDK.start_span("test.ancestor_middle", {}, root, false)
+	var parent := SentrySDK.start_span("test.ancestor_parent", {}, middle, inherited_parent)
+	match ended_depth:
+		0: root.end()
+		1: middle.end()
+		2: parent.end()
+
+	var rejected: SentrySpan
+	if inherited_parent:
+		rejected = SentrySDK.start_span("test.rejected_child")
+		assert_object(SentrySDK.get_active_span()).is_same(rejected)
+	else:
+		rejected = SentrySDK.start_span("test.rejected_child", {}, parent, false)
+	assert_array(rejected.get_trace_headers()).is_empty()
+	var descendant := SentrySDK.start_span("test.rejected_descendant", {}, rejected, false)
+	assert_array(descendant.get_trace_headers()).is_empty()
+	descendant.end()
+	rejected.end()
+	if inherited_parent:
+		assert_object(SentrySDK.get_active_span()).is_same(parent)
+	parent.end()
+	middle.end()
+	root.end()
+
+
+func test_ended_previous_span_is_not_a_tracing_ancestor() -> void:
+	var root := SentrySDK.start_span("test.explicit_root", {}, null, false)
+	var unrelated := SentrySDK.start_span("test.unrelated_scope")
+	var child := SentrySDK.start_span("test.explicit_child", {}, root)
+	unrelated.end()
+
+	var grandchild := SentrySDK.start_span("test.allowed_grandchild")
+	assert_array(grandchild.get_trace_headers()).is_not_empty()
+	grandchild.end()
+	child.end()
+	root.end()
+	assert_object(SentrySDK.get_active_span()).is_null()
+
+
+@warning_ignore("unused_parameter")
+func test_active_span_parent_links_are_released(clone_scope: bool, test_parameters := [
+		[false],
+		[true],
+]) -> void:
+	var root := SentrySDK.start_span("test.active_root")
+	var child := SentrySDK.start_span("test.active_child")
+	var root_ref: WeakRef = weakref(root)
+	var child_ref: WeakRef = weakref(child)
+	var scope_copy: SentryScope
+	if clone_scope:
+		scope_copy = SentrySDK.with_scope(func(scope: SentryScope) -> SentryScope:
+			return scope
+			)
+	child.end()
+	root.end()
+	root = null
+	assert_bool(root_ref.get_ref() != null).is_true()
+	child = null
+	assert_object(SentrySDK.get_active_span()).is_null()
+	if clone_scope:
+		assert_bool(child_ref.get_ref() != null).is_true()
+		assert_bool(root_ref.get_ref() != null).is_true()
+		scope_copy.clear()
+	assert_bool(child_ref.get_ref() == null).is_true()
+	assert_bool(root_ref.get_ref() == null).is_true()

--- a/src/sentry/sentry_span.cpp
+++ b/src/sentry/sentry_span.cpp
@@ -122,10 +122,14 @@ Ref<SentryScope> SentrySpan::get_associated_scope() const {
 
 Ref<SentrySpan> SentrySpan::start_child(const String &p_name, const Dictionary &p_attributes) {
 	ERR_SENTRY_THREAD_GUARD_V(create_noop(), WRONG_THREAD_MSG);
-	ERR_FAIL_COND_V_MSG(_ended, create_noop(), "Sentry: Can't start a child span on a span that has ended.");
+	for (const SentrySpan *ancestor = this; ancestor; ancestor = ancestor->_parent.ptr()) {
+		ERR_FAIL_COND_V_MSG(ancestor->_ended, create_noop(), "Sentry: Can't start a child span when its parent or an ancestor has ended.");
+	}
 	ERR_FAIL_COND_V_MSG(p_name.is_empty(), create_noop(), "Sentry: Can't start a child span with an empty name.");
 	SentrySpanImpl *child_impl = _impl->start_child(p_name, p_attributes);
-	return memnew(SentrySpan(child_impl));
+	Ref<SentrySpan> child = memnew(SentrySpan(child_impl));
+	child->_parent = Ref<SentrySpan>(this);
+	return child;
 }
 
 SentrySpan::SentrySpan() {

--- a/src/sentry/sentry_span.h
+++ b/src/sentry/sentry_span.h
@@ -25,6 +25,7 @@ public:
 
 private:
 	SentrySpanImpl *_impl;
+	Ref<SentrySpan> _parent;
 
 	// The span this one displaced when it was bound to a scope, assigned by SentrySDK.
 	// Scopes resolve their slot through this chain, so it must outlive this span's end().


### PR DESCRIPTION
Child spans now keep their parents and ancestors alive until freed, preventing premature transaction release on Cocoa. Creating a child under an ended span or any of its descendants prints an error and returns a no-op span consistently across platforms.

- Depends on #921

#skip-changelog: the issue was not shipped