### PR TITLE
fix(dotnet): Sync regex trace propagation targets back to native

### DIFF
--- a/doc_classes/SentryOptions.xml
+++ b/doc_classes/SentryOptions.xml
@@ -195,6 +195,7 @@
 			Restrict this list to services you trust to prevent sending trace headers to third parties. Leave this empty to block trace headers for all specified URLs.
 			[b]Note:[/b] This option applies only when [method SentrySpan.get_trace_headers] is called with a URL. Omitting the URL bypasses target filtering.
 			[b]Note:[/b] The Project Settings field accepts only literal strings. Add [RegEx] entries from the configuration callback (see [method SentrySDK.init]).
+			[b].NET:[/b] When configured from .NET, regular expressions sync to the native layer using only their pattern. Constructor-supplied [code]RegexOptions[/code] are not preserved. For case-insensitive matching in both layers, include [code](?i)[/code] in the pattern instead of using [code]RegexOptions.IgnoreCase[/code].
 		</member>
 		<member name="traces_sample_rate" type="float" setter="set_traces_sample_rate" getter="get_traces_sample_rate" default="0.0">
 			Configures the sample rate for performance traces, in the range of 0.0 to 1.0. The default is 0.0, which prevents spans from being sent. If set to 1.0, all traces are sent. If set to 0.1, approximately 10% of traces are sent.

--- a/project/test/dotnet/DotnetTestHarness.cs
+++ b/project/test/dotnet/DotnetTestHarness.cs
@@ -54,6 +54,30 @@ public partial class DotnetTestHarness : RefCounted
     private readonly Godot.Collections.Dictionary _receivedOptions = [];
     public Godot.Collections.Dictionary GetReceivedOptions() => _receivedOptions;
 
+    public void InitWithRegexTracePropagationTargets()
+    {
+        SentrySdk.Init(options =>
+        {
+            options.Debug = false;
+            options.AttachScreenshot = false;
+            options.TracePropagationTargets.Clear();
+            options.TracePropagationTargets.Add(@"^literal\.example\.com$");
+            options.TracePropagationTargets.Add(new Regex(@"^https://api\.example\.com/żółw$"));
+            options.TracePropagationTargets.Add("");
+            options.TracePropagationTargets.Add(new Regex(""));
+        });
+    }
+
+    public void InitWithEmptyTracePropagationTargets()
+    {
+        SentrySdk.Init(options =>
+        {
+            options.Debug = false;
+            options.AttachScreenshot = false;
+            options.TracePropagationTargets.Clear();
+        });
+    }
+
     public string[] GetCurrentTracePropagationTargets()
     {
         var optionsProperty = typeof(SentrySdk).GetProperty("CurrentOptions", BindingFlags.NonPublic | BindingFlags.Static);
@@ -62,12 +86,11 @@ public partial class DotnetTestHarness : RefCounted
             return [];
         }
 
-        var regexField = typeof(StringOrRegex).GetField("_regex", BindingFlags.NonPublic | BindingFlags.Instance);
         var targets = new string[options.TracePropagationTargets.Count];
         for (int i = 0; i < targets.Length; i++)
         {
             var target = options.TracePropagationTargets[i];
-            string type = regexField?.GetValue(target) is Regex ? "regex" : "string";
+            string type = target.IsRegex ? "regex" : "string";
             targets[i] = $"{type}:{target}";
         }
         return targets;

--- a/src/sentry/dotnet/csharp_interop.cpp
+++ b/src/sentry/dotnet/csharp_interop.cpp
@@ -124,26 +124,34 @@ static Dictionary _managed_string_map_to_dictionary(const ManagedStringMap &map)
 	return dict;
 }
 
-// Managed-owned string list for passing string arrays across P/Invoke.
+// Managed-owned trace propagation targets for passing across P/Invoke.
 // C# builds and pins this; native reads it synchronously during the call.
