### PR TITLE
docs(apple): Remove outdated span support warnings

### DIFF
--- a/doc_classes/SentrySDK.xml
+++ b/doc_classes/SentrySDK.xml
@@ -240,7 +240,6 @@
 				The [param attributes] dictionary is added to the span when it starts. The special [code]sentry.op[/code] attribute sets the operation the span is grouped under in Sentry. The SDK skips an entry with an empty key and prints an error.
 				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code]. The API works either way: telemetry captured during an active span carries its trace context even when the span is not sent.
 				[b]Note:[/b] The child span keeps its parent and ancestors alive until it is freed.
-				[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 				To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 			</description>
 		</method>
@@ -287,7 +286,6 @@
 				Nested calls create nested spans. When the callable returns, the enclosing active span and scope are restored.
 				[b]Note:[/b] The span covers the synchronous part of [param callable] only. If the callable awaits, the span is ended at the first [code]await[/code] and a warning is printed.
 				[b]Note:[/b] The SDK sends spans only if [member SentryOptions.traces_sample_rate] is set above its default of [code]0.0[/code].
-				[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning.
 			</description>
 		</method>
 	</methods>

--- a/doc_classes/SentrySpan.xml
+++ b/doc_classes/SentrySpan.xml
@@ -19,7 +19,6 @@
 		Set [code]sentry.op[/code] to categorize the work the span measures, such as [code]asset.load[/code] or [code]db.query[/code]. Sentry groups and filters spans by operation. Pass it in the [code]attributes[/code] dictionary of [method SentrySDK.start_span], since some platforms fix the operation when the span starts.
 		[b]Note:[/b] Spans are thread-local. Call span methods only from the thread that created the span.
 		[b]Note:[/b] A child span keeps its parent and ancestors alive until it is freed.
-		[b]Platform support:[/b] Spans are not supported on macOS or iOS yet. On those platforms, the SDK returns a no-op span and prints a one-time warning. Calling methods on that span is safe, but no span is recorded.
 		To learn more, visit [url=https://docs.sentry.io/concepts/key-terms/tracing/]Tracing documentation[/url].
 	</description>
 	<tutorials>


### PR DESCRIPTION
Remove the class-reference warnings that describe macOS and iOS spans as unsupported. Both platforms now support GDScript spans.

- Refs #921
