### PR TITLE
ref(native): Use Native SDK initialization state

### DIFF
--- a/src/sentry/native/native_sdk.cpp
+++ b/src/sentry/native/native_sdk.cpp
@@ -496,7 +496,6 @@ void NativeSDK::init() {
 #endif
 
 	int err = sentry_init(options);
-	initialized = (err == 0);
 
 	if (is_enabled()) {
 		set_user(SentryUser::create_default());
@@ -507,7 +506,6 @@ void NativeSDK::init() {
 
 void NativeSDK::close() {
 	int err = sentry_close();
-	initialized = false;
 	user_attachments.clear();
 
 	if (err != 0) {
@@ -516,7 +514,7 @@ void NativeSDK::close() {
 }
 
 bool NativeSDK::is_enabled() const {
-	return initialized;
+	return sentry_is_enabled() != 0;
 }
 
 NativeSDK::NativeSDK() {

--- a/src/sentry/native/native_sdk.h
+++ b/src/sentry/native/native_sdk.h
@@ -12,7 +12,6 @@ class NativeSDK : public InternalSDK {
 private:
 	sentry_uuid_t last_uuid;
 	Ref<Mutex> last_uuid_mutex;
-	bool initialized = false;
 	Vector<sentry_attachment_t *> user_attachments;
 
 public:


### PR DESCRIPTION
Use `sentry_is_enabled()`, introduced in Native SDK 0.16.6, to query initialization state directly. This removes the wrapper’s duplicated state tracking.

- Refs #932
