### PR TITLE
test(apple): Enable span E2E checks on macOS and iOS

### DIFF
--- a/tests/integration/Integration.Tests.ps1
+++ b/tests/integration/Integration.Tests.ps1
@@ -840,7 +840,7 @@ Describe "Platform Integration Tests" {
         }
     }
 
-    Context "Spans" -Skip:$script:IsCocoa {
+    Context "Spans" {
         BeforeAll {
             $runResult = $script:spanRunResult
 


### PR DESCRIPTION
Enable the existing span E2E checks on macOS and iOS now that both platforms support GDScript spans. This verifies transaction delivery, child spans, attributes, status, and event trace correlation.

- Refs #921
- Refs #925
