### PR TITLE
ref(native): Use Native SDK event level setter

### DIFF
--- a/src/sentry/native/native_event.cpp
+++ b/src/sentry/native/native_event.cpp
@@ -96,8 +96,7 @@ String NativeEvent::get_platform() const {
 }
 
 void NativeEvent::set_level(sentry::Level p_level) {
-	sentry_value_set_by_key(native_event, "level",
-			sentry_value_new_string(sentry::native::level_to_cstring(p_level)));
+	sentry_event_set_level(native_event, sentry::native::level_to_native(p_level));
 }
 
 sentry::Level NativeEvent::get_level() const {


### PR DESCRIPTION
Use `sentry_event_set_level()`, introduced in Native SDK 0.16.6, to delegate event-level assignment to the Native SDK while preserving the existing Godot level mapping.

- Refs #932