-// Buffer layout: all strings concatenated as UTF-16, with one length per entry.
-struct ManagedStringList {
+// Buffer layout: all patterns concatenated as UTF-16, with one length and regex flag per entry.
+struct ManagedTracePropagationTargets {
 	const char16_t *buffer;
 	const int32_t *lengths;
+	const uint8_t *is_regex;
 	int32_t count;
 };
 
-static PackedStringArray _managed_string_list_to_packed_array(const ManagedStringList &list) {
-	PackedStringArray result;
-	if (list.count <= 0 || list.buffer == nullptr || list.lengths == nullptr) {
+static Array _managed_trace_propagation_targets_to_array(const ManagedTracePropagationTargets &list) {
+	Array result;
+	if (list.count <= 0 || list.buffer == nullptr || list.lengths == nullptr || list.is_regex == nullptr) {
 		return result;
 	}
 	const char16_t *ptr = list.buffer;
-	result.resize(list.count);
 	for (int32_t i = 0; i < list.count; i++) {
 		const int32_t length = list.lengths[i];
-		result[i] = String::utf16(ptr, length);
+		const String pattern = String::utf16(ptr, length);
 		ptr += length;
+		if (list.is_regex[i]) {
+			Ref<RegEx> regex;
+			regex.instantiate();
+			ERR_CONTINUE_MSG(regex->compile(pattern) != OK, "Sentry: Ignoring a trace propagation target that Godot cannot compile.");
+			result.push_back(regex);
+		} else {
+			result.push_back(pattern);
+		}
 	}
 	return result;
 }
@@ -284,7 +292,7 @@ struct ManagedOptions {
 	// Trace propagation
 	const char16_t *org_id;
 	int32_t org_id_len;
-	ManagedStringList trace_propagation_targets;
+	ManagedTracePropagationTargets trace_propagation_targets;
 	uint8_t propagate_traceparent;
 };
 
@@ -327,7 +335,7 @@ static void _apply_managed_options(const ManagedOptions &data, Ref<SentryOptions
 	options->get_android()->set_anr_timeout_interval_ms(data.android_anr_timeout_interval_ms);
 	options->get_android()->set_attach_anr_thread_dump(data.android_attach_anr_thread_dump);
 	options->set_org_id(String::utf16(data.org_id, data.org_id_len));
-	options->set_trace_propagation_targets(_managed_string_list_to_packed_array(data.trace_propagation_targets));
+	options->set_trace_propagation_targets(_managed_trace_propagation_targets_to_array(data.trace_propagation_targets));
 	options->set_propagate_traceparent(data.propagate_traceparent);
 }
 

--- a/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/Interop/NativeBridge.cs
@@ -232,7 +232,7 @@ internal static partial class NativeBridge
         public byte android_attach_anr_thread_dump;
         public char* org_id;
         public int org_id_len;
-        public ManagedStringList trace_propagation_targets;
+        public ManagedTracePropagationTargets trace_propagation_targets;
         public byte propagate_traceparent;
     }
 
@@ -255,14 +255,15 @@ internal static partial class NativeBridge
         public int PairCount;
     }
 
-    // Managed-owned string list for passing string arrays across P/Invoke.
-    // Buffer layout: all strings concatenated as UTF-16, with one length per entry.
-    // Must match layout of ManagedStringList in csharp_interop.cpp.
+    // Managed-owned trace propagation targets for passing across P/Invoke.
+    // Buffer layout: all patterns concatenated as UTF-16, with one length and regex flag per entry.
+    // Must match layout of ManagedTracePropagationTargets in csharp_interop.cpp.
     [StructLayout(LayoutKind.Sequential)]
-    private unsafe struct ManagedStringList
+    private unsafe struct ManagedTracePropagationTargets
     {
         public char* Buffer;
         public int* Lengths;
+        public byte* IsRegex;
         public int Count;
     }
 
@@ -322,7 +323,7 @@ internal static partial class NativeBridge
         }
     }
 
