### PR TITLE
test: Make breadcrumb tests tolerate unrelated events

### DIFF
--- a/project/test/isolated/test_logger_breadcrumbs.gd
+++ b/project/test/isolated/test_logger_breadcrumbs.gd
@@ -9,9 +9,6 @@ func init_sdk() -> void:
 
 
 func test_logger_warnings_and_prints_create_breadcrumbs() -> void:
-	# Wait a small amount of time to dodge initial device events on Android.
-	await get_tree().create_timer(0.5).timeout
-
 	# We expect print() and push_warning() to become breadcrumbs and not create events.
 	print("Debug message")
 	push_warning("Warning message")
@@ -20,15 +17,21 @@ func test_logger_warnings_and_prints_create_breadcrumbs() -> void:
 	var json: String = await wait_for_captured_event_json()
 	assert_int(captured_events.size()).is_equal(1).override_failure_message("expected a single event")
 
-	assert_json(json).describe("print() should appear as the pre-last breadcrumb") \
-		.at("/breadcrumbs/-2") \
+	var breadcrumbs: Array = JSON.parse_string(json).get("breadcrumbs", [])
+	var logger_breadcrumbs := breadcrumbs.filter(func(crumb: Dictionary) -> bool:
+		return crumb.get("message") in ["Debug message", "Warning message"]
+	)
+	assert_array(logger_breadcrumbs).has_size(2)
+
+	assert_json(logger_breadcrumbs).describe("print() should appear before the warning breadcrumb") \
+		.at("/0") \
 		.must_contain("message", "Debug message") \
 		.must_contain("level", "info") \
 		.must_contain("category", "log") \
 		.verify()
 
-	assert_json(json).describe("Warning should appear as the last breadcrumb") \
-		.at("/breadcrumbs/-1") \
+	assert_json(logger_breadcrumbs).describe("Warning should appear after the print breadcrumb") \
+		.at("/1") \
 		.must_contain("message", "Warning message") \
 		.must_contain("level", "warning") \
 		.must_contain("category", "error") \

--- a/project/test/suites/test_breadcrumbs_json.gd
+++ b/project/test/suites/test_breadcrumbs_json.gd
@@ -43,21 +43,21 @@ func test_breadcrumbs_order() -> void:
 
 	var json: String = await capture_event_and_get_json(SentrySDK.create_event())
 
-	assert_json(json).describe("Breadcrumbs exist") \
-		.at("/breadcrumbs") \
-		.is_array() \
-		.with_objects() \
-		.at_least(2)
+	var breadcrumbs: Array = JSON.parse_string(json).get("breadcrumbs", [])
+	var ordered_breadcrumbs := breadcrumbs.filter(func(crumb: Dictionary) -> bool:
+		return crumb.get("message") in ["First breadcrumb", "Second breadcrumb"]
+	)
+	assert_array(ordered_breadcrumbs).has_size(2)
 
-	# NOTE: -1 is last, -2 is pre-last (element in JSON array)
-	assert_json(json).describe("Breadcrumbs are added in proper order") \
-		.at("/breadcrumbs/-1") \
-		.is_object() \
-		.must_contain("message", "Second breadcrumb") \
-		.verify()
-	assert_json(json).at("/breadcrumbs/-2") \
+	assert_json(ordered_breadcrumbs).describe("First breadcrumb precedes the second breadcrumb") \
+		.at("/0") \
 		.is_object() \
 		.must_contain("message", "First breadcrumb") \
+		.verify()
+	assert_json(ordered_breadcrumbs).describe("Second breadcrumb follows the first breadcrumb") \
+		.at("/1") \
+		.is_object() \
+		.must_contain("message", "Second breadcrumb") \
 		.verify()
 
 
@@ -71,13 +71,13 @@ func test_breadcrumbs_with_utf8() -> void:
 	var json: String = await capture_event_and_get_json(SentrySDK.create_event())
 
 	assert_json(json).describe("Breadcrumb retains UTF-8 encoded data") \
-		.at("/breadcrumbs/-1") \
-		.is_object() \
-		.must_contain("message", "Hello 世界! 👋") \
+		.at("/breadcrumbs/") \
+		.with_objects() \
+		.containing("message", "Hello 世界! 👋") \
+		.containing("category", "Hello 世界! 👋") \
 		.must_contain("type", "Hello 世界! 👋") \
-		.must_contain("category", "Hello 世界! 👋") \
 		.must_contain("data", {"Hello, World! 👋": "Hello 世界! 👋"}) \
-		.verify()
+		.exactly(1)
 
 
 func test_breadcrumbs_with_complex_nested_data() -> void:
@@ -95,10 +95,9 @@ func test_breadcrumbs_with_complex_nested_data() -> void:
 	var json: String = await capture_event_and_get_json(SentrySDK.create_event())
 
 	assert_json(json).describe("Breadcrumb retains complex nested data") \
-		.at("/breadcrumbs/-1") \
-		.is_object() \
-		.is_not_empty() \
-		.must_contain("message", "Player stats updated") \
+		.at("/breadcrumbs/") \
+		.with_objects() \
+		.containing("message", "Player stats updated") \
 		.must_contain("category", "gameplay") \
 		.must_contain("level", "debug") \
 		.must_contain("type", "info") \
@@ -107,4 +106,4 @@ func test_breadcrumbs_with_complex_nested_data() -> void:
 			"level_complete": false,
 			"experience_gained": 125.5,
 		}) \
-		.verify()
+		.exactly(1)

--- a/project/test/suites/test_logger_integration.gd
+++ b/project/test/suites/test_logger_integration.gd
@@ -44,7 +44,7 @@ func test_past_errors_appear_as_breadcrumbs() -> void:
 
 	assert_int(captured_events.size()).is_equal(2).override_failure_message("expected two events")
 
-	assert_json(second_event).describe("First error captured should be the last breadcrumb") \
+	assert_json(second_event).describe("First error should appear as a breadcrumb on the second event") \
 		.at("/breadcrumbs/") \
 		.with_objects() \
 		.containing("message", "first error") \


### PR DESCRIPTION
The [Android Godot 4.7.1 test job](https://github.com/getsentry/sentry-godot/actions/runs/34539139863/job/103186043970?pr=929) failed because a battery event appeared where the test expected a log breadcrumb: `expected "log", but found "device.event"`. Update the breadcrumb tests to find the entries they added instead of assuming those entries are last. Keep checking their contents and order, and remove the startup delay that could not prevent this failure.

- Refs #929
