### PR TITLE
test(cpp): Return after failed prerequisite checks

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -201,7 +201,8 @@ elif internal_sdk == SDK.JAVASCRIPT:
 if env["tests"]:
     env.Append(CPPDEFINES=[
         "TESTS_ENABLED",
-        "DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS" # godot-cpp is built with exceptions disabled
+        "DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS", # godot-cpp is built with exceptions disabled
+        "DOCTEST_CONFIG_ASSERTS_RETURN_VALUES"
     ])
     env.Append(CPPPATH=["tests/cpp", "modules/doctest/doctest"])
     sources += [File("tests/cpp/cpp_test_runner.cpp")]

--- a/tests/cpp/cpp_test_helpers.h
+++ b/tests/cpp/cpp_test_helpers.h
@@ -9,6 +9,14 @@
 #include <string_view>
 #include <vector>
 
+// Returns from the current void function; calling it in a helper does not exit the caller.
+#define REQUIRED_CHECK(...)        \
+	do {                           \
+		if (!CHECK(__VA_ARGS__)) { \
+			return;                \
+		}                          \
+	} while (false)
+
 namespace sentry::tests {
 
 // Wraps string_view so doctest renders \r \n \t as visible.

--- a/tests/cpp/tests/test_csproj_patcher.cpp
+++ b/tests/cpp/tests/test_csproj_patcher.cpp
@@ -148,25 +148,25 @@ TEST_SUITE("CsprojPatcher") {
 
 	TEST_CASE_FIXTURE(CsprojFixture, "Missing import gets patched") {
 		auto result = CsprojPatcher::ensure_import(PROJECT_WITHOUT_IMPORT, IMPORT_PATH);
-		REQUIRE(result.status == CsprojPatcher::Status::PATCHED);
+		REQUIRED_CHECK(result.status == CsprojPatcher::Status::PATCHED);
 		CHECK_SNAPSHOT_EQ(as_view(result.patched_content), PROJECT_PATCHED);
 	}
 
 	TEST_CASE_FIXTURE(CsprojFixture, "CRLF line endings preserved") {
 		auto result = CsprojPatcher::ensure_import(PROJECT_WITHOUT_IMPORT_CRLF, IMPORT_PATH);
-		REQUIRE(result.status == CsprojPatcher::Status::PATCHED);
+		REQUIRED_CHECK(result.status == CsprojPatcher::Status::PATCHED);
 		CHECK_SNAPSHOT_EQ(as_view(result.patched_content), PROJECT_PATCHED_CRLF);
 	}
 
 	TEST_CASE_FIXTURE(CsprojFixture, "Tab indentation preserved") {
 		auto result = CsprojPatcher::ensure_import(PROJECT_WITHOUT_IMPORT_TABS, IMPORT_PATH);
-		REQUIRE(result.status == CsprojPatcher::Status::PATCHED);
+		REQUIRED_CHECK(result.status == CsprojPatcher::Status::PATCHED);
 		CHECK_SNAPSHOT_EQ(as_view(result.patched_content), PROJECT_PATCHED_TABS);
 	}
 
 	TEST_CASE_FIXTURE(CsprojFixture, "Commented-out import is ignored") {
 		auto result = CsprojPatcher::ensure_import(PROJECT_WITH_COMMENTED_IMPORT, IMPORT_PATH);
-		REQUIRE(result.status == CsprojPatcher::Status::PATCHED);
+		REQUIRED_CHECK(result.status == CsprojPatcher::Status::PATCHED);
 		CHECK_SNAPSHOT_EQ(as_view(result.patched_content), PROJECT_PATCHED_FROM_COMMENTED);
 	}
 
@@ -187,7 +187,7 @@ TEST_SUITE("CsprojPatcher") {
 
 	TEST_CASE_FIXTURE(CsprojFixture, "UTF-8 BOM is preserved") {
 		auto result = CsprojPatcher::ensure_import(PROJECT_WITHOUT_IMPORT_BOM, IMPORT_PATH);
-		REQUIRE(result.status == CsprojPatcher::Status::PATCHED);
+		REQUIRED_CHECK(result.status == CsprojPatcher::Status::PATCHED);
 		CHECK_SNAPSHOT_EQ(as_view(result.patched_content), PROJECT_PATCHED_BOM);
 	}
 

--- a/tests/cpp/tests/test_dotnet_before_send.cpp
+++ b/tests/cpp/tests/test_dotnet_before_send.cpp
@@ -36,9 +36,9 @@ TEST_SUITE("[.NET] Test options.Native.SetBeforeSend bridging") {
 		}
 
 		InitFixture fixture("InitWithNativeHooks"); // inits the SDK, closes at scope exit
-		REQUIRE(fixture.get_harness() != nullptr);
-		REQUIRE(sentry::dotnet::is_managed_layer_registered());
-		REQUIRE(sentry::dotnet::is_before_send_defined());
+		REQUIRED_CHECK(fixture.get_harness() != nullptr);
+		REQUIRED_CHECK(sentry::dotnet::is_managed_layer_registered());
+		REQUIRED_CHECK(sentry::dotnet::is_before_send_defined());
 
 		SUBCASE("Event passes through the callback") {
 			// Create event carrying know values.
@@ -52,7 +52,7 @@ TEST_SUITE("[.NET] Test options.Native.SetBeforeSend bridging") {
 			event->set_tag("before_send.remove_me", "remove-me");
 
 			Ref<SentryEvent> result = sentry::process_event(event);
-			REQUIRE(result.is_valid());
+			REQUIRED_CHECK(result.is_valid());
 
 			SUBCASE("Getters observe the values set on the event") {
 				Dictionary seen = fixture.get_harness()->call("GetSeenEventValues");
@@ -88,7 +88,7 @@ TEST_SUITE("[.NET] Test options.Native.SetBeforeSend bridging") {
 
 		SUBCASE("Managed event capture should never run the Native.SetBeforeSend hook directly") {
 			const int64_t calls_before = fixture.get_harness()->call("GetNativeBeforeSendCallCount");
-			REQUIRE(bool(fixture.get_harness()->call("CaptureManagedEvent")));
+			REQUIRED_CHECK(bool(fixture.get_harness()->call("CaptureManagedEvent")));
 			const int64_t calls_after = fixture.get_harness()->call("GetNativeBeforeSendCallCount");
 			CHECK(calls_after == calls_before);
 		}

--- a/tests/cpp/tests/test_dotnet_options.cpp
+++ b/tests/cpp/tests/test_dotnet_options.cpp
@@ -47,11 +47,8 @@ String option_name(const OptionCase &p_option) {
 	return path.substr(path.rfind(":") + 1);
 }
 
-void _configure_regex_trace_propagation_target(const Ref<SentryOptions> &p_options) {
-	Ref<RegEx> regex;
-	regex.instantiate();
-	REQUIRE(regex->compile("api\\.example\\.com") == OK);
-	p_options->set_trace_propagation_targets(Array({ "literal.example.com", regex }));
+void _configure_trace_propagation_targets(const Ref<SentryOptions> &p_options, const Array &p_targets) {
+	p_options->set_trace_propagation_targets(p_targets);
 }
 
 } // unnamed namespace
@@ -176,8 +173,12 @@ TEST_SUITE("[.NET] Options interop") {
 			}
 
 			Object *harness = sentry::tests::get_dotnet_harness();
-			REQUIRE(harness != nullptr);
-			SentrySDK::get_singleton()->init(callable_mp_static(&_configure_regex_trace_propagation_target));
+			REQUIRED_CHECK(harness != nullptr);
+			Ref<RegEx> configured_regex;
+			configured_regex.instantiate();
+			REQUIRED_CHECK(configured_regex->compile("api\\.example\\.com") == OK);
+			const Array configured_targets({ "literal.example.com", configured_regex });
+			SentrySDK::get_singleton()->init(callable_mp_static(&_configure_trace_propagation_targets).bind(configured_targets));
 			const PackedStringArray targets = harness->call("GetCurrentTracePropagationTargets");
 			CHECK(targets == PackedStringArray({ "string:literal.example.com", "regex:api\\.example\\.com" }));
 			const Array native_targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
@@ -200,17 +201,17 @@ TEST_SUITE("[.NET] Options interop") {
 			}
 
 			InitFixture fixture("InitWithRegexTracePropagationTargets");
-			REQUIRE(fixture.get_harness() != nullptr);
+			REQUIRED_CHECK(fixture.get_harness() != nullptr);
 			const Array targets = SENTRY_OPTIONS()->get_trace_propagation_targets();
-			REQUIRE(targets.size() == 3);
+			REQUIRED_CHECK(targets.size() == 3);
 			CHECK(targets[0] == Variant("^literal\\.example\\.com$"));
 			const Ref<RegEx> regex = targets[1];
-			REQUIRE(regex.is_valid());
+			REQUIRED_CHECK(regex.is_valid());
 			CHECK(regex->get_pattern() == String::utf8("^https://api\\.example\\.com/żółw$"));
 			CHECK(regex->search(String::utf8("https://api.example.com/żółw")).is_valid());
 			CHECK(regex->search(String::utf8("https://apiXexample.com/żółw")).is_null());
 			const Ref<RegEx> empty_regex = targets[2];
-			REQUIRE(empty_regex.is_valid());
+			REQUIRED_CHECK(empty_regex.is_valid());
 			CHECK(empty_regex->is_valid());
 			CHECK(empty_regex->get_pattern().is_empty());
 		}
@@ -222,7 +223,7 @@ TEST_SUITE("[.NET] Options interop") {
 			}
 
 			InitFixture fixture("InitWithEmptyTracePropagationTargets");
-			REQUIRE(fixture.get_harness() != nullptr);
+			REQUIRED_CHECK(fixture.get_harness() != nullptr);
 			CHECK(SENTRY_OPTIONS()->get_trace_propagation_targets().is_empty());
 		}
 	}

--- a/tests/cpp/tests/test_dotnet_trace_sync.cpp
+++ b/tests/cpp/tests/test_dotnet_trace_sync.cpp
@@ -33,8 +33,8 @@ TEST_SUITE("[.NET] Cross-layer trace sync") {
 
 		InitFixture fixture("Init"); // inits the SDK, closes at scope exit
 		Object *harness = fixture.get_harness();
-		REQUIRE(harness != nullptr);
-		REQUIRE(sentry::dotnet::is_managed_layer_registered());
+		REQUIRED_CHECK(harness != nullptr);
+		REQUIRED_CHECK(sentry::dotnet::is_managed_layer_registered());
 
 		// Baseline: .NET adopts native's session trace at init, so the layers start aligned.
 		const String session_trace = _native_trace_id();
@@ -62,8 +62,8 @@ TEST_SUITE("[.NET] Cross-layer trace sync") {
 
 		InitFixture fixture("Init"); // inits the SDK, closes at scope exit
 		Object *harness = fixture.get_harness();
-		REQUIRE(harness != nullptr);
-		REQUIRE(sentry::dotnet::is_managed_layer_registered());
+		REQUIRED_CHECK(harness != nullptr);
+		REQUIRED_CHECK(sentry::dotnet::is_managed_layer_registered());
 
 		const String session_trace = _native_trace_id();
 		CHECK_FALSE(session_trace.is_empty());


### PR DESCRIPTION
The C++ tests run without exceptions, so doctest’s `REQUIRE` records failures but continues execution, potentially crashing on invalid state. Adds `REQUIRED_CHECK` to record the failure and return from the current function, and replaces the existing `REQUIRE` calls.

- Depends on #945