-    private static (char[] Buffer, int[] Lengths) MarshallStringList<T>(IList<T> values)
+    private static (char[] Buffer, int[] Lengths, byte[] IsRegex) MarshallTracePropagationTargets(IList<StringOrRegex> values)
     {
         int totalChars = 0;
         for (int i = 0; i < values.Count; i++)
@@ -331,6 +332,7 @@ internal static partial class NativeBridge
         }
 
         var lengths = new int[values.Count];
+        var isRegex = new byte[values.Count];
         var buffer = new char[Math.Max(totalChars, 1)];
 
         int position = 0;
@@ -338,10 +340,11 @@ internal static partial class NativeBridge
         {
             string value = values[i]?.ToString() ?? "";
             lengths[i] = value.Length;
+            isRegex[i] = (byte)(values[i]?.IsRegex == true ? 1 : 0);
             value.CopyTo(0, buffer, position, value.Length);
             position += value.Length;
         }
-        return (buffer, lengths);
+        return (buffer, lengths, isRegex);
     }
 
     // Must match ManagedFunctions struct in csharp_interop.cpp
@@ -908,10 +911,8 @@ internal static partial class NativeBridge
         var dist = opts.Distribution ?? "";
         var env = opts.Environment ?? "";
         var orgId = opts.OrgId ?? "";
-        // LIMITATION: sentry-dotnet does not expose whether StringOrRegex contains a regex,
-        // so managed targets cross as literals.
-        var (tracePropagationTargetsBuffer, tracePropagationTargetsLengths) =
-                MarshallStringList(opts.TracePropagationTargets);
+        var (tracePropagationTargetsBuffer, tracePropagationTargetsLengths, tracePropagationTargetsIsRegex) =
+                MarshallTracePropagationTargets(opts.TracePropagationTargets);
 
         fixed (char* dsnPtr = dsn)
         fixed (char* relPtr = release)
@@ -920,6 +921,7 @@ internal static partial class NativeBridge
         fixed (char* orgIdPtr = orgId)
         fixed (char* tracePropagationTargetsPtr = tracePropagationTargetsBuffer)
         fixed (int* tracePropagationTargetLengthsPtr = tracePropagationTargetsLengths)
+        fixed (byte* tracePropagationTargetsIsRegexPtr = tracePropagationTargetsIsRegex)
         {
             var managed = new ManagedOptions
             {
@@ -963,10 +965,11 @@ internal static partial class NativeBridge
                 android_attach_anr_thread_dump = (byte)(opts.Android.AttachAnrThreadDump ? 1 : 0),
                 org_id = orgIdPtr,
                 org_id_len = orgId.Length,
-                trace_propagation_targets = new ManagedStringList
+                trace_propagation_targets = new ManagedTracePropagationTargets
                 {
                     Buffer = tracePropagationTargetsPtr,
                     Lengths = tracePropagationTargetLengthsPtr,
+                    IsRegex = tracePropagationTargetsIsRegexPtr,
                     Count = tracePropagationTargetsLengths.Length,
                 },
                 propagate_traceparent = (byte)(opts.PropagateTraceparent ? 1 : 0),

--- a/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
+++ b/src/sentry/dotnet/managed/Sentry.Godot/SentryGodotOptions.cs
@@ -5,6 +5,15 @@ using System.Collections.Generic;
 
 namespace Sentry.Godot;
 
+/// <summary>
+/// Configures the Sentry SDK for Godot.
+/// </summary>
+/// <remarks>
+/// Regular expressions in <see cref="SentryOptions.TracePropagationTargets"/> sync to the native layer using only
+/// their pattern. Constructor-supplied <see cref="System.Text.RegularExpressions.RegexOptions"/> are not preserved.
+/// For case-insensitive matching in both layers, include <c>(?i)</c> in the pattern instead of using
+/// <see cref="System.Text.RegularExpressions.RegexOptions.IgnoreCase"/>.
+/// </remarks>
 public sealed class SentryGodotOptions : SentryOptions
 {
     public SentryGodotOptions()

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -12,6 +12,7 @@
 #include <godot_cpp/classes/class_db_singleton.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/classes/reg_ex.hpp>
+#include <godot_cpp/classes/reg_ex_match.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/local_vector.hpp>
 #include <godot_cpp/variant/callable_method_pointer.hpp>
@@ -168,7 +169,7 @@ TEST_SUITE("[.NET] Options interop") {
 			}
 		}
 
-		SUBCASE("Native regex propagation targets remain regexes in .NET") {
+		SUBCASE("Native regex propagation targets survive the managed roundtrip") {
 			if (!sentry::dotnet::godot_supports_dotnet()) {
 				MESSAGE("Skipping: managed runtime unavailable (non-mono Godot build).");
 				return;
@@ -179,7 +180,50 @@ TEST_SUITE("[.NET] Options interop") {
 			SentrySDK::get_singleton()->init(callable_mp_static(&_configure_regex_trace_propagation_target));
 			const PackedStringArray targets = harness->call("GetCurrentTracePropagationTargets");
 			CHECK(targets == PackedStringArray({ "string:literal.example.com", "regex:api\\.example\\.com" }));
+			const Array native_targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
+			CHECK(native_targets.size() == 2);
+			if (native_targets.size() == 2) {
+				CHECK(native_targets[0] == Variant("literal.example.com"));
+				const Ref<RegEx> regex = native_targets[1];
+				CHECK(regex.is_valid());
+				if (regex.is_valid()) {
+					CHECK(regex->get_pattern() == "api\\.example\\.com");
+				}
+			}
 			SentrySDK::get_singleton()->close();
+		}
+
+		SUBCASE("Managed regex propagation targets retain their type and matching behavior in native") {
+			if (!sentry::dotnet::godot_supports_dotnet()) {
+				MESSAGE("Skipping: managed runtime unavailable (non-mono Godot build).");
+				return;
+			}
+
+			InitFixture fixture("InitWithRegexTracePropagationTargets");
+			REQUIRE(fixture.get_harness() != nullptr);
+			const Array targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
+			REQUIRE(targets.size() == 3);
+			CHECK(targets[0] == Variant("^literal\\.example\\.com$"));
+			const Ref<RegEx> regex = targets[1];
+			REQUIRE(regex.is_valid());
+			CHECK(regex->get_pattern() == String::utf8("^https://api\\.example\\.com/żółw$"));
+			CHECK(regex->search(String::utf8("https://api.example.com/żółw")).is_valid());
+			CHECK(regex->search(String::utf8("https://apiXexample.com/żółw")).is_null());
+			const Ref<RegEx> empty_regex = targets[2];
+			REQUIRE(empty_regex.is_valid());
+			CHECK(empty_regex->is_valid());
+			CHECK(empty_regex->get_pattern().is_empty());
+		}
+
+		SUBCASE("Managed propagation targets can be cleared") {
+			if (!sentry::dotnet::godot_supports_dotnet()) {
+				MESSAGE("Skipping: managed runtime unavailable (non-mono Godot build).");
+				return;
+			}
+
+			InitFixture fixture("InitWithEmptyTracePropagationTargets");
+			REQUIRE(fixture.get_harness() != nullptr);
+			CHECK(SENTRY_OPTIONS()->get_trace_propagation_targets().is_empty());
 		}
 	}
 }


### PR DESCRIPTION
Preserves regular expressions in `TracePropagationTargets` when .NET options sync back to native, including targets originally configured in Godot. Native trace-header filtering now uses these patterns as regular expressions. Documents that constructor-supplied `RegexOptions` are not preserved and recommends inline pattern modifiers.

- Refs #943

#skip-changelog: the issue was not shipped